### PR TITLE
Always allow registered users to login and submit their address

### DIFF
--- a/config.go
+++ b/config.go
@@ -393,7 +393,7 @@ func loadConfig() (*config, []string, error) {
 	activeNetParams = &mainNetParams
 	if cfg.TestNet {
 		numNets++
-		activeNetParams = &testNetParams
+		activeNetParams = &testNet2Params
 	}
 	if cfg.SimNet {
 		numNets++

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -1629,7 +1629,7 @@ func (controller *MainController) TicketsPost(c web.C, r *http.Request) (string,
 
 	voteBits := uint16(0)
 
-	if controller.params.Net == wire.TestNet {
+	if controller.params.Net == wire.TestNet2 {
 		voteBlockSize := r.FormValue("voteBlockSize")
 		votePrevBlockInvalid := r.FormValue("votePrevBlockInvalid")
 		switch voteBlockSize {

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 3fa092c0562caf125c568ee179c9dc8cb73b7573527a6d8e866c61299a91f87a
-updated: 2017-02-15T10:05:17.292989339-08:00
+updated: 2017-03-28T12:46:54.311648366-07:00
 imports:
 - name: github.com/btcsuite/btclog
   version: 73889fb79bd687870312b6e40effcecffbd57d30
@@ -20,6 +20,7 @@ imports:
   - ripemd160
   - salsa20/salsa
   - scrypt
+  - ssh/terminal
 - name: github.com/btcsuite/seelog
   version: 313961b101eb55f65ae0f03ddd4e322731763b6c
 - name: github.com/btcsuite/websocket
@@ -27,7 +28,7 @@ imports:
 - name: github.com/decred/blake256
   version: a840e32d7c31fe2e0218607334cb120a683951a4
 - name: github.com/decred/dcrd
-  version: bfc076ecf1557c370bde149daca9c35bfe74218c
+  version: 64a414c64fd59706460f47c2aef5930a9e86dce4
   subpackages:
   - addrmgr
   - blockchain
@@ -48,7 +49,7 @@ imports:
 - name: github.com/decred/dcrrpcclient
   version: a1200f54d5aff356f7db4699d64ccdf2e35e2876
 - name: github.com/decred/dcrutil
-  version: ba0a5f399a43abc0e1a0a0442509c36f35321bce
+  version: ee6d002bf0de123fe47a8d2b8489f75145ce746e
   subpackages:
   - base58
   - hdkeychain
@@ -92,4 +93,5 @@ imports:
   subpackages:
   - bcrypt
   - blowfish
+  - ripemd160
 testImports: []

--- a/params.go
+++ b/params.go
@@ -32,11 +32,11 @@ var mainNetParams = params{
 	WalletRPCServerPort: "9110",
 }
 
-// testNetParams contains parameters specific to the test network (version 0)
+// testNet2Params contains parameters specific to the test network (version 0)
 // (wire.TestNet).  NOTE: The RPC port is intentionally different than the
 // reference implementation - see the mainNetParams comment for details.
-var testNetParams = params{
-	Params:              &chaincfg.TestNetParams,
+var testNet2Params = params{
+	Params:              &chaincfg.TestNet2Params,
 	WalletRPCServerPort: "19110",
 }
 
@@ -58,8 +58,8 @@ var simNetParams = params{
 // removed and the network parameter's name used instead.
 func netName(chainParams *params) string {
 	switch chainParams.Net {
-	case wire.TestNet:
-		return "testnet"
+	case wire.TestNet2:
+		return "testnet2"
 	default:
 		return chainParams.Name
 	}


### PR DESCRIPTION
Closing the pool should only prevent new signups, but presently it prevents registered users from logging in and uploading their address.

Remove the close pool checks from the API address handler, the /address POST handler, and the signin POST handler.

SignUp is still restricted when closePool is true.

Work in progress in that I will update when done testing.

Closes #114.