### PR TITLE
Add getNetworkName method to strip suffix off testnetN network names

### DIFF
--- a/controllers/main.go
+++ b/controllers/main.go
@@ -144,6 +144,17 @@ func NewMainController(params *chaincfg.Params, adminIPs []string,
 	return mc, nil
 }
 
+// getNetworkName will strip any suffix from a network name starting with
+// "testnet" (e.g. "testnet2"). This is primarily intended for the tickets page,
+// which generates block explorer links using a value set by the network string,
+// which is a problem since there is no testnet2.deced.org host.
+func (controller *MainController) getNetworkName() string {
+	if strings.HasPrefix(controller.params.Name, "testnet") {
+		return "testnet"
+	}
+	return controller.params.Name
+}
+
 // API is the main frontend that handles all API requests.
 func (controller *MainController) API(c web.C, r *http.Request) *system.APIResponse {
 	command := c.URLParams["command"]
@@ -1467,7 +1478,7 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 	}
 
 	c.Env["IsTickets"] = true
-	c.Env["Network"] = controller.params.Name
+	c.Env["Network"] = controller.getNetworkName()
 	c.Env["PoolFees"] = controller.poolFees
 	c.Env["Title"] = "Decred Stake Pool - Tickets"
 

--- a/controllers/main_test.go
+++ b/controllers/main_test.go
@@ -1,0 +1,29 @@
+package controllers
+
+import (
+	"testing"
+
+	"github.com/decred/dcrd/chaincfg"
+)
+
+func TestGetNetworkName(t *testing.T) {
+	// First test that "testnet2" is translated to "testnet"
+	mc := MainController{
+		params: &chaincfg.TestNet2Params,
+	}
+
+	netName := mc.getNetworkName()
+	if netName != "testnet" {
+		t.Errorf("Incorrect network name: expected %s, got %s", "testnet",
+			netName)
+	}
+
+	// ensure "mainnet" is unaltered
+	mc.params = &chaincfg.MainNetParams
+	netName = mc.getNetworkName()
+	if netName != "mainnet" {
+		t.Errorf("Incorrect network name: expected %s, got %s", "mainnet",
+			netName)
+	}
+
+}


### PR DESCRIPTION
This is a fix for the /tickets page, which generates block explorer links using the "Network" env value, set by this network string (there is no testnet2.deced.org).

Also add tests.