### PR TITLE
Always show the expired count in the stats page

### DIFF
--- a/views/stats.html
+++ b/views/stats.html
@@ -58,9 +58,7 @@
                 <tr><td>Live:</td><td><span id="Live">{{ .StakeInfo.Live }}</td></tr>
                 <tr><td>Voted:</td><td><span id="Voted">{{ .StakeInfo.Voted }}</td></tr>
                 <tr><td>Missed:</td><td><span id="Missed">{{ .StakeInfo.Missed }}</td></tr>
-                {{if .StakeInfo.Expired}}
                 <tr><td>Expired:</td><td><span id="Expired">{{ .StakeInfo.Expired }}</td></tr>
-                {{end}}
                 <tr><td>Revoked:</td><td><span id="Revoked">{{ .StakeInfo.Revoked }}</td></tr>
                 <tr><td>ProportionMissed:</td><td><span id="ProportionMissed">{{ .StakeInfo.ProportionMissed }}</td></tr>
                 <tr><td>Pool Size:</td><td><span id="PoolSize">{{ .StakeInfo.PoolSize }}</td></tr>


### PR DESCRIPTION
This was probably conditional because there were pools with
wallets that did not yet break out expired, and would have been
wrong to show this value as 0 in those cases.  However, all pools
should support the expired value from getstakeinfo.

When .StakeInfo.Expired is 0, it would have been hidden.  This fixes that.  If your wallet doesn't have it, you don't meet the requirements to run dcrstakepool.