### PR TITLE
use headers then fallback to RemoteAddr when getting remote IP

### DIFF
--- a/sample-nginx.conf
+++ b/sample-nginx.conf
@@ -39,7 +39,7 @@ http {
         ssl                     on;
         ssl_certificate         /etc/ssl/www/stakepool.domain.tld.crt;
         ssl_certificate_key     /etc/ssl/www/stakepool.domain.tld.key;
- 
+
         ssl_session_cache               shared:SSL:20m;
         ssl_protocols                   TLSv1 TLSv1.1 TLSv1.2;
         ssl_ciphers                     EECDH+CHACHA20:EECDH+CHACHA20-draft:EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
@@ -51,7 +51,7 @@ http {
             limit_req zone=stakepool burst=5;
 
             proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Real-Ip $remote_addr;
             proxy_pass http://127.0.0.1:8000;
             proxy_http_version 1.0;
         }


### PR DESCRIPTION
Lightly tested and seems to work.

I also dos2unix'd the nginx.conf and changed X-Real-IP to X-Real-Ip since it was converting to that anyway due to the mime header specification.

I figured out why it worked for me -- I was running it on my firewall/nat box and it was spitting out my external address instead of 127.0.0.1 every time so it looked like it was working.  I tested with lynx from a VPS this time.

Fixes #63.