### PR TITLE
remove deprecated fields and disable stakemining safety check

### DIFF
--- a/controllers/dcrclient.go
+++ b/controllers/dcrclient.go
@@ -1524,9 +1524,6 @@ func (w *walletSvrManager) CheckServers() error {
 		if !wi.DaemonConnected {
 			return fmt.Errorf("Wallet on svr %d not connected\n", i)
 		}
-		if !wi.StakeMining {
-			return fmt.Errorf("Wallet on svr %d not stakemining.\n", i)
-		}
 		if !wi.Unlocked {
 			return fmt.Errorf("Wallet on svr %d not unlocked.\n", i)
 		}
@@ -1747,9 +1744,6 @@ func checkIfWalletConnected(client *dcrrpcclient.Client) error {
 	}
 	if !wi.DaemonConnected {
 		return fmt.Errorf("wallet not connected")
-	}
-	if !wi.StakeMining {
-		return fmt.Errorf("wallet not stakemining")
 	}
 	if !wi.Unlocked {
 		return fmt.Errorf("wallet not unlocked")

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -1388,12 +1388,9 @@ func (controller *MainController) Status(c web.C, r *http.Request) (string, int)
 	}
 
 	type WalletInfoPage struct {
-		Connected         bool
-		DaemonConnected   bool
-		Unlocked          bool
-		TicketMaxPrice    float64
-		BalanceToMaintain float64
-		StakeMining       bool
+		Connected       bool
+		DaemonConnected bool
+		Unlocked        bool
 	}
 	walletPageInfo := make([]WalletInfoPage, len(walletInfo), len(walletInfo))
 	connectedWallets := 0
@@ -1413,12 +1410,9 @@ func (controller *MainController) Status(c web.C, r *http.Request) (string, int)
 		// Wallet has been successfully queried.
 		connectedWallets++
 		walletPageInfo[i] = WalletInfoPage{
-			Connected:         true,
-			DaemonConnected:   v.DaemonConnected,
-			Unlocked:          v.Unlocked,
-			TicketMaxPrice:    v.TicketMaxPrice,
-			BalanceToMaintain: v.BalanceToMaintain,
-			StakeMining:       v.StakeMining,
+			Connected:       true,
+			DaemonConnected: v.DaemonConnected,
+			Unlocked:        v.Unlocked,
 		}
 	}
 


### PR DESCRIPTION
Closes #108.

Related to #99.

Basically where we're at now:

- dcrwallet 0.8.2 has deprecated enablestakemining
- dcrd master has various walletinfo fields removed
- dcrwallet has a pr pending to update the walletinfo rpcs
- We're moving to a voting daemon for 1.0 rather than having the wallet vote directly.

So with all that being taken into account, I think it's best to just remove the stakemining safety check.  The pools are well established now so hopefully it won't cause an issue to remove this minimal safety check.