### PR TITLE
API with JSON types package

### DIFF
--- a/controllers/main.go
+++ b/controllers/main.go
@@ -177,7 +177,7 @@ func (controller *MainController) APIHandler(c web.C, w http.ResponseWriter,
 	switch r.Method {
 	case "GET":
 		switch command {
-		case "getpurchaseinfo":
+		case "getPurchaseInfo":
 			data, response, err = controller.APIPurchaseInfo(c, r)
 		case "startsession":
 			status, response = "success", "session started"

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -484,7 +484,7 @@ func (controller *MainController) APIStats(c web.C,
 	stats := &poolapi.Stats{
 		AllMempoolTix:    I32toa(gsi.AllMempoolTix),
 		BlockHeight:      I32toa(uint32(gsi.BlockHeight)),
-		Difficulty:       strconv.FormatFloat(gsi.ProportionLive, 'f', 2, 64),
+		Difficulty:       strconv.FormatFloat(gsi.Difficulty, 'f', 2, 64),
 		Immature:         I32toa(gsi.Immature),
 		Live:             I32toa(gsi.Live),
 		Missed:           I32toa(gsi.Missed),

--- a/poolapi/apijson.go
+++ b/poolapi/apijson.go
@@ -10,32 +10,34 @@ func NewResponse(status, message string, data interface{}) *Response {
 	return &Response{status, message, data}
 }
 
+// TODO: make JSON tags lower-case and add "_" between words
+
 type PurchaseInfo struct {
-	PoolAddress   string `json:"pool_address"`
-	PoolFees      string `json:"pool_fees"`
-	Script        string `json:"script"`
-	TicketAddress string `json:"ticket_address"`
+	PoolAddress   string `json:"PoolAddress"`
+	PoolFees      string `json:"PoolFees"`
+	Script        string `json:"Script"`
+	TicketAddress string `json:"TicketAddress"`
 }
 
 type Stats struct {
-	AllMempoolTix    string `json:"allmempooltix"`
-	BlockHeight      string `json:"block_height"`
-	Difficulty       string `json:"difficulty"`
-	Immature         string `json:"immature"`
-	Live             string `json:"live"`
-	Missed           string `json:"missed"`
-	OwnMempoolTix    string `json:"ownmempooltix"`
-	PoolSize         string `json:"pool_size"`
-	ProportionLive   string `json:"proportion_live"`
-	ProportionMissed string `json:"proportion_missed"`
-	Revoked          string `json:"revoked"`
-	TotalSubsidy     string `json:"total_subsidy"`
-	Voted            string `json:"voted"`
-	Network          string `json:"network"`
-	PoolEmail        string `json:"pool_email"`
-	PoolFees         string `json:"pool_fees"`
-	PoolStatus       string `json:"pool_status"`
-	UserCount        string `json:"user_count"`
-	UserCountActive  string `json:"user_count_active"`
-	Version          string `json:"version"`
+	AllMempoolTix    string `json:"AllMempoolTix"`
+	BlockHeight      string `json:"BlockHeight"`
+	Difficulty       string `json:"Difficulty"`
+	Immature         string `json:"Immature"`
+	Live             string `json:"Live"`
+	Missed           string `json:"Missed"`
+	OwnMempoolTix    string `json:"OwnMempoolTix"`
+	PoolSize         string `json:"PoolSize"`
+	ProportionLive   string `json:"ProportionLive"`
+	ProportionMissed string `json:"ProportionMissed"`
+	Revoked          string `json:"Revoked"`
+	TotalSubsidy     string `json:"TotalSubsidy"`
+	Voted            string `json:"Voted"`
+	Network          string `json:"Network"`
+	PoolEmail        string `json:"PoolEmail"`
+	PoolFees         string `json:"PoolFees"`
+	PoolStatus       string `json:"PoolStatus"`
+	UserCount        string `json:"UserCount"`
+	UserCountActive  string `json:"UserCountActive"`
+	Version          string `json:"Version"`
 }

--- a/poolapi/apijson.go
+++ b/poolapi/apijson.go
@@ -1,0 +1,7 @@
+package poolapi
+
+type Response struct {
+	Status  string `json:"status"`
+	Message string `json:"message"`
+	Data    string `json:"omitempty"`
+}

--- a/poolapi/apijson.go
+++ b/poolapi/apijson.go
@@ -1,7 +1,41 @@
 package poolapi
 
 type Response struct {
-	Status  string `json:"status"`
-	Message string `json:"message"`
-	Data    string `json:"omitempty"`
+	Status  string      `json:"status"`
+	Message string      `json:"message"`
+	Data    interface{} `json:",omitempty"`
+}
+
+func NewResponse(status, message string, data interface{}) *Response {
+	return &Response{status, message, data}
+}
+
+type PurchaseInfo struct {
+	PoolAddress   string `json:"pool_address"`
+	PoolFees      string `json:"pool_fees"`
+	Script        string `json:"script"`
+	TicketAddress string `json:"ticket_address"`
+}
+
+type Stats struct {
+	AllMempoolTix    string `json:"allmempooltix"`
+	BlockHeight      string `json:"block_height"`
+	Difficulty       string `json:"difficulty"`
+	Immature         string `json:"immature"`
+	Live             string `json:"live"`
+	Missed           string `json:"missed"`
+	OwnMempoolTix    string `json:"ownmempooltix"`
+	PoolSize         string `json:"pool_size"`
+	ProportionLive   string `json:"proportion_live"`
+	ProportionMissed string `json:"proportion_missed"`
+	Revoked          string `json:"revoked"`
+	TotalSubsidy     string `json:"total_subsidy"`
+	Voted            string `json:"voted"`
+	Network          string `json:"network"`
+	PoolEmail        string `json:"pool_email"`
+	PoolFees         string `json:"pool_fees"`
+	PoolStatus       string `json:"pool_status"`
+	UserCount        string `json:"user_count"`
+	UserCountActive  string `json:"user_count_active"`
+	Version          string `json:"version"`
 }

--- a/poolapi/apijson.go
+++ b/poolapi/apijson.go
@@ -3,7 +3,7 @@ package poolapi
 type Response struct {
 	Status  string      `json:"status"`
 	Message string      `json:"message"`
-	Data    interface{} `json:",omitempty"`
+	Data    interface{} `json:"data,omitempty"`
 }
 
 func NewResponse(status, message string, data interface{}) *Response {

--- a/server.go
+++ b/server.go
@@ -125,6 +125,7 @@ func main() {
 
 	// API
 	goji.Handle("/api/*", application.Route(controller, "API"))
+	goji.Handle("/api/*", system.GojiWebHandlerFunc(controller))
 
 	// Email change/update confirmation
 	goji.Get("/emailupdate", application.Route(controller, "EmailUpdate"))

--- a/server.go
+++ b/server.go
@@ -25,6 +25,8 @@ var (
 	cfg *config
 )
 
+// gojify wraps system's GojiWebHandlerFunc to allow the use of an
+// http.HanderFunc as a web.HandlerFunc.
 func gojify(h http.HandlerFunc) web.HandlerFunc {
 	return system.GojiWebHandlerFunc(h)
 }
@@ -129,7 +131,7 @@ func main() {
 
 	// API
 	goji.Handle("/api/v1/:command", controller.APIHandler)
-	goji.Handle("/api/*", gojify(controller.APIInvalidHandler))
+	goji.Handle("/api/*", gojify(controllers.APIInvalidHandler))
 
 	// Email change/update confirmation
 	goji.Get("/emailupdate", application.Route(controller, "EmailUpdate"))

--- a/server.go
+++ b/server.go
@@ -25,6 +25,10 @@ var (
 	cfg *config
 )
 
+func gojify(h http.HandlerFunc) web.HandlerFunc {
+	return system.GojiWebHandlerFunc(h)
+}
+
 func main() {
 	// Load configuration and parse command line.  This function also
 	// initializes logging and configures it accordingly.
@@ -124,8 +128,8 @@ func main() {
 	goji.Post("/address", application.Route(controller, "AddressPost"))
 
 	// API
-	goji.Handle("/api/*", application.Route(controller, "API"))
-	goji.Handle("/api/*", system.GojiWebHandlerFunc(controller))
+	goji.Handle("/api/v1/:command", controller.APIHandler)
+	goji.Handle("/api/*", gojify(controller.APIInvalidHandler))
 
 	// Email change/update confirmation
 	goji.Get("/emailupdate", application.Route(controller, "EmailUpdate"))

--- a/system/core.go
+++ b/system/core.go
@@ -34,6 +34,8 @@ type Application struct {
 	CsrfProtection *CsrfProtection
 }
 
+// GojiWebHandlerFunc is an adaptor that allows an http.HanderFunc where a
+// web.HandlerFunc is required.
 func GojiWebHandlerFunc(h http.HandlerFunc) web.HandlerFunc {
 	return func(_ web.C, w http.ResponseWriter, r *http.Request) {
 		h(w, r)

--- a/system/core.go
+++ b/system/core.go
@@ -34,6 +34,12 @@ type Application struct {
 	CsrfProtection *CsrfProtection
 }
 
+func GojiWebHandlerFunc(h http.HandlerFunc) web.HandlerFunc {
+	return func(_ web.C, w http.ResponseWriter, r *http.Request) {
+		h(w, r)
+	}
+}
+
 func (application *Application) Init(filename *string) {
 
 	config, err := toml.LoadFile(*filename)
@@ -91,7 +97,7 @@ func (application *Application) Close() {
 	glog.Info("Bye!")
 }
 
-func (application *Application) Route(controller interface{}, route string) interface{} {
+func (application *Application) Route(controller interface{}, route string) web.HandlerFunc {
 	fn := func(c web.C, w http.ResponseWriter, r *http.Request) {
 		c.Env["Content-Type"] = "text/html"
 


### PR DESCRIPTION
This is more for discussion than anything at this point as it is completely untested.  I believe the API needs several improvements, but this pertains to the following:

- For the convenience of encoding JSON by the server, struct response types with json tags should be created.
- For Go clients the json structs should put in their own package.
- The main API handler should be rewritten to use these types and the encodings/json package.
- The route handler should not include logic for parsing the version and command out of the url (goji and any router will do that).

Specifically, from the commit messages, this PR does the following:

- Add `poolapi` package with json structs, and new+modified api routes.  The `poolapi` package helps write go clients, and facilitate use of `json.Marshal` in generating the response for `http.ResponseWriter`.
- Modify `APIStats` and `APIPurchaseInfo` to use the new types and `json.Encoder.Encode()` directly into the `http.ResponseWriter`.
- `API()` -> `APIHandler` + `APIResponseHandler` + `APIInvalidHandler`.
- `APIHandler` uses `poolapi.NewResponse` to ready the response for `APIResponseHandler`.
- If no appropriate route+method exists, `APIInvalidHandler` is used.

A more elegant routing solution, like github.com/pressly/chi, should possibly be put in place, which could simplify how `APIHandler` is written.