### PR TITLE
add word break on panel body

### DIFF
--- a/public/css/dcrstakepool.css
+++ b/public/css/dcrstakepool.css
@@ -8,6 +8,10 @@ body {
 	margin-bottom: 60px;
 }
 
+.panel-body  {
+    word-break: break-all;
+}
+
 .panel-heading a:after {
     font-family:'Glyphicons Halflings';
     content:"\e114";


### PR DESCRIPTION
This just breaks the text up in panel bodies so it doesn't overflow anymore on smaller screens/windows.

Closes #4.