### PR TITLE
add basic API and example script

### DIFF
--- a/apiClientExample.sh
+++ b/apiClientExample.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+# This script registers a new account at a stakepool, waits a bit
+# for the email verification link to be clicked, submits an address,
+# requests the ticket purchasing information for the account, and
+# then requests the pool's statistics.
+
+apiURL="http://127.0.0.1:8000/api/v0.1"
+cookieFile=$(mktemp /tmp/stakepoolapiclient.XXXXXXXXXX)
+email="example@example.com"
+password="blake256"
+pubKeyAddr="TkKnJTAQTQ42nAwLj9wSXJcrKadSJneNkXT9LW25kqBKH646N4Bws"
+secsForEmailVerification=15
+
+apiCmd() {
+    # $1 = cmd, $2 = data
+    if [ -z "$2" ]; then
+        echo "running curl -s -b $cookieFile -c $cookieFile $apiURL/$1"
+        r="$(curl -s -b $cookieFile -c $cookieFile $apiURL/$1)"
+    else
+        updateCsrfToken
+        echo "running curl -s -b $cookieFile -c $cookieFile --data $2&csrf_token=$csrftoken $apiURL/$1"
+        r="$(curl -s -b $cookieFile -c $cookieFile --data "$2&csrf_token=$csrftoken" $apiURL/$1)"
+    fi
+
+    if [ -z "$r" ]; then
+        fatal "command $1 failed"
+    fi
+
+    status=$(echo $r |jq -r .status)
+
+    if [ "$status" == "error" ]; then
+        echo "WARNING: command returned with error"
+    fi
+    # can add additional processing of the result here
+    echo $r
+}
+
+cleanUp() {
+    echo "removing $cookieFile"
+    rm $cookieFile
+}
+
+fatal() {
+    echo >&2 "$1"
+    cleanUp
+    exit 1
+}
+
+updateCsrfToken() {
+    csrftoken=$(grep XSRF-TOKEN $cookieFile |awk '{print $7}')
+}
+
+waitForVerification() {
+    echo "sleeping $secsForEmailVerification seconds to allow email verification link to be clicked"
+    for i in `seq $secsForEmailVerification -1 1`;
+        do echo "$i seconds left to verify email"; sleep 1
+    done
+}
+
+command -v jq >/dev/null 2>&1 || { fatal "I require the binary jq (https://stedolan.github.io/jq/) but it's not installed.  Aborting."; }
+
+echo "using cookieFile $cookieFile"
+
+apiCmd "startsession"
+
+apiCmd "signup" "email=$email&password=$password&passwordrepeat=$password"
+
+waitForVerification
+
+apiCmd "signin" "email=$email&password=$password"
+
+apiCmd "address" "UserPubKeyAddr=$pubKeyAddr"
+
+apiCmd "getPurchaseInfo"
+
+apiCmd "stats"
+
+cleanUp

--- a/config.go
+++ b/config.go
@@ -87,6 +87,7 @@ type config struct {
 	WalletUsers      []string `long:"walletusers" description:"Username for wallet server"`
 	WalletPasswords  []string `long:"walletpasswords" description:"Pasword for wallet server"`
 	WalletCerts      []string `long:"walletcerts" description:"Certificate path for wallet server"`
+	Version          string
 }
 
 // serviceOptions defines the configuration options for the daemon as a service on
@@ -278,6 +279,7 @@ func loadConfig() (*config, []string, error) {
 		RecaptchaSecret:  defaultRecaptchaSecret,
 		RecaptchaSitekey: defaultRecaptchaSitekey,
 		SMTPHost:         defaultSMTPHost,
+		Version:          version(),
 	}
 
 	// Service options which are only added on Windows.

--- a/models/user.go
+++ b/models/user.go
@@ -70,6 +70,27 @@ func GetUserById(dbMap *gorp.DbMap, id int64) (user *User) {
 	return
 }
 
+// GetUserCount gives a count of all users
+func GetUserCount(dbMap *gorp.DbMap) int64 {
+	userCount, err := dbMap.SelectInt("SELECT COUNT(*) FROM Users")
+	if err != nil {
+		return int64(0)
+	}
+
+	return userCount
+}
+
+// GetUserCountActive gives a count of all users who have submitted an address
+func GetUserCountActive(dbMap *gorp.DbMap) int64 {
+	userCountActive, err := dbMap.SelectInt("SELECT COUNT(*) FROM Users " +
+		"WHERE MultiSigAddress <> ''")
+	if err != nil {
+		return int64(0)
+	}
+
+	return userCountActive
+}
+
 func InsertEmailChange(dbMap *gorp.DbMap, emailChange *EmailChange) error {
 	return dbMap.Insert(emailChange)
 }

--- a/sample-nginx.conf
+++ b/sample-nginx.conf
@@ -30,6 +30,8 @@ http {
         rewrite ^       https://stakepool.domain.tld/$request_uri permanent;
     }
 
+    limit_req_zone $binary_remote_addr zone=stakepool:10m rate=1r/s;
+
     server {
         listen       443 default_server;
         server_name  _;
@@ -45,10 +47,13 @@ http {
         add_header                      Strict-Transport-Security max-age=15552001;
 
         location / {
-                proxy_set_header Host $host;
-                proxy_set_header X-Real-IP $remote_addr;
-                proxy_pass http://127.0.0.1:8000;
-                proxy_http_version 1.0;
+            # apply rate limiting
+            limit_req zone=stakepool burst=5;
+
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_pass http://127.0.0.1:8000;
+            proxy_http_version 1.0;
         }
     }
 }

--- a/server.go
+++ b/server.go
@@ -87,8 +87,8 @@ func main() {
 	controller, err := controllers.NewMainController(activeNetParams.Params,
 		cfg.BaseURL, cfg.ClosePool, cfg.ClosePoolMsg, cfg.ColdWalletExtPub,
 		cfg.PoolEmail, cfg.PoolFees, cfg.PoolLink,
-		cfg.RecaptchaSecret, cfg.RecaptchaSitekey,
-		cfg.SMTPFrom, cfg.SMTPHost, cfg.SMTPUsername, cfg.SMTPPassword,
+		cfg.RecaptchaSecret, cfg.RecaptchaSitekey, cfg.SMTPFrom, cfg.SMTPHost,
+		cfg.SMTPUsername, cfg.SMTPPassword, cfg.Version,
 		cfg.WalletHosts, cfg.WalletCerts, cfg.WalletUsers, cfg.WalletPasswords)
 	if err != nil {
 		application.Close()
@@ -121,6 +121,9 @@ func main() {
 	// Address form
 	goji.Get("/address", application.Route(controller, "Address"))
 	goji.Post("/address", application.Route(controller, "AddressPost"))
+
+	// API
+	goji.Handle("/api/*", application.Route(controller, "API"))
 
 	// Email change/update confirmation
 	goji.Get("/emailupdate", application.Route(controller, "EmailUpdate"))


### PR DESCRIPTION
This is a basic/hacky implementation of #34 and #36.  As mentioned in the comments and #47, the framework and middleware need some modernizing so we can provide a cleaner/better API.

With that being said it does work and the API is versioned appropriately so it can improved later.

Also fixes some copy & paste errors from #45.

Closes #34.
Closes #36.