### PR TITLE
	Add poolapi package with json structs, new api routes.

### DIFF
--- a/controllers/main.go
+++ b/controllers/main.go
@@ -175,6 +175,8 @@ func (controller *MainController) API(c web.C, r *http.Request) *system.APIRespo
 
 	if err != nil {
 		status = err.Error()
+	} else {
+		status = "success"
 	}
 
 	return system.NewAPIResponse(status, response, data)

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -174,7 +174,7 @@ func (controller *MainController) API(c web.C, r *http.Request) *system.APIRespo
 	}
 
 	if err != nil {
-		status = err.Error()
+		status = "error"
 	} else {
 		status = "success"
 	}

--- a/poolapi/apijson.go
+++ b/poolapi/apijson.go
@@ -1,0 +1,43 @@
+package poolapi
+
+import (
+	"encoding/json"
+)
+
+type Response struct {
+	Status  string           `json:"status"`
+	Message string           `json:"message"`
+	Data    *json.RawMessage `json:"data,omitempty"`
+}
+
+// TODO: make JSON tags lower-case and add "_" between words
+
+type PurchaseInfo struct {
+	PoolAddress   string `json:"PoolAddress"`
+	PoolFees      string `json:"PoolFees"`
+	Script        string `json:"Script"`
+	TicketAddress string `json:"TicketAddress"`
+}
+
+type Stats struct {
+	AllMempoolTix    string `json:"AllMempoolTix"`
+	BlockHeight      string `json:"BlockHeight"`
+	Difficulty       string `json:"Difficulty"`
+	Immature         string `json:"Immature"`
+	Live             string `json:"Live"`
+	Missed           string `json:"Missed"`
+	OwnMempoolTix    string `json:"OwnMempoolTix"`
+	PoolSize         string `json:"PoolSize"`
+	ProportionLive   string `json:"ProportionLive"`
+	ProportionMissed string `json:"ProportionMissed"`
+	Revoked          string `json:"Revoked"`
+	TotalSubsidy     string `json:"TotalSubsidy"`
+	Voted            string `json:"Voted"`
+	Network          string `json:"Network"`
+	PoolEmail        string `json:"PoolEmail"`
+	PoolFees         string `json:"PoolFees"`
+	PoolStatus       string `json:"PoolStatus"`
+	UserCount        string `json:"UserCount"`
+	UserCountActive  string `json:"UserCountActive"`
+	Version          string `json:"Version"`
+}

--- a/server.go
+++ b/server.go
@@ -139,7 +139,7 @@ func runMain() int {
 	app.Post("/address", application.Route(controller, "AddressPost"))
 
 	// API
-	app.Handle("/api/v1/:command", application.APIHandler(controller.API))
+	app.Handle("/api/v0.1/:command", application.APIHandler(controller.API))
 	app.Handle("/api/*", gojify(system.APIInvalidHandler))
 
 	// Email change/update confirmation

--- a/server.go
+++ b/server.go
@@ -24,6 +24,12 @@ var (
 	cfg *config
 )
 
+// gojify wraps system's GojiWebHandlerFunc to allow the use of an
+// http.HanderFunc as a web.HandlerFunc.
+func gojify(h http.HandlerFunc) web.HandlerFunc {
+	return system.GojiWebHandlerFunc(h)
+}
+
 func listenTo(bind string) (net.Listener, error) {
 	if strings.Contains(bind, ":") {
 		return net.Listen("tcp", bind)
@@ -133,7 +139,8 @@ func runMain() int {
 	app.Post("/address", application.Route(controller, "AddressPost"))
 
 	// API
-	app.Handle("/api/*", application.Route(controller, "API"))
+	app.Handle("/api/v1/:command", application.APIHandler(controller.API))
+	app.Handle("/api/*", gojify(system.APIInvalidHandler))
 
 	// Email change/update confirmation
 	app.Get("/emailupdate", application.Route(controller, "EmailUpdate"))

--- a/system/core.go
+++ b/system/core.go
@@ -169,7 +169,8 @@ func WriteAPIResponse(resp *APIResponse, code int, w http.ResponseWriter) {
 	}
 }
 
-// APIInvalidHandler responds to invalid requests. It satisfies http.Hander.
+// APIInvalidHandler responds to invalid requests. It matches the signature of
+// http.HanderFunc.
 func APIInvalidHandler(w http.ResponseWriter, _ *http.Request) {
 	resp := &APIResponse{Status: "error",
 		Message: "invalid API version",

--- a/system/core.go
+++ b/system/core.go
@@ -3,7 +3,6 @@ package system
 import (
 	"crypto/sha256"
 	"encoding/json"
-	"fmt"
 	"html/template"
 	"io"
 	"net/http"
@@ -165,7 +164,7 @@ func WriteAPIResponse(resp *APIResponse, code int, w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(code)
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		log.Warningf("JSON encode error: %v", err)
+		log.Warnf("JSON encode error: %v", err)
 	}
 }
 


### PR DESCRIPTION
Trying PR https://github.com/decred/dcrstakepool/pull/69 again.

**UPDATED: Pretty well tested**, but needs more documentation.

I believe the API needs several improvements, but this pertains to the following:

- For the convenience of encoding JSON by the server, struct response types with json tags should be created.
- For Go clients the json structs should put in their own package.
- The main API handler should be rewritten to use these types and the encodings/json package.
- The route handler should not include logic for parsing the version and command out of the url (goji and any router will do that).

Specifically, from the commit messages, this PR does the following:

- Add `poolapi` package with json structs, and new+modified api routes.  The `poolapi` package helps write go clients, and facilitate use of `json.Marshal` in generating the response for `http.ResponseWriter`.
- Modify `APIStats` and `APIPurchaseInfo` to use the new types and `json.Encoder.Encode()` directly into the `http.ResponseWriter`.
See the commit for more details.

A more elegant routing solution, like github.com/pressly/chi, should possibly be put in place, which could simplify how `APIHandler` is written.