### PR TITLE
stakepoold: only lock data, not code path

### DIFF
--- a/backend/stakepoold/server_test.go
+++ b/backend/stakepoold/server_test.go
@@ -81,8 +81,8 @@ var (
 func init() {
 
 	c = &appContext{
-		tickets: make(map[string]string),
-		testing: true,
+		ticketsMSA: make(map[chainhash.Hash]string),
+		testing:    true,
 	}
 
 	// Create a pool of tickets around expected size
@@ -95,7 +95,7 @@ func init() {
 		ticket := &chainhash.Hash{b[0], b[1], b[2], b[3]}
 
 		// use ticket as the key
-		c.tickets[ticket.String()] = msa
+		c.ticketsMSA[*ticket] = msa
 
 		// last 5 tickets win
 		if i > ticketCount-6 {


### PR DESCRIPTION
As a quick workaround we held locks longer than needed.  It is time to start moving this code to hold locks only on data.  There is much more cleaning to be done but this is where we start.