### PR TITLE
Set Content-Type to json for API.

### DIFF
--- a/controllers/main.go
+++ b/controllers/main.go
@@ -144,6 +144,9 @@ func NewMainController(params *chaincfg.Params, adminIPs []string, baseURL strin
 // This would make it much easier to share code between the web UI and JSON
 // API with less duplication.
 func (controller *MainController) API(c web.C, r *http.Request) (string, int) {
+	// JSON is always returned presently
+	c.Env["Content-Type"] = "application/json; charset=utf-8"
+
 	// we expect /api/vX.YZ/command
 	URIparts := strings.Split(r.RequestURI, "/")
 	if len(URIparts) != 4 {


### PR DESCRIPTION
Not tested, but pretty straightforward since application.Route will apply any content-type in Env unless status is error.