### PR TITLE
simplify send/create vote functions in backend rpcclient

### DIFF
--- a/backend/stakepoold/rpcclient.go
+++ b/backend/stakepoold/rpcclient.go
@@ -130,7 +130,7 @@ func walletCreateVote(ctx *appContext, blockHash *chainhash.Hash, blockHeight in
 	// look up the voting config for this user's ticket
 	userVotingConfig, ok := ctx.userVotingConfig[msa]
 	if !ok {
-		log.Errorf("Unknown multisig address %s. Cannot create vote.", msa)
+		log.Errorf("Unknown multisig address %s. Creating vote with defaults.", msa)
 		// do not return; vote with defaults
 	}
 	votebitsToUse := userVotingConfig.VoteBits


### PR DESCRIPTION
Only perform map lookup once in `walletCreateVote`.  Verify that the multisig address was found in the map.