### PR TITLE
Compute missed excluding expired in the template

### DIFF
--- a/system/core.go
+++ b/system/core.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/Masterminds/sprig"
 	"github.com/decred/dcrstakepool/codes"
 	"github.com/decred/dcrstakepool/models"
 	"github.com/gorilla/sessions"
@@ -98,7 +99,8 @@ func (application *Application) LoadTemplates(templatePath string) error {
 		return err
 	}
 
-	application.Template = template.Must(template.ParseFiles(templates...))
+	t := template.New("dcrstakepool").Funcs(sprig.FuncMap())
+	application.Template = template.Must(t.ParseFiles(templates...))
 	application.TemplatesPath = templatePath
 	return nil
 }

--- a/views/stats.html
+++ b/views/stats.html
@@ -28,7 +28,7 @@
 		<tr><td><span style="font-size: larger;">Immature:</span></td><td><span id="Immature">{{ .StakeInfo.Immature }}</span></td></tr>
 		<tr><td><span style="font-size: larger;">Live:</span></td><td><span id="Live">{{ .StakeInfo.Live }}</span></td></tr>
 		<tr><td><span style="font-size: larger;">Voted:</span></td><td><span id="Voted">{{ .StakeInfo.Voted }}</span></td></tr>
-		<tr><td><span style="font-size: larger;">Missed:</span></td><td><span id="Missed">{{ .StakeInfo.Missed }}</span></td></tr>
+		<tr><td><span style="font-size: larger;">Missed:</span></td><td><span id="Missed">{{ sub .StakeInfo.Missed .StakeInfo.Expired }}</span></td></tr>
 		{{if .StakeInfo.Expired}}
 		<tr><td><span style="font-size: larger;">Expired:</span></td><td><span id="Expired">{{ .StakeInfo.Expired }}</span></td></tr>
 		{{end}}


### PR DESCRIPTION
This is just for discussion, since it it's undecided how missed should be displayed.  Plus it brings in a dependency, but it's shorter than writing the function ourselves.

This math is done in the template to facilitate operators changing the semantics of their stats without recompiling golang.  When/if dcrwallet changes, this is easy to change back.