### PR TITLE
backend: Fix computing 1 extra fee address, add test

### DIFF
--- a/backend/stakepoold/server.go
+++ b/backend/stakepoold/server.go
@@ -110,10 +110,9 @@ func calculateFeeAddresses(xpubStr string, params *chaincfg.Params) (map[string]
 
 func deriveChildAddresses(key *hdkeychain.ExtendedKey, startIndex, count uint32, params *chaincfg.Params) ([]dcrutil.Address, error) {
 	addresses := make([]dcrutil.Address, 0, count)
-	for i := uint32(0); i < count; i++ {
+	for i := uint32(0); i < count; {
 		child, err := key.Child(startIndex + i)
 		if err == hdkeychain.ErrInvalidChild {
-			// NOTE: return slice will be shorter than requested
 			continue
 		}
 		if err != nil {
@@ -124,6 +123,7 @@ func deriveChildAddresses(key *hdkeychain.ExtendedKey, startIndex, count uint32,
 			return nil, err
 		}
 		addresses = append(addresses, addr)
+		i++
 	}
 	return addresses, nil
 }

--- a/backend/stakepoold/server.go
+++ b/backend/stakepoold/server.go
@@ -94,7 +94,8 @@ func calculateFeeAddresses(xpubStr string, params *chaincfg.Params) (map[string]
 	}
 
 	// Derive the addresses from [0, end) for this extended public key.
-	addrs, err := deriveChildAddresses(branchKey, 0, end+1, params)
+	// deriveChildAddresses takes the start index and the count.
+	addrs, err := deriveChildAddresses(branchKey, 0, end, params)
 	if err != nil {
 		return nil, err
 	}
@@ -112,6 +113,7 @@ func deriveChildAddresses(key *hdkeychain.ExtendedKey, startIndex, count uint32,
 	for i := uint32(0); i < count; i++ {
 		child, err := key.Child(startIndex + i)
 		if err == hdkeychain.ErrInvalidChild {
+			// NOTE: return slice will be shorter than requested
 			continue
 		}
 		if err != nil {

--- a/backend/stakepoold/server_test.go
+++ b/backend/stakepoold/server_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2017 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
 package main
 
 import (

--- a/backend/stakepoold/server_test.go
+++ b/backend/stakepoold/server_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/decred/dcrd/chaincfg"
+)
+
+func TestCalculateFeeAddresses(t *testing.T) {
+	xpubStr := "tpubVpQL1h9UcY9c1BPZYfjYEtw5froRAvqZEo6sn5Tji6VkhcpfMaQ6id9Spf5iNvprRTcpdF5pj7m5Suyu1E8iC4xnb6MkjUnCJureTsmdXfG"
+	firstAddrs := []string{
+		"TsYLznZJn2xhM9F7Vnt7i39NuUFENGx9Hff",
+		"TsiWMbdbmfMaJ9SDb7ig8EKfYp3KU3pvYfu",
+		"TsgTraHPFWes88oTjpPVy7SEroJvgShv1G1",
+	}
+	params := &chaincfg.TestNet2Params
+
+	// calculateFeeAddresses is currently hard-coded to return 10,000 addresses
+	numAddr := 10000
+	addrs, err := calculateFeeAddresses(xpubStr, params)
+	if err != nil {
+		t.Error("calculateFeeAddresses failed with ", err)
+	}
+	if len(addrs) != numAddr {
+		t.Errorf("expected %d addresses, got %d", numAddr, len(addrs))
+	}
+
+	// Check that the first few addresses are in the map. NOTE: don't even think
+	// about doing a range over the map as the order is random
+	for _, addr := range firstAddrs {
+		if _, ok := addrs[addr]; !ok {
+			t.Errorf("Did not find address %s in derived address map", addr)
+		}
+	}
+
+	// empty (i.e. invalid) xpubStr
+	addrs, err = calculateFeeAddresses("", params)
+	if err == nil {
+		t.Error("calculateFeeAddresses did not error with empty extended key")
+	}
+	if len(addrs) != 0 {
+		t.Errorf("expected empty map, actual length %d", len(addrs))
+	}
+
+	// wrong network
+	expectedErr := fmt.Errorf("extended public key is for wrong network")
+	addrs, err = calculateFeeAddresses(xpubStr, &chaincfg.MainNetParams)
+	if err == nil {
+		t.Error("calculateFeeAddresses did not error with wrong network parmas")
+	}
+	if err.Error() != expectedErr.Error() {
+		t.Errorf("expected error %v, got %v", expectedErr, err)
+	}
+	if len(addrs) != 0 {
+		t.Errorf("expected empty map, actual length %d", len(addrs))
+	}
+}


### PR DESCRIPTION
`deriveChildAddresses` takes a start index and a count, not a [start, end) range.

Add server_test.go, and test for `calculateFeeAddresses` using a testnet extended public key.