### PR TITLE
Vote bits sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
-.vscode/
 config.toml
 dcrstakepool
 vendor
 .vscode/
-config.go*
+stock/
+votebitssync/
+controllers/config.go*

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ config.toml
 dcrstakepool
 vendor
 .vscode/
-stock/
-votebitssync/
 controllers/config.go*
+testing/
+*.orig
+

--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ const (
 	defaultDBPort           = 3306
 	defaultDBUser           = "stakepool"
 	defaultPoolEmail        = "admin@example.com"
-	defaultPoolFees         = 7.5
+	defaultPoolFees         = 5
 	defaultPoolLink         = "https://forum.decred.org/threads/rfp-6-setup-and-operate-10-stake-pools.1361/"
 	defaultRecaptchaSecret  = "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe"
 	defaultRecaptchaSitekey = "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"
@@ -90,8 +90,8 @@ type config struct {
 	Version          string
 }
 
-// serviceOptions defines the configuration options for the daemon as a service on
-// Windows.
+// serviceOptions defines the configuration options for the daemon as a service
+// on Windows.
 type serviceOptions struct {
 	ServiceCommand string `short:"s" long:"service" description:"Service command {install, remove, start, stop}"`
 }

--- a/controllers/dcrclient.go
+++ b/controllers/dcrclient.go
@@ -11,13 +11,13 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/decred/dcrd/blockchain/stake"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrjson"
 	"github.com/decred/dcrrpcclient"
 	"github.com/decred/dcrstakepool/models"
 	"github.com/decred/dcrutil"
 	"github.com/decred/dcrwallet/waddrmgr"
-	"github.com/decred/dcrd/blockchain/stake"
 )
 
 // functionName
@@ -1006,9 +1006,9 @@ func (w *walletSvrManager) SetTicketsVoteBits(hashes []*chainhash.Hash, votesBit
 
 	reply := make(chan setTicketsVoteBitsResponse)
 	w.msgChan <- setTicketsVoteBitsMsg{
-		hashes:     hashes,
+		hashes:    hashes,
 		votesBits: votesBits,
-		reply:    reply,
+		reply:     reply,
 	}
 
 	// If the set was successful, reset the timer.
@@ -1260,7 +1260,7 @@ func (w *walletSvrManager) SyncVoteBits() error {
 	ticketHashesMined := getMinedTickets(w.servers[0], ticketHashes)
 	numLiveTickets := len(ticketHashesMined)
 	log.Infof("Excluding %d unmined tickets in votebits sync.",
-		len(ticketHashes) - numLiveTickets)
+		len(ticketHashes)-numLiveTickets)
 
 	// gsi, err := w.servers[0].GetStakeInfo()
 	// if err != nil {
@@ -1272,7 +1272,7 @@ func (w *walletSvrManager) SyncVoteBits() error {
 	// }
 
 	// Check number of tickets
-	
+
 	for i, cl := range w.servers {
 		if i == 0 {
 			continue
@@ -1660,31 +1660,6 @@ func newWalletSvrManager(walletHosts []string, walletCerts []string,
 		setVoteBitsResyncChan:  make(chan error, 500),
 		msgChan:                make(chan interface{}, 500),
 		quit:                   make(chan struct{}),
-	}
-
-	// Sync address index and redeemscripts
-
-	// TODO: Wait for wallets to sync, or schedule the vote bits sync somehow.
-	// For now, just skip full vote bits sync in favor of on-demand user's vote
-	// bits sync if the wallets are busy at this point.
-
-	// Allow sync to get going before attempting vote bits sync.
-	time.Sleep(2 * time.Second)
-
-	// Look for that -4 message from wallet that says: "the wallet is
-	// currently syncing to the best block, please try again later"
-	err = wsm.CheckWalletsReady()
-	if err != nil /*strings.Contains(err.Error(), "try again later")*/ {
-		// If importscript is running, it will take a while.
-		log.Errorf("Wallets are syncing. Unable to initiate votebits sync: %v",
-			err)
-	} else {
-		// Sync vote bits for all tickets owned by the wallet
-		err = wsm.SyncVoteBits()
-		if err != nil {
-			log.Error(err)
-			return nil, err
-		}
 	}
 
 	return &wsm, nil

--- a/controllers/dcrclient.go
+++ b/controllers/dcrclient.go
@@ -1177,7 +1177,7 @@ func (w *walletSvrManager) SyncVoteBits() error {
 	if err != nil {
 		return err
 	}
-	if int(gsi.Live) != numLiveTickets {
+	if int(gsi.Live+gsi.Immature) != numLiveTickets {
 		return fmt.Errorf("Number of live tickets inconsistent: %v, %v",
 			gsi.Live, numLiveTickets)
 	}
@@ -1231,6 +1231,8 @@ func (w *walletSvrManager) SyncTicketsVoteBits(tickets []*chainhash.Hash) error 
 	votebitsPerServer := make([]map[chainhash.Hash]uint16, w.serversLen)
 
 	for i, cl := range w.servers {
+		votebitsPerServer[i] = make(map[chainhash.Hash]uint16)
+
 		votebits, err := cl.GetTicketsVoteBits(tickets)
 		if err != nil {
 			return err

--- a/controllers/dcrclient.go
+++ b/controllers/dcrclient.go
@@ -1139,13 +1139,13 @@ func (w *walletSvrManager) CheckServers() error {
 			return err
 		}
 		if !wi.DaemonConnected {
-			return fmt.Errorf("wallet on svr %d not connected", i)
+			return fmt.Errorf("Wallet on svr %d not connected\n", i)
 		}
 		if !wi.StakeMining {
-			return fmt.Errorf("wallet on svr %d not stakemining", i)
+			return fmt.Errorf("Wallet on svr %d not stakemining.\n", i)
 		}
 		if !wi.Unlocked {
-			return fmt.Errorf("wallet on svr %d not unlocked", i)
+			return fmt.Errorf("Wallet on svr %d not unlocked.\n", i)
 		}
 	}
 

--- a/controllers/dcrclient.go
+++ b/controllers/dcrclient.go
@@ -1167,7 +1167,7 @@ func (w *walletSvrManager) SyncVoteBits() error {
 
 	// Check live tickets
 	// legacyrpc.getTickets excludes spent tickets
-	ticketHashes, err := w.servers[0].GetTickets(false)
+	ticketHashes, err := w.servers[0].GetTickets(true)
 	if err != nil {
 		return err
 	}
@@ -1188,13 +1188,13 @@ func (w *walletSvrManager) SyncVoteBits() error {
 			continue
 		}
 
-		// ticketHashes, err = cl.GetTickets(false)
+		// ticketHashes, err = cl.GetTickets(true)
 		gsi, err = cl.GetStakeInfo()
 		if err != nil {
 			return err
 		}
 
-		if i > 0 && numLiveTickets != int(gsi.Live) {
+		if numLiveTickets != int(gsi.Live+gsi.Immature) {
 			log.Infof("Non-equivalent number of tickets on servers %v, %v "+
 				" (%v, %v)", 0, i, numLiveTickets, gsi.Live)
 			return fmt.Errorf("non equivalent num elements returned")
@@ -1207,6 +1207,10 @@ func (w *walletSvrManager) SyncVoteBits() error {
 // SyncTicketsVoteBits ensures that the wallet servers are all in sync with each
 // other in terms of vote bits of the given tickets.  First wallet rules.
 func (w *walletSvrManager) SyncTicketsVoteBits(tickets []*chainhash.Hash) error {
+	if len(tickets) == 0 {
+		return nil
+	}
+
 	// Check for connectivity and if unlocked.
 	err := w.CheckServers()
 	if err != nil {
@@ -1223,13 +1227,9 @@ func (w *walletSvrManager) SyncTicketsVoteBits(tickets []*chainhash.Hash) error 
 	}
 	defer atomic.StoreInt32(&w.ticketDataBlocker, 0)
 
-	if len(tickets) == 0 {
-		return nil
-	}
-
+	// Go through each server, get ticket vote bits
 	votebitsPerServer := make([]map[chainhash.Hash]uint16, w.serversLen)
 
-	// Go through each server, get ticket vote bits
 	for i, cl := range w.servers {
 		votebits, err := cl.GetTicketsVoteBits(tickets)
 		if err != nil {
@@ -1245,6 +1245,7 @@ func (w *walletSvrManager) SyncTicketsVoteBits(tickets []*chainhash.Hash) error 
 	}
 
 	// Synchronize, using first server's bits if different
+	// NOTE: This does not check for missing tickets.
 	masterVotebitsMap := votebitsPerServer[0]
 	for i, votebitsMap := range votebitsPerServer {
 		if i == 0 {
@@ -1277,7 +1278,7 @@ func (w *walletSvrManager) SyncUserVoteBits(userMultiSigAddress dcrutil.Address)
 	}
 
 	// Get all live tickets for user
-	ticketHashes, err := w.GetLiveUserTickets(userMultiSigAddress)
+	ticketHashes, err := w.GetUnspentUserTickets(userMultiSigAddress)
 	if err != nil {
 		return err
 	}
@@ -1285,16 +1286,21 @@ func (w *walletSvrManager) SyncUserVoteBits(userMultiSigAddress dcrutil.Address)
 	return w.SyncTicketsVoteBits(ticketHashes)
 }
 
-func (w *walletSvrManager) GetLiveUserTickets(userMultiSigAddress dcrutil.Address) ([]*chainhash.Hash, error) {
+// GetUnspentUserTickets gets live and immature tickets for a stakepool user
+func (w *walletSvrManager) GetUnspentUserTickets(userMultiSigAddress dcrutil.Address) ([]*chainhash.Hash, error) {
 	// live tickets only
 	var tickethashes []*chainhash.Hash
 
+	// TicketsForAddress returns all tickets, not just live, when wallet is
+	// queried rather than just the node. With StakePoolUserInfo, "live" status
+	// includes immature, but not spent.
 	spui, err := w.StakePoolUserInfo(userMultiSigAddress)
 	if err != nil {
 		return tickethashes, err
 	}
 
 	for _, ticket := range spui.Tickets {
+		// "live" includes immature
 		if ticket.Status == "live" {
 			th, err := chainhash.NewHashFromStr(ticket.Ticket)
 			if err != nil {

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -11,6 +11,7 @@ import (
 	"net/smtp"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"html/template"

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/chaincfg/chainhash"
-	"github.com/decred/dcrd/dcrjson"
+	// "github.com/decred/dcrd/dcrjson"
 	"github.com/decred/dcrutil"
 	"github.com/decred/dcrutil/hdkeychain"
 	"github.com/decred/dcrwallet/waddrmgr"
@@ -531,22 +531,24 @@ func (controller *MainController) RPCSync(dbMap *gorp.DbMap) error {
 	return nil
 }
 
-// RPCStart
+// RPCStart starts the wallet RPC handler.
 func (controller *MainController) RPCStart() {
 	controller.rpcServers.Start()
 }
 
-// RPCStop
+// RPCStop stops the wallet RPC handler.
 func (controller *MainController) RPCStop() error {
 	return controller.rpcServers.Stop()
 }
 
-// RPCIsStopped
+// RPCIsStopped checks if the wallet RPC manager is stopped or in the process
+// of stopping. 
 func (controller *MainController) RPCIsStopped() bool {
 	return controller.rpcServers.IsStopped()
 }
 
-// handlePotentialFatalError
+// handlePotentialFatalError is used to respond to wallet RPC manager errors byte
+// logging the error message adn stopping the RPC manager.
 func (controller *MainController) handlePotentialFatalError(fn string, err error) {
 	cnErr, ok := err.(connectionError)
 	if ok {
@@ -557,6 +559,7 @@ func (controller *MainController) handlePotentialFatalError(fn string, err error
 }
 
 // Address page route
+// Handles GET at "/address".
 func (controller *MainController) Address(c web.C, r *http.Request) (string, int) {
 	t := controller.GetTemplate(c)
 	session := controller.GetSession(c)
@@ -580,7 +583,10 @@ func (controller *MainController) Address(c web.C, r *http.Request) (string, int
 	return controller.Parse(t, "main", c.Env), http.StatusOK
 }
 
-// Address form submit route
+// AddressPost is the Address form submit route. If the user us logged in, and
+// does not already have a pub key address submitted, AddressPost will create a
+// multisignature script from the user's address and a new pool address.
+// Handles POST at "/address".
 func (controller *MainController) AddressPost(c web.C, r *http.Request) (string, int) {
 	session := controller.GetSession(c)
 
@@ -594,6 +600,7 @@ func (controller *MainController) AddressPost(c web.C, r *http.Request) (string,
 		return "/", http.StatusSeeOther
 	}
 
+	// Only accept address if user does not already have a PubKeyAddr set.
 	dbMap := controller.GetDbMap(c)
 	user := models.GetUserById(dbMap, session.Values["UserId"].(int64))
 	if len(user.UserPubKeyAddr) > 0 {
@@ -613,6 +620,7 @@ func (controller *MainController) AddressPost(c web.C, r *http.Request) (string,
 		return controller.Address(c, r)
 	}
 
+	// Get dcrutil.Address for user from pubkey address string
 	u, err := dcrutil.DecodeAddress(userPubKeyAddr, controller.params)
 	if err != nil {
 		session.AddFlash("Couldn't decode address", "address")
@@ -625,6 +633,7 @@ func (controller *MainController) AddressPost(c web.C, r *http.Request) (string,
 		return controller.Address(c, r)
 	}
 
+	// Get new address from pool wallets
 	if controller.RPCIsStopped() {
 		return "/error", http.StatusSeeOther
 	}
@@ -634,6 +643,7 @@ func (controller *MainController) AddressPost(c web.C, r *http.Request) (string,
 		return "/error", http.StatusSeeOther
 	}
 
+	// From new address (pkh), get pubkey address
 	if controller.RPCIsStopped() {
 		return "/error", http.StatusSeeOther
 	}
@@ -644,12 +654,14 @@ func (controller *MainController) AddressPost(c web.C, r *http.Request) (string,
 	}
 	poolPubKeyAddr := poolValidateAddress.PubKeyAddr
 
+	// Get back Address from pool's new pubkey address
 	p, err := dcrutil.DecodeAddress(poolPubKeyAddr, controller.params)
 	if err != nil {
 		controller.handlePotentialFatalError("DecodeAddress poolPubKeyAddr", err)
 		return "/error", http.StatusSeeOther
 	}
 
+	// Create the the multisig script. Result includes a P2SH and RedeemScript.
 	if controller.RPCIsStopped() {
 		return "/error", http.StatusSeeOther
 	}
@@ -659,6 +671,7 @@ func (controller *MainController) AddressPost(c web.C, r *http.Request) (string,
 		return "/error", http.StatusSeeOther
 	}
 
+	// Serialize the RedeemScript (hex string -> []byte)
 	if controller.RPCIsStopped() {
 		return "/error", http.StatusSeeOther
 	}
@@ -675,12 +688,15 @@ func (controller *MainController) AddressPost(c web.C, r *http.Request) (string,
 		controller.handlePotentialFatalError("CreateMultisig DecodeString", err)
 		return "/error", http.StatusSeeOther
 	}
+
+	// Import the RedeemScript
 	err = controller.rpcServers.ImportScript(serializedScript, int(bestBlockHeight))
 	if err != nil {
 		controller.handlePotentialFatalError("ImportScript", err)
 		return "/error", http.StatusSeeOther
 	}
 
+	// Get the pool fees address for this user
 	uid64 := session.Values["UserId"].(int64)
 	userFeeAddr, err := controller.FeeAddressForUserID(int(uid64))
 	if err != nil {
@@ -688,7 +704,9 @@ func (controller *MainController) AddressPost(c web.C, r *http.Request) (string,
 		return "/error", http.StatusSeeOther
 	}
 
-	models.UpdateUserById(dbMap, uid64, createMultiSig.Address,
+	// Update the user's DB entry with multisig, user and pool pubkey
+	// addresses, and the fee address 
+	models.UpdateUserByID(dbMap, uid64, createMultiSig.Address,
 		createMultiSig.RedeemScript, poolPubKeyAddr, userPubKeyAddr,
 		userFeeAddr.EncodeAddress(), bestBlockHeight)
 
@@ -803,7 +821,8 @@ func (controller *MainController) EmailVerify(c web.C, r *http.Request) (string,
 	return controller.Parse(t, "main", c.Env), http.StatusOK
 }
 
-// Error page route
+// Error is the error page route.
+// Handles GET on "/error".
 func (controller *MainController) Error(c web.C, r *http.Request) (string, int) {
 	t := controller.GetTemplate(c)
 
@@ -819,13 +838,14 @@ func (controller *MainController) Error(c web.C, r *http.Request) (string, int) 
 	c.Env["RateLimited"] = r.URL.Query().Get("rl")
 	c.Env["Referer"] = r.URL.Query().Get("r")
 
-	var widgets = controller.Parse(t, "error", c.Env)
+	widgets := controller.Parse(t, "error", c.Env)
 	c.Env["Content"] = template.HTML(widgets)
 
 	return controller.Parse(t, "main", c.Env), http.StatusOK
 }
 
-// Home page route
+// Index is the home page route.
+// Handles GET on "/".
 func (controller *MainController) Index(c web.C, r *http.Request) (string, int) {
 	if controller.closePool {
 		c.Env["IsClosed"] = true
@@ -837,9 +857,12 @@ func (controller *MainController) Index(c web.C, r *http.Request) (string, int) 
 	c.Env["PoolLink"] = controller.poolLink
 
 	t := controller.GetTemplate(c)
+	//t := c.Env["Template"].(*template.Template)
 
+	// execute the named template with data in c.Env 
 	widgets := helpers.Parse(t, "home", c.Env)
 
+	// With that kind of flags template can "figure out" what route is being rendered
 	c.Env["IsIndex"] = true
 
 	c.Env["Title"] = "Decred Stake Pool - Welcome"
@@ -1193,15 +1216,17 @@ func (controller *MainController) SettingsPost(c web.C, r *http.Request) (string
 	return controller.Settings(c, r)
 }
 
-// Sign in route
+// SignIn is the sign in route.
+// Handles GET on "/signup".
 func (controller *MainController) SignIn(c web.C, r *http.Request) (string, int) {
 	t := controller.GetTemplate(c)
 	session := controller.GetSession(c)
 
+	// Tell main.html what route is being rendered
 	c.Env["IsSignIn"] = true
 
 	c.Env["Flash"] = session.Flashes("auth")
-	var widgets = controller.Parse(t, "auth/signin", c.Env)
+	widgets := controller.Parse(t, "auth/signin", c.Env)
 
 	c.Env["Title"] = "Decred Stake Pool - Sign In"
 	c.Env["Content"] = template.HTML(widgets)
@@ -1209,16 +1234,17 @@ func (controller *MainController) SignIn(c web.C, r *http.Request) (string, int)
 	return controller.Parse(t, "main", c.Env), http.StatusOK
 }
 
-// Sign In form submit route. Logs user in or sets an appropriate message in
-// session if login was not successful
+// SignInPost is the sign in form submit route. Logs user in or set appropriate
+// message in session if login was not succesful.
+// Handles POST on "/signup".
 func (controller *MainController) SignInPost(c web.C, r *http.Request) (string, int) {
 	email, password := r.FormValue("email"), r.FormValue("password")
 
 	session := controller.GetSession(c)
 	dbMap := controller.GetDbMap(c)
 
+	// Validate email and password combination.
 	user, err := helpers.Login(dbMap, email, password)
-
 	if err != nil {
 		log.Infof(email+" login failed %v", err)
 		session.AddFlash("Invalid Email or Password", "auth")
@@ -1230,6 +1256,8 @@ func (controller *MainController) SignInPost(c web.C, r *http.Request) (string, 
 		return controller.SignIn(c, r)
 	}
 
+	// If pool is closed and user has not yet provided a pubkey address, do not
+	// allow login.
 	if controller.closePool {
 		if len(user.UserPubKeyAddr) == 0 {
 			session.AddFlash(controller.closePoolMsg, "auth")
@@ -1241,18 +1269,22 @@ func (controller *MainController) SignInPost(c web.C, r *http.Request) (string, 
 
 	session.Values["UserId"] = user.Id
 
+	// Go to Address page if multisig script not yet set up.
 	if user.MultiSigAddress == "" {
 		return "/address", http.StatusSeeOther
 	}
 
+	// Go to Tickets page if user already set up.
 	return "/tickets", http.StatusSeeOther
 }
 
-// Sign up route
+// SignUp is the sign up route.
+// Handles GET on "/signup".
 func (controller *MainController) SignUp(c web.C, r *http.Request) (string, int) {
 	t := controller.GetTemplate(c)
 	session := controller.GetSession(c)
 
+	// Tell main.html what route is being rendered
 	c.Env["IsSignUp"] = true
 	if controller.smtpHost == "" {
 		c.Env["SMTPDisabled"] = true
@@ -1266,7 +1298,7 @@ func (controller *MainController) SignUp(c web.C, r *http.Request) (string, int)
 	c.Env["FlashSuccess"] = session.Flashes("signupSuccess")
 	c.Env["RecaptchaSiteKey"] = controller.recaptchaSiteKey
 
-	var widgets = controller.Parse(t, "auth/signup", c.Env)
+	widgets := controller.Parse(t, "auth/signup", c.Env)
 
 	c.Env["Title"] = "Decred Stake Pool - Sign Up"
 	c.Env["Content"] = template.HTML(widgets)
@@ -1274,14 +1306,15 @@ func (controller *MainController) SignUp(c web.C, r *http.Request) (string, int)
 	return controller.Parse(t, "main", c.Env), http.StatusOK
 }
 
-// Sign Up form submit route. Registers new user or shows Sign Up route with appropriate messages set in session
+// SignUpPost is the form submit route. Registers new user or shows SignUp
+// route with appropriate messages set in session. Handles POST on "/signup".
 func (controller *MainController) SignUpPost(c web.C, r *http.Request) (string, int) {
 	if controller.closePool {
 		log.Infof("attempt to signup while registration disabled")
 		return "/error?r=/signup", http.StatusSeeOther
 	}
 
-	re := recaptcha.R{
+	recap := recaptcha.R{
 		Secret: controller.recaptchaSecret,
 	}
 
@@ -1305,10 +1338,10 @@ func (controller *MainController) SignUpPost(c web.C, r *http.Request) (string, 
 		return controller.SignUp(c, r)
 	}
 
-	isValid := re.Verify(*r)
+	isValid := recap.Verify(*r)
 	if !isValid {
 		session.AddFlash("Recaptcha error", "signupError")
-		log.Errorf("Recaptcha error %v", re.LastError())
+		log.Errorf("Recaptcha error %v", recap.LastError())
 		return controller.SignUp(c, r)
 	}
 
@@ -1391,7 +1424,7 @@ func (controller *MainController) Stats(c web.C, r *http.Request) (string, int) 
 	c.Env["UserCount"] = userCount
 	c.Env["UserCountActive"] = userCountActive
 
-	var widgets = controller.Parse(t, "stats", c.Env)
+	widgets := controller.Parse(t, "stats", c.Env)
 	c.Env["Content"] = template.HTML(widgets)
 
 	return controller.Parse(t, "main", c.Env), http.StatusOK
@@ -1410,7 +1443,7 @@ func (controller *MainController) Status(c web.C, r *http.Request) (string, int)
 	c.Env["Title"] = "Decred Stake Pool - Status"
 	c.Env["RPCStatus"] = rpcstatus
 
-	var widgets = controller.Parse(t, "status", c.Env)
+	widgets := controller.Parse(t, "status", c.Env)
 	c.Env["Content"] = template.HTML(widgets)
 
 	if controller.RPCIsStopped() {
@@ -1464,16 +1497,18 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 		log.Info("Multisigaddress empty")
 	}
 
-	ms, err := dcrutil.DecodeAddress(user.MultiSigAddress, controller.params)
+	// Get P2SH Address
+	multisig, err := dcrutil.DecodeAddress(user.MultiSigAddress, controller.params)
 	if err != nil {
 		c.Env["Error"] = "Invalid multisig data in database"
 		log.Infof("Invalid address %v in database: %v", user.MultiSigAddress, err)
 	}
 
-	var widgets = controller.Parse(t, "tickets", c.Env)
+	widgets := controller.Parse(t, "tickets", c.Env)
 
+	// TODO: how could this happen?
 	if err != nil {
-		log.Info("err is set")
+		log.Info(err)
 		c.Env["Content"] = template.HTML(widgets)
 		widgets = controller.Parse(t, "tickets", c.Env)
 		return controller.Parse(t, "main", c.Env), http.StatusOK
@@ -1483,20 +1518,24 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 		return "/error", http.StatusSeeOther
 	}
 
-	spui := new(dcrjson.StakePoolUserInfoResult)
-	spui, err = controller.rpcServers.StakePoolUserInfo(ms)
+	// spui := new(dcrjson.StakePoolUserInfoResult)
+	spui, err := controller.rpcServers.StakePoolUserInfo(multisig)
 	if err != nil {
 		// Log the error, but do not return. Consider reporting
 		// the error to the user on the page. A blank tickets
 		// page will be displayed in the meantime.
 		log.Infof("RPC StakePoolUserInfo failed: %v", err)
+		session.AddFlash("Unable to retreive stake pool user info.", "tickets")
 	}
 
+	// If the user has tickets, get their info
 	if spui != nil && len(spui.Tickets) > 0 {
+		// Retrieve ticket hashes
 		var tickethashes []*chainhash.Hash
 
 		for _, ticket := range spui.Tickets {
 			th, err := chainhash.NewHashFromStr(ticket.Ticket)
+			// This may not be a fatal error. TODO: Inform user to try again.
 			if err != nil {
 				log.Infof("NewHashFromStr failed for %v", ticket)
 				return "/error?r=/tickets", http.StatusSeeOther
@@ -1512,20 +1551,20 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 		}
 
 		for idx, ticket := range spui.Tickets {
-			switch {
-			case ticket.Status == "live":
+			switch ticket.Status {
+			case "live":
 				ticketInfoLive[idx] = TicketInfoLive{
 					Ticket:       ticket.Ticket,
 					TicketHeight: ticket.TicketHeight,
 					VoteBits:     gtvb.VoteBitsList[idx].VoteBits,
 				}
-			case ticket.Status == "missed":
+			case "missed":
 				ticketInfoMissed[idx] = TicketInfoHistoric{
 					Ticket:        ticket.Ticket,
 					SpentByHeight: ticket.SpentByHeight,
 					TicketHeight:  ticket.TicketHeight,
 				}
-			case ticket.Status == "voted":
+			case "voted":
 				ticketInfoVoted[idx] = TicketInfoHistoric{
 					Ticket:        ticket.Ticket,
 					SpentBy:       ticket.SpentBy,
@@ -1546,11 +1585,15 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 	c.Env["TicketsVoted"] = ticketInfoVoted
 	widgets = controller.Parse(t, "tickets", c.Env)
 	c.Env["Content"] = template.HTML(widgets)
+	c.Env["Flash"] = session.Flashes("tickets")
 
 	return controller.Parse(t, "main", c.Env), http.StatusOK
 }
 
-// Tickets form submit route
+// TicketsPost is the Tickets page form submit route, which involves setting
+// vote bits.  Currently this is done by toggling pool control and, if pool
+// control is disabled (manual control), choosing to either approve or
+// disapprove blocks. Handles POST on "/tickets".
 func (controller *MainController) TicketsPost(c web.C, r *http.Request) (string, int) {
 	chooseallow := r.FormValue("chooseallow")
 	// votebitsmanual := r.FormValue("votebitsmanual")
@@ -1569,16 +1612,25 @@ func (controller *MainController) TicketsPost(c web.C, r *http.Request) (string,
 		}
 	}
 
+	// Look up user, and try very hard to avoid a panic
 	session := controller.GetSession(c)
 	dbMap := controller.GetDbMap(c)
-	user := models.GetUserById(dbMap, session.Values["UserId"].(int64))
+	id, ok := session.Values["UserId"].(int64)
+	if !ok {
+		log.Error("No valid UserID")
+	}
+
+	user := models.GetUserById(dbMap, id)
+	if user==nil {
+		log.Error("Unable to find user with ID", id)
+	}
 
 	if user.MultiSigAddress == "" {
 		log.Info("Multisigaddress empty")
 		return "/error?r=/tickets", http.StatusSeeOther
 	}
 
-	ms, err := dcrutil.DecodeAddress(user.MultiSigAddress, controller.params)
+	multisig, err := dcrutil.DecodeAddress(user.MultiSigAddress, controller.params)
 	if err != nil {
 		log.Infof("Invalid address %v in database: %v", user.MultiSigAddress, err)
 		return "/error?r=/tickets", http.StatusSeeOther
@@ -1587,11 +1639,14 @@ func (controller *MainController) TicketsPost(c web.C, r *http.Request) (string,
 	if controller.RPCIsStopped() {
 		return "/error", http.StatusSeeOther
 	}
-	spui, err := controller.rpcServers.StakePoolUserInfo(ms)
+	spui, err := controller.rpcServers.StakePoolUserInfo(multisig)
 	if err != nil {
 		log.Infof("RPC StakePoolUserInfo failed: %v", err)
 		return "/error?r=/tickets", http.StatusSeeOther
 	}
+
+	outPath := "/tickets"
+	status := http.StatusOK
 
 	for _, ticket := range spui.Tickets {
 		if controller.RPCIsStopped() {
@@ -1600,7 +1655,9 @@ func (controller *MainController) TicketsPost(c web.C, r *http.Request) (string,
 		th, err := chainhash.NewHashFromStr(ticket.Ticket)
 		if err != nil {
 			log.Infof("NewHashFromStr failed for %v", ticket)
-			return "/error?r=/tickets", http.StatusSeeOther
+			outPath = "/error?r=/tickets"
+			status = http.StatusSeeOther
+			continue
 		}
 		err = controller.rpcServers.SetTicketVoteBits(th, voteBits)
 		if err != nil {
@@ -1612,7 +1669,7 @@ func (controller *MainController) TicketsPost(c web.C, r *http.Request) (string,
 		}
 	}
 
-	return "/tickets", http.StatusSeeOther
+	return outPath, status
 }
 
 // This route logs user out

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -1581,7 +1581,7 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 		}
 
 		// Only get votebits for live tickets
-		liveTicketHashes, err := w.GetLiveUserTickets(multisig)
+		liveTicketHashes, err := w.GetUnspentUserTickets(multisig)
 		if err != nil {
 			return "/error?r=/tickets", http.StatusSeeOther
 		}

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -268,7 +268,7 @@ func (controller *MainController) APIAddress(c web.C, r *http.Request) ([]string
 		return nil, "system error", errors.New("unable to process wallet commands")
 	}
 
-	models.UpdateUserById(dbMap, uid64, createMultiSig.Address,
+	models.UpdateUserByID(dbMap, uid64, createMultiSig.Address,
 		createMultiSig.RedeemScript, poolPubKeyAddr, userPubKeyAddr,
 		userFeeAddr.EncodeAddress(), bestBlockHeight)
 

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync/atomic"
+	"time"
 	"net/smtp"
 	"strconv"
 	"strings"
@@ -1533,10 +1534,10 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 		responseHeaderMap["Retry-After"] = "60"
 		// Render page with messgae to try again later
 		//c.Env["Content"] = template.HTML("Ticket data resyncing.  Please try again later.")
-		c.Env["Content"] = template.HTML(controller.Parse(t, "tickets", c.Env))
 		session.AddFlash("Ticket data resyncing.  Please try again later.", "tickets")
 		c.Env["Flash"] = session.Flashes("tickets")
-		return controller.Parse(t, "main", c.Env), http.StatusProcessing
+		c.Env["Content"] = template.HTML(controller.Parse(t, "tickets", c.Env))
+		return controller.Parse(t, "main", c.Env), http.StatusOK
 	}
 
 	// Vote bits sync is not running, but we also don't want a sync process
@@ -1560,8 +1561,8 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 	if err != nil {
 		// Render page with messgae to try again later
 		log.Infof("RPC StakePoolUserInfo failed: %v", err)
-		session.AddFlash("Unable to retreive stake pool user info.", "tickets")
-		c.Env["Flash"] = session.Flashes("tickets")
+		session.AddFlash("Unable to retreive stake pool user info.", "main")
+		c.Env["Flash"] = session.Flashes("main")
 		return controller.Parse(t, "main", c.Env), http.StatusInternalServerError
 	}
 
@@ -1593,9 +1594,9 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 				go w.SyncTicketsVoteBits(tickethashes)
 				responseHeaderMap["Retry-After"] = "60"
 				// Render page with messgae to try again later
-				c.Env["Content"] = template.HTML(controller.Parse(t, "tickets", c.Env))
 				session.AddFlash("Ticket data resyncing.  Please try again later.", "tickets")
 				c.Env["Flash"] = session.Flashes("tickets")
+				c.Env["Content"] = template.HTML(controller.Parse(t, "tickets", c.Env))
 				// Return with a 503 error indicating when to retry
 				return controller.Parse(t, "main", c.Env), http.StatusServiceUnavailable
 			}
@@ -1655,6 +1656,13 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 // control is disabled (manual control), choosing to either approve or
 // disapprove blocks. Handles POST on "/tickets".
 func (controller *MainController) TicketsPost(c web.C, r *http.Request) (string, int) {
+	w := controller.rpcServers
+
+	// If already processing let /ticktets handle this
+	if atomic.LoadInt32(&w.ticketDataBlocker) != 0 {
+		return "/tickets", http.StatusSeeOther
+	}
+
 	chooseallow := r.FormValue("chooseallow")
 	// votebitsmanual := r.FormValue("votebitsmanual")
 	var voteBits = uint16(0)
@@ -1699,35 +1707,52 @@ func (controller *MainController) TicketsPost(c web.C, r *http.Request) (string,
 	if controller.RPCIsStopped() {
 		return "/error", http.StatusSeeOther
 	}
-	spui, err := controller.rpcServers.StakePoolUserInfo(multisig)
+	spui, err := w.StakePoolUserInfo(multisig)
 	if err != nil {
 		log.Infof("RPC StakePoolUserInfo failed: %v", err)
 		return "/error?r=/tickets", http.StatusSeeOther
 	}
 
 	outPath := "/tickets"
-	status := http.StatusOK
+	status := http.StatusSeeOther
 
-	for _, ticket := range spui.Tickets {
-		if controller.RPCIsStopped() {
-			return "/error", http.StatusSeeOther
+	// Set this off in a goroutine
+	go func() (string, int) {
+		// write lock
+		w.ticketDataLock.Lock()
+		defer w.ticketDataLock.Unlock()
+
+		if !atomic.CompareAndSwapInt32(&w.ticketDataBlocker, 0, 1) {
+			return outPath, status
 		}
-		th, err := chainhash.NewHashFromStr(ticket.Ticket)
-		if err != nil {
-			log.Infof("NewHashFromStr failed for %v", ticket)
-			outPath = "/error?r=/tickets"
-			status = http.StatusSeeOther
-			continue
-		}
-		err = controller.rpcServers.SetTicketVoteBits(th, voteBits)
-		if err != nil {
-			if err == ErrSetVoteBitsCoolDown {
-				return "/error?r=/tickets&rl=1", http.StatusSeeOther
+		defer atomic.StoreInt32(&w.ticketDataBlocker, 0)
+
+		for _, ticket := range spui.Tickets {
+			if controller.RPCIsStopped() {
+				return "/error", http.StatusSeeOther
 			}
-			controller.handlePotentialFatalError("SetTicketVoteBits", err)
-			return "/error?r=/tickets", http.StatusSeeOther
+			th, err := chainhash.NewHashFromStr(ticket.Ticket)
+			if err != nil {
+				log.Infof("NewHashFromStr failed for %v", ticket)
+				outPath = "/error?r=/tickets"
+				status = http.StatusSeeOther
+				continue
+			}
+			err = controller.rpcServers.SetTicketVoteBits(th, voteBits)
+			if err != nil {
+				if err == ErrSetVoteBitsCoolDown {
+					return "/error?r=/tickets&rl=1", http.StatusSeeOther
+				}
+				controller.handlePotentialFatalError("SetTicketVoteBits", err)
+				return "/error?r=/tickets", http.StatusSeeOther
+			}
 		}
-	}
+		return outPath, status
+	}()
+
+	// Like a timeout, give the sync some time to process, otherwise /tickets
+	// will show a message that it is still syncing.
+	time.Sleep(3 * time.Second)
 
 	return outPath, status
 }

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -1594,7 +1594,7 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 				go w.SyncTicketsVoteBits(tickethashes)
 				responseHeaderMap["Retry-After"] = "60"
 				// Render page with messgae to try again later
-				session.AddFlash("Ticket data resyncing.  Please try again later.", "tickets")
+				session.AddFlash("Detected mismatching vote bits.  Ticket data resyncing.  Please try again later.", "tickets")
 				c.Env["Flash"] = session.Flashes("tickets")
 				c.Env["Content"] = template.HTML(controller.Parse(t, "tickets", c.Env))
 				// Return with a 503 error indicating when to retry

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -1646,7 +1646,7 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 func (controller *MainController) TicketsPost(c web.C, r *http.Request) (string, int) {
 	w := controller.rpcServers
 
-	// If already processing let /ticktets handle this
+	// If already processing let /tickets handle this
 	if atomic.LoadInt32(&w.ticketDataBlocker) != 0 {
 		return "/tickets", http.StatusSeeOther
 	}

--- a/glide.yaml
+++ b/glide.yaml
@@ -15,6 +15,7 @@ import:
   - txscript
   - wire
 - package: github.com/decred/dcrrpcclient
+  version: b0a8d313e5b89d0673a6e3e4df87540200b48f3f
 - package: github.com/decred/dcrutil
   subpackages:
   - hdkeychain

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,6 +4,7 @@ import:
 - package: github.com/btcsuite/go-flags
 - package: github.com/btcsuite/seelog
 - package: github.com/decred/dcrd
+  version: v0.4.0
   subpackages:
   - addrmgr
   - blockchain
@@ -15,7 +16,7 @@ import:
   - txscript
   - wire
 - package: github.com/decred/dcrrpcclient
-  version: b0a8d313e5b89d0673a6e3e4df87540200b48f3f
+  version: f3c620d63cb02aec0c1152a72d3c8669b92a2fb5
 - package: github.com/decred/dcrutil
   subpackages:
   - hdkeychain

--- a/helpers/auth.go
+++ b/helpers/auth.go
@@ -130,6 +130,10 @@ func UserIDExists(dbMap *gorp.DbMap, userid int64) (*models.User, error) {
 	return &user, err
 }
 
+// Login looks up a user by email and validates the provided clear text password
+// against the bcrypt hashed password stored in the DB. Returns the *User and an
+// error. On failure *User is nil and error is non-nil. On success, error is
+// nil.
 func Login(dbMap *gorp.DbMap, email string, password string) (*models.User, error) {
 	var user models.User
 	err := dbMap.SelectOne(&user, "SELECT * FROM Users WHERE Email = ?", email)

--- a/models/user.go
+++ b/models/user.go
@@ -110,7 +110,7 @@ func InsertPasswordReset(dbMap *gorp.DbMap, passwordReset *PasswordReset) error 
 // username and password.
 func UpdateUserByID(dbMap *gorp.DbMap, id int64, multiSigAddr string,
 	multiSigScript string, poolPubKeyAddr string, userPubKeyAddr string,
-	userFeeAddr string) (user *User) {
+	userFeeAddr string, height int64) (user *User) {
 	err := dbMap.SelectOne(&user, "SELECT * FROM Users WHERE UserId = ?", id)
 
 	if err != nil {

--- a/models/user.go
+++ b/models/user.go
@@ -95,6 +95,7 @@ func InsertEmailChange(dbMap *gorp.DbMap, emailChange *EmailChange) error {
 	return dbMap.Insert(emailChange)
 }
 
+// InsertUser inserts a user into the DB
 func InsertUser(dbMap *gorp.DbMap, user *User) error {
 	return dbMap.Insert(user)
 }
@@ -103,18 +104,24 @@ func InsertPasswordReset(dbMap *gorp.DbMap, passwordReset *PasswordReset) error 
 	return dbMap.Insert(passwordReset)
 }
 
-func UpdateUserById(dbMap *gorp.DbMap, id int64, msa string, mss string, ppka string, upka string, ufa string, height int64) (user *User) {
+// UpdateUserByID updates a user, specified by id, in the DB with a new
+// multiSigAddr, multiSigScript, multiSigScript, pool pubkey address,
+// user pub key address, and fee address.  Unchanged are the user's ID, email,
+// username and password.
+func UpdateUserByID(dbMap *gorp.DbMap, id int64, multiSigAddr string,
+	multiSigScript string, poolPubKeyAddr string, userPubKeyAddr string,
+	userFeeAddr string) (user *User) {
 	err := dbMap.SelectOne(&user, "SELECT * FROM Users WHERE UserId = ?", id)
 
 	if err != nil {
 		glog.Warningf("Can't get user by id: %v", err)
 	}
 
-	user.MultiSigAddress = msa
-	user.MultiSigScript = mss
-	user.PoolPubKeyAddr = ppka
-	user.UserPubKeyAddr = upka
-	user.UserFeeAddr = ufa
+	user.MultiSigAddress = multiSigAddr
+	user.MultiSigScript = multiSigScript
+	user.PoolPubKeyAddr = poolPubKeyAddr
+	user.UserPubKeyAddr = userPubKeyAddr
+	user.UserFeeAddr = userFeeAddr
 	user.HeightRegistered = height
 
 	_, err = dbMap.Update(user)
@@ -122,6 +129,8 @@ func UpdateUserById(dbMap *gorp.DbMap, id int64, msa string, mss string, ppka st
 	if err != nil {
 		glog.Warningf("Couldn't update user: %v", err)
 	}
+	
+	// return updated User
 	return
 }
 

--- a/models/user.go
+++ b/models/user.go
@@ -129,7 +129,7 @@ func UpdateUserByID(dbMap *gorp.DbMap, id int64, multiSigAddr string,
 	if err != nil {
 		glog.Warningf("Couldn't update user: %v", err)
 	}
-	
+
 	// return updated User
 	return
 }

--- a/system/core.go
+++ b/system/core.go
@@ -108,11 +108,20 @@ func (application *Application) Route(controller interface{}, route string) inte
 			}
 		}
 
+		if respHeader, exists := c.Env["ResponseHeaderMap"]; exists {
+			if hdrMap, ok := respHeader.(map[string]string); ok {
+				for key, val := range hdrMap {
+					w.Header().Set(key, val)
+				}
+			}
+		}
+
 		switch code {
-		case http.StatusOK:
+		case http.StatusOK, http.StatusProcessing, http.StatusServiceUnavailable:
 			if _, exists := c.Env["Content-Type"]; exists {
 				w.Header().Set("Content-Type", c.Env["Content-Type"].(string))
 			}
+			w.WriteHeader(code)
 			io.WriteString(w, body)
 		case http.StatusSeeOther, http.StatusFound:
 			http.Redirect(w, r, body, code)

--- a/views/tickets.html
+++ b/views/tickets.html
@@ -2,6 +2,9 @@
 {{if .Error}}
 	<div class="alert alert-danger">{{.Error}}</div><p>
 {{end}}
+{{range .Flash}}
+	<div class="alert alert-danger">{{.}}</div>
+{{end}}
 <div class="panel panel-default">
 	<div class="panel-heading" style="background-color: #222; color: #ffffff;">
 		<h4 class="panel-title">

--- a/views/tickets.html
+++ b/views/tickets.html
@@ -5,6 +5,9 @@
 {{range .Flash}}
 	<div class="alert alert-danger">{{.}}</div>
 {{end}}
+{{range .FlashWarn}}
+	<div class="alert alert-warning">{{.}}</div>
+{{end}}
 <div class="panel panel-default">
 	<div class="panel-heading" style="background-color: #222; color: #ffffff;">
 		<h4 class="panel-title">


### PR DESCRIPTION
This implements vote bits (re)synchronization/repair.  Please test and review.  All of the new or modified functionality is tested on a testnet pool, but there may be more attack protections that should be made (walletRPCHandlerize any of this?).

In terms of behavior:
- On startup of dcrstakepool, a full vote bits sync of all tickets owned by the pool is performed.  It will be skipped if importscript gets run since that takes a long time.
- /tickets POST (set bits) has a short timeout so a large number of tickets does not block page loading.  TODO: implement a proper timeout with a channel and time.After select.
- A flash message will indicate that a tickets sync is in progress.  No tickets are shown in this period.
- /tickets GET checks for consistency of vote bits between wallets and launches a resync when needed.  A flash message is also used in this case, and no tickets are shown (as shown in image below).

Implementation:
- A RWMutex is used so multiple readers can access ticket vote bits data, while a single writer can lock before doing a set of any vote bits.
- An atomic is used to make a kind of "try lock" that the /tickets page can check without blocking.

It needs a dcrrpcclient version change for the new GetTickets RPC.

Issues:
- [x] `getstakeinfo`'s immature includes unmined, whereas `gettickets` does not include mempool. This prevents the startup check from passing [`int(gsi.Live+gsi.Immature) != numLiveTickets`](https://github.com/decred/dcrstakepool-private/pull/32/files#diff-454a23714e7d91a2a570cae4ce8ee807R1034) while tickets are in mempool. All is well after tickets get mined.  Workaround is to avoid such a check, and only check that the wallets agree with eachother w.r.t. gettickets.
- [x] On startup, if wallets are out of sync w.r.t. address indexes or scripts, then it is likely that `SyncVoteBits` will either report different numbers of tickets (before they are processing the import/sync) or report -4: syncing...  [here](https://github.com/decred/dcrstakepool-private/pull/32/files#diff-454a23714e7d91a2a570cae4ce8ee807R1311)  Rather than quit, the solution is to just skip the full ticket vote bits sync (check and repair).  The vote bits are repaired on-demand via /tickets.
- [x] Look like at least 33% of this PR is done.

Startup auto-repair:
![resync](http://i.imgur.com/9go1p8k.jpg)

User changing vote bits, if process exceeds 3 seconds:
![bitschange](http://i.imgur.com/QjG5gDA.jpg)
