### PR TITLE
More sync and POST logging

### DIFF
--- a/controllers/dcrclient.go
+++ b/controllers/dcrclient.go
@@ -1538,6 +1538,7 @@ func (w *walletSvrManager) SyncVoteBits() error {
 	}
 
 	// Check live tickets
+	log.Info("SyncVoteBits: Getting list of all live tickets on wallet 0.")
 	// legacyrpc.getTickets excludes spent tickets
 	ticketHashes, err := w.servers[0].GetTickets(true)
 	if err != nil {
@@ -1545,7 +1546,7 @@ func (w *walletSvrManager) SyncVoteBits() error {
 	}
 	ticketHashesMined := getMinedTickets(w.servers[0], ticketHashes)
 	numLiveTickets := len(ticketHashesMined)
-	log.Infof("Excluding %d unmined tickets in votebits sync.",
+	log.Infof("SyncVoteBits: Excluding %d unmined tickets in votebits sync.",
 		len(ticketHashes)-numLiveTickets)
 
 	// gsi, err := w.servers[0].GetStakeInfo()
@@ -1564,6 +1565,7 @@ func (w *walletSvrManager) SyncVoteBits() error {
 			continue
 		}
 
+		log.Infof("SyncVoteBits: Checking number of tickets on wallet %d", i)
 		ticketHashes, err = cl.GetTickets(true)
 		//gsi, err = cl.GetStakeInfo()
 		if err != nil {
@@ -1795,6 +1797,7 @@ func walletSvrsSync(wsm *walletSvrManager, multiSigScripts []models.User) error 
 	}
 	// Go through each server and see who is synced to the longest
 	// address indexes and and the most redeemscripts.
+	log.Info("Getting address index and importscript information from wallets.")
 	for i := range wsm.servers {
 		if wsm.servers[i] == nil {
 			continue
@@ -1836,6 +1839,7 @@ func walletSvrsSync(wsm *walletSvrManager, multiSigScripts []models.User) error 
 	// Synchronize the address indexes if needed, then synchronize the
 	// redeemscripts. Ignore the errors when importing scripts and
 	// assume it'll just skip reimportation if it already has it.
+	log.Info("Syncing wallets' redeem scripts and setting address indexes.")
 	desynced := false
 	for i := range wsm.servers {
 		if wsm.servers[i] == nil {

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -939,8 +939,6 @@ func (controller *MainController) PasswordResetPost(c web.C, r *http.Request) (s
 	if err != nil {
 		session.AddFlash("Invalid Email", "passwordresetError")
 	} else {
-		session.AddFlash("Recaptcha error", "passwordresetError")
-		
 		log.Infof("PasswordReset POST from %v, email %v", r.RemoteAddr,
 			user.Email)
 


### PR DESCRIPTION
More logging around startup sync, which can feel like it's hung for lots of tickets, and the POST handlers.

The calls to `GetTickets` are particularly slow, so it's helpful to have these messages:

```
08:11:00 2016-11-12 [INF] DCRS: Established connection to RPC server ...:...
08:11:00 2016-11-12 [INF] DCRS: Getting address index and importscript information from wallets.
08:11:01 2016-11-12 [INF] DCRS: Syncing wallets' redeem scripts and setting address indexes.
08:11:04 2016-11-12 [INF] DCRS: SyncVoteBits: Getting list of all live tickets on wallet 0.
08:12:09 2016-11-12 [INF] DCRS: SyncVoteBits: Excluding 0 unmined tickets in votebits sync.
08:12:09 2016-11-12 [INF] DCRS: SyncVoteBits: Checking number of tickets on wallet 1
...
08:14:29 2016-11-12 [INF] DCRS: Beginning resync of vote bits for [N] tickets.
08:14:30 2016-11-12 [INF] DCRS: Completed resync of vote bits for [N] tickets.
08:14:30 2016-11-12 [INF] DCRS: Starting wallet RPC manager
```

TODO: If a wallet votes during startup, thus decrementing the number of live tickets, this can be a frustration as it breaks the check and you are forced to try starting again.  The check for number of tickets [here](https://github.com/decred/dcrstakepool/blob/master/controllers/dcrclient.go#L1560) does not need to be done with `GetTickets`, although for wallet 0, it is necessary to use GetTickets to get the hashes that are passed to `SyncTicketsVoteBits` (a speedy function).  Use another way to check this or just don't bother with this check since there are other ticket syncs that happen before the vote bits sync.

Also disallow simultaneous password update and reset.