### PR TITLE
Speed up startup live ticket count check in SyncVoteBits

### DIFF
--- a/config.go
+++ b/config.go
@@ -88,6 +88,7 @@ type config struct {
 	WalletUsers      []string `long:"walletusers" description:"Username for wallet server"`
 	WalletPasswords  []string `long:"walletpasswords" description:"Pasword for wallet server"`
 	WalletCerts      []string `long:"walletcerts" description:"Certificate path for wallet server"`
+	SkipVoteBitsSync bool     `long:"skipvotebitssync" descrition:"Skip full vote bits check and sync on startup"`
 	Version          string
 	AdminIPs         []string `long:"adminips" description:"Expected admin host"`
 	MinServers       int      `long:"minservers" description:"Minimum number of wallets connected needed to avoid errors"`

--- a/controllers/dcrclient.go
+++ b/controllers/dcrclient.go
@@ -1593,25 +1593,21 @@ func (w *walletSvrManager) SyncVoteBits() error {
 	// 		gsi.Live+gsi.Immature, numLiveTickets)
 	// }
 
-	// Check number of tickets
-
+	// Check number of live tickets on other servers
 	for i, cl := range w.servers {
 		if i == 0 {
 			continue
 		}
 
 		log.Infof("SyncVoteBits: Checking number of tickets on wallet %d", i)
-		ticketHashes, err = cl.GetTickets(true)
-		//gsi, err = cl.GetStakeInfo()
+		gsi, err := cl.GetStakeInfo()
 		if err != nil {
 			return err
 		}
 
-		thMined := getMinedTickets(w.servers[0], ticketHashes)
-
-		if numLiveTickets != len(thMined) {
+		if numLiveTickets != int(gsi.Live+gsi.Immature) {
 			log.Errorf("Non-equivalent number of tickets on servers %v, %v "+
-				" (%v, %v)", 0, i, numLiveTickets, len(thMined))
+				" (%v, %v)", 0, i, numLiveTickets, int(gsi.Live))
 			return fmt.Errorf("non equivalent num elements returned")
 		}
 	}
@@ -1679,7 +1675,7 @@ func (w *walletSvrManager) SyncTicketsVoteBits(tickets []*chainhash.Hash) error 
 					hash)
 			}
 			if votebits != refVoteBits {
-                log.Infof("Setting ticket %v votebits to %v on wallet %v",
+				log.Infof("Setting ticket %v votebits to %v on wallet %v",
 					hash.String(), refVoteBits, i)
 				err := w.servers[i].SetTicketVoteBits(&hash, refVoteBits)
 				if err != nil {
@@ -2027,7 +2023,7 @@ func newWalletSvrManager(walletHosts []string, walletCerts []string,
 			return nil, err
 		}
 	}
-	
+
 	wsm := walletSvrManager{
 		walletHosts:            walletHosts,
 		walletCerts:            walletCerts,

--- a/server.go
+++ b/server.go
@@ -100,7 +100,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	err = controller.RPCSync(application.DbMap)
+	err = controller.RPCSync(application.DbMap, cfg.SkipVoteBitsSync)
 	if err != nil {
 		application.Close()
 		dcrstakepoolLog.Errorf("Failed to sync the wallets: %v",


### PR DESCRIPTION
Since getMinedTickets was added, which removes unconfirmed tx from list from GetTickets, it's OK now to use getstakeinfo.(Live + Immature) to compare the total live (actually live+immature) ticket count on the other wallets with the count from getMinedTickets(gettickets(true)).

This makes startup much quicker and far less likely to hit a non-equiv error that you would get when live count goes down during startup.

Tested on testnet with and without unconfirmed tickets during startup (only time this is run).

- [x] test on mainnet
- [x] test once my testnet user gets live tickets too <s>(currently 0, all immature)</s> - looking good