### PR TITLE
Use net.SplitHostPort instead of string splitting.

### DIFF
--- a/config.go
+++ b/config.go
@@ -101,6 +101,7 @@ type config struct {
 	Version          string
 	AdminIPs         []string `long:"adminips" description:"Expected admin host"`
 	MinServers       int      `long:"minservers" description:"Minimum number of wallets connected needed to avoid errors"`
+	RealIPHeader     string   `long:"realipheader" description:"The name of an HTTP request header containing the actual remote client IP address, typically set by a reverse proxy. An empty string (default) indicates to use net/Request.RemodeAddr."`
 }
 
 // serviceOptions defines the configuration options for the daemon as a service

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -82,12 +82,11 @@ func randToken() string {
 // real_ip module to correctly set the X-Real-IP header.
 func getClientIP(r *http.Request, realIPHeader string) string {
 	// getHost returns the host portion of a string containing either a
-	// host:port formatted name or just a host. An empty string is returned if
-	// net.SplitHostPort returns an error.
+	// host:port formatted name or just a host.
 	getHost := func(hostPort string) string {
 		ip, _, err := net.SplitHostPort(hostPort)
 		if err != nil {
-			return ""
+			return hostPort
 		}
 		return ip
 	}

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -61,6 +61,7 @@ type MainController struct {
 	poolLink             string
 	params               *chaincfg.Params
 	rpcServers           *walletSvrManager
+	realIPHeader         string
 	recaptchaSecret      string
 	recaptchaSiteKey     string
 	smtpFrom             string
@@ -79,7 +80,7 @@ func randToken() string {
 // Get the client's real IP address using the X-Real-IP header, or if that is
 // empty, http.Request.RemoteAddr. See the sample nginx.conf for using the
 // real_ip module to correctly set the X-Real-IP header.
-func getClientIP(r *http.Request) string {
+func getClientIP(r *http.Request, realIPHeader string) string {
 	// getHost returns the host portion of a string containing either a
 	// host:port formatted name or just a host. An empty string is returned if
 	// net.SplitHostPort returns an error.
@@ -91,16 +92,11 @@ func getClientIP(r *http.Request) string {
 		return ip
 	}
 
-	realIP := r.Header.Get("X-Real-IP")
-	realIP = getHost(realIP)
-
-	if realIP == "" {
-		log.Info(`"X-Real-IP" header invalid, using RemoteAddr instead`)
-		// If this somehow errors, just go with empty
-		realIP = getHost(r.RemoteAddr)
+	// If header not set, return RemoteAddr. Invalid hosts are replaced with "".
+	if realIPHeader == "" {
+		return getHost(r.RemoteAddr)
 	}
-
-	return realIP
+	return getHost(r.Header.Get(realIPHeader))
 }
 
 // NewMainController is the constructor for the entire controller routing.
@@ -111,7 +107,7 @@ func NewMainController(params *chaincfg.Params, adminIPs []string,
 	recaptchaSiteKey string, smtpFrom string,
 	smtpHost string, smtpUsername string, smtpPassword string, version string,
 	walletHosts []string, walletCerts []string, walletUsers []string,
-	walletPasswords []string, minServers int) (*MainController, error) {
+	walletPasswords []string, minServers int, realIPHeader string) (*MainController, error) {
 	// Parse the extended public key and the pool fees.
 	key, err := hdkeychain.NewKeyFromString(extPubStr)
 	if err != nil {
@@ -138,6 +134,7 @@ func NewMainController(params *chaincfg.Params, adminIPs []string,
 		recaptchaSecret:      recaptchaSecret,
 		recaptchaSiteKey:     recaptchaSiteKey,
 		rpcServers:           rpcs,
+		realIPHeader:         realIPHeader,
 		smtpFrom:             smtpFrom,
 		smtpHost:             smtpHost,
 		smtpUsername:         smtpUsername,
@@ -520,7 +517,7 @@ func (controller *MainController) Address(c web.C, r *http.Request) (string, int
 // AddressPost is address form submit route.
 func (controller *MainController) AddressPost(c web.C, r *http.Request) (string, int) {
 	session := controller.GetSession(c)
-	remoteIP := getClientIP(r)
+	remoteIP := getClientIP(r, controller.realIPHeader)
 
 	// User may have a session so error out here as well.
 	if controller.closePool {
@@ -844,7 +841,7 @@ func (controller *MainController) PasswordResetPost(c web.C, r *http.Request) (s
 	if err != nil {
 		session.AddFlash("Invalid Email", "passwordresetError")
 	} else {
-		remoteIP := getClientIP(r)
+		remoteIP := getClientIP(r, controller.realIPHeader)
 
 		log.Infof("PasswordReset POST from %v, email %v", remoteIP,
 			user.Email)
@@ -923,7 +920,7 @@ func (controller *MainController) PasswordUpdate(c web.C, r *http.Request) (stri
 func (controller *MainController) PasswordUpdatePost(c web.C, r *http.Request) (string, int) {
 	session := controller.GetSession(c)
 	dbMap := controller.GetDbMap(c)
-	remoteIP := getClientIP(r)
+	remoteIP := getClientIP(r, controller.realIPHeader)
 
 	// validate that the token is set and not expired.
 	token := r.URL.Query().Get("t")
@@ -1036,7 +1033,7 @@ func (controller *MainController) Settings(c web.C, r *http.Request) (string, in
 func (controller *MainController) SettingsPost(c web.C, r *http.Request) (string, int) {
 	session := controller.GetSession(c)
 	dbMap := controller.GetDbMap(c)
-	remoteIP := getClientIP(r)
+	remoteIP := getClientIP(r, controller.realIPHeader)
 
 	if session.Values["UserId"] == nil {
 		return "/", http.StatusSeeOther
@@ -1187,7 +1184,7 @@ func (controller *MainController) SignInPost(c web.C, r *http.Request) (string, 
 
 	session := controller.GetSession(c)
 	dbMap := controller.GetDbMap(c)
-	remoteIP := getClientIP(r)
+	remoteIP := getClientIP(r, controller.realIPHeader)
 
 	// Validate email and password combination.
 	user, err := helpers.Login(dbMap, email, password)
@@ -1268,7 +1265,7 @@ func (controller *MainController) SignUpPost(c web.C, r *http.Request) (string, 
 	}
 
 	session := controller.GetSession(c)
-	remoteIP := getClientIP(r)
+	remoteIP := getClientIP(r, controller.realIPHeader)
 
 	email, password, passwordRepeat := r.FormValue("email"),
 		r.FormValue("password"), r.FormValue("passwordrepeat")
@@ -1379,7 +1376,7 @@ func (controller *MainController) Status(c web.C, r *http.Request) (string, int)
 
 	// Confirm that the incoming IP address is an approved
 	// admin IP as set in config.
-	remoteIP := getClientIP(r)
+	remoteIP := getClientIP(r, controller.realIPHeader)
 
 	if !stringSliceContains(controller.adminIPs, remoteIP) {
 		return "/error", http.StatusSeeOther
@@ -1491,7 +1488,7 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 
 	t := controller.GetTemplate(c)
 	session := controller.GetSession(c)
-	remoteIP := getClientIP(r)
+	remoteIP := getClientIP(r, controller.realIPHeader)
 
 	if session.Values["UserId"] == nil {
 		return "/", http.StatusSeeOther
@@ -1711,7 +1708,7 @@ func (controller *MainController) TicketsPost(c web.C, r *http.Request) (string,
 		log.Error("No valid UserID")
 	}
 
-	remoteIP := getClientIP(r)
+	remoteIP := getClientIP(r, controller.realIPHeader)
 
 	user := models.GetUserById(dbMap, id)
 	if user == nil {

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"net"
 	"net/http"
 	"net/smtp"
 	"strings"
@@ -79,10 +80,13 @@ func randToken() string {
 // empty, http.Request.RemoteAddr. See the sample nginx.conf for using the
 // real_ip module to correctly set the X-Real-IP header.
 func getClientIP(r *http.Request) string {
-	getHost := func(ip string) string {
-		if strings.Contains(ip, ":") {
-			parts := strings.Split(ip, ":")
-			return parts[0]
+	// getHost returns the host portion of a string containing either a
+	// host:port formatted name or just a host. An empty string is returned if
+	// net.SplitHostPort returns an error.
+	getHost := func(hostPort string) string {
+		ip, _, err := net.SplitHostPort(hostPort)
+		if err != nil {
+			return ""
 		}
 		return ip
 	}

--- a/sample-dcrstakepool.conf
+++ b/sample-dcrstakepool.conf
@@ -24,6 +24,12 @@
 ; Specify a Go-style network listener.  Default is below.
 ;listen=:8000
 
+; The HTTP request header containing the actual remote client IP address for
+; accurate logging. The default value is the empty string, indicating to use
+; golang's Request.RealAddr value, which may be incorrect when behind a proxy.
+; See sample-nginx.conf for an example configuration of ngx_http_realip_module.
+;realipheader=X-Real-IP
+
 ; Support email and link show on the homepage.
 ;poolemail=admin@example.com
 ;poollink=https://example.com/

--- a/server.go
+++ b/server.go
@@ -104,7 +104,7 @@ func runMain() int {
 		cfg.PoolFees, cfg.PoolLink, cfg.RecaptchaSecret, cfg.RecaptchaSitekey,
 		cfg.SMTPFrom, cfg.SMTPHost, cfg.SMTPUsername, cfg.SMTPPassword,
 		cfg.Version, cfg.WalletHosts, cfg.WalletCerts, cfg.WalletUsers,
-		cfg.WalletPasswords, cfg.MinServers)
+		cfg.WalletPasswords, cfg.MinServers, cfg.RealIPHeader)
 	if err != nil {
 		application.Close()
 		log.Errorf("Failed to initialize the main controller: %v",


### PR DESCRIPTION
Closes https://github.com/decred/dcrstakepool/issues/84
go fmt also alphabetized imports

NOT yet tested.