### PR TITLE
Move defer to proper location.

### DIFF
--- a/backend/stakepoold/server.go
+++ b/backend/stakepoold/server.go
@@ -136,6 +136,8 @@ func runMain() int {
 	cfg = loadedCfg
 	dataPath := filepath.Join(cfg.DataDir, "data.json")
 
+	defer backendLog.Flush()
+
 	log.Infof("Version: %s", version())
 	log.Infof("Network: %s", activeNetParams.Params.Name)
 
@@ -152,8 +154,6 @@ func runMain() int {
 		log.Errorf("Error calculating fee payment addresses: %v", err)
 		return 2
 	}
-
-	defer backendLog.Flush()
 
 	dcrrpcclient.UseLogger(clientLog)
 


### PR DESCRIPTION
In order to see early errors we need the defer to backend flush to be
setup much earlier.  This enables us to see errors before the daemon
comes online.