### PR TITLE
SIGUSR1 to reload html templates

### DIFF
--- a/server.go
+++ b/server.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-
+	"os/signal"
+	"syscall"
+	
 	"github.com/golang/glog"
 	"github.com/gorilla/context"
 
@@ -46,6 +48,25 @@ func main() {
 
 	application.Init(filename)
 	application.LoadTemplates()
+
+	// Set up signal handler
+	// SIGUSR1 = Reload html templates
+	sigs := make(chan os.Signal, 1)
+
+	signal.Notify(sigs, syscall.SIGUSR1)
+
+	go func() {
+		for {
+			sig := <-sigs
+			dcrstakepoolLog.Infof("Received: %s", sig)
+			fmt.Fprintf(os.Stdout, "Received: %s\n", sig)
+			if sig == syscall.SIGUSR1 {
+				application.LoadTemplates()
+				dcrstakepoolLog.Infof("LoadTemplates() executed.")
+				fmt.Fprintf(os.Stdout, "LoadTemplates() executed.\n")		
+			}
+		}
+	}()
 
 	// Setup static files
 	static := web.New()


### PR DESCRIPTION
It's useful during development so you don't have to keep restarting the services while making small incremental changes. Just `kill -SIGUSR1 [pid]` and refresh the browser.

I left some prints in since logging isn't working yet. Once logging is fixed I planned to remove them. 
