### PR TITLE
Fix processWinningTickets benchmark

### DIFF
--- a/backend/stakepoold/server.go
+++ b/backend/stakepoold/server.go
@@ -54,9 +54,9 @@ type appContext struct {
 // VotingConfig contains global voting defaults.
 type VotingConfig struct {
 	VoteBits         uint16
+	VoteVersion      uint32
 	VoteBitsExtended string
 	VoteInfo         *dcrjson.GetVoteInfoResult
-	VoteVersion      uint32
 }
 
 type WinningTicketsForBlock struct {
@@ -352,13 +352,12 @@ func (ctx *appContext) processWinningTickets(wt WinningTicketsForBlock) {
 			// Use defaults if not found.
 			log.Warnf("vote config not found for %v using default",
 				msa)
-			defaultVoteCfg := &userdata.UserVotingConfig{
+			voteCfg = userdata.UserVotingConfig{
 				Userid:          0,
 				MultiSigAddress: msa,
 				VoteBits:        ctx.votingConfig.VoteBits,
 				VoteBitsVersion: ctx.votingConfig.VoteVersion,
 			}
-			voteCfg = *defaultVoteCfg
 		} else {
 			// If the user's voting config has a vote version that
 			// is different from our global vote version that we
@@ -419,11 +418,9 @@ func (ctx *appContext) processWinningTickets(wt WinningTicketsForBlock) {
 		if err != nil {
 			log.Infof("failed to vote: %v", err)
 		}
-		voteEnd := time.Now()
-		log.Infof("voted ticket %d in %v", winnersCount+1, voteEnd.Sub(voteStart))
+		log.Infof("voted ticket %d in %v", winnersCount+1, time.Since(voteStart))
 	}
-	loopEnd := time.Now()
-	log.Infof("processWinningTickets took %v", loopEnd.Sub(loopStart))
+	log.Infof("processWinningTickets took %v", time.Since(loopStart))
 }
 
 func (ctx *appContext) reloadTicketsHandler() {

--- a/backend/stakepoold/server.go
+++ b/backend/stakepoold/server.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/chaincfg/chainhash"
-	"github.com/decred/dcrd/dcrjson"
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrrpcclient"
 	"github.com/decred/dcrstakepool/backend/stakepoold/userdata"
@@ -56,7 +55,6 @@ type VotingConfig struct {
 	VoteBits         uint16
 	VoteVersion      uint32
 	VoteBitsExtended string
-	VoteInfo         *dcrjson.GetVoteInfoResult
 }
 
 type WinningTicketsForBlock struct {


### PR DESCRIPTION
Benchmark was broken because appContext.votingConfig was nil.  So fix is to set a valid VotingConfig when creating the appContext in init() in server_test.go.

For a more realistic benchmark, also fill out the userVotingConfig map.  Previously it was empty, and the lookup would fail, and default voting config was used.  By adding random user multisigs, where the last 5 own the winning tickets.

Reorder fields of VotingConfig so it goes from 40 -> 32 bytes by avoiding excess padding.

Remove unnecessary allocation of a UserVotingConfig inside processWinningTickets (when msa lookup fails).

Simplify timing of processWinningTickets by using time.Since.