### PR TITLE
stakepoold: make additional wallet calls async

### DIFF
--- a/backend/stakepoold/rpcclient.go
+++ b/backend/stakepoold/rpcclient.go
@@ -110,7 +110,7 @@ func connectWalletRPC(cfg *config) (*dcrrpcclient.Client, semver, error) {
 	return dcrwClient, walletVer, nil
 }
 
-func walletFetchUserTickets(ctx *appContext) map[chainhash.Hash]string {
+func walletFetchUserTickets(ctx *appContext) (map[chainhash.Hash]string, string) {
 	// This is suboptimal to copy and needs fixing.
 	users := make(map[string]userdata.UserVotingConfig)
 	ctx.RLock()
@@ -174,8 +174,6 @@ func walletFetchUserTickets(ctx *appContext) map[chainhash.Hash]string {
 	ticketNoun := pickNoun(ticketcount, "ticket", "tickets")
 	userNoun := pickNoun(usercount, "user", "users")
 
-	log.Infof("loaded %v %v for %v %v",
+	return userTickets, fmt.Sprintf("loaded %v %v for %v %v",
 		ticketcount, ticketNoun, usercount, userNoun)
-
-	return userTickets
 }

--- a/backend/stakepoold/server.go
+++ b/backend/stakepoold/server.go
@@ -460,7 +460,7 @@ func (ctx *appContext) processWinningTickets(wt WinningTicketsForBlock) {
 			if w.err == nil {
 				w.err = errSuccess
 			}
-			log.Infof("winning ticket %v %v msa %v: %v",
+			log.Infof("winning ticket %v msa %v: %v",
 				w.ticket, w.msa, w.err)
 		}
 	}()

--- a/backend/stakepoold/server.go
+++ b/backend/stakepoold/server.go
@@ -216,7 +216,7 @@ func runMain() int {
 		testing:            false,
 	}
 
-	ctx.ticketsMSA = walletFetchUserTickets(ctx)
+	ctx.ticketsMSA, _ = walletFetchUserTickets(ctx)
 
 	// Daemon client connection
 	nodeConn, nodeVer, err := connectNodeRPC(ctx, cfg)
@@ -439,7 +439,7 @@ func (ctx *appContext) reloadTicketsHandler() {
 		select {
 		case <-ctx.reloadTickets:
 			start := time.Now()
-			newTickets := walletFetchUserTickets(ctx)
+			newTickets, msg := walletFetchUserTickets(ctx)
 			end := time.Now()
 
 			// replace tickets
@@ -447,7 +447,8 @@ func (ctx *appContext) reloadTicketsHandler() {
 			ctx.ticketsMSA = newTickets
 			ctx.Unlock()
 
-			log.Infof("walletFetchUserTickets: %v", end.Sub(start))
+			log.Infof("walletFetchUserTickets: %v %v", msg,
+				end.Sub(start))
 		case <-ctx.quit:
 			return
 		}

--- a/backend/stakepoold/server.go
+++ b/backend/stakepoold/server.go
@@ -441,6 +441,7 @@ func (ctx *appContext) processWinningTickets(wt WinningTicketsForBlock) {
 
 	// Wait for wallet to complete raw transaction sends.
 	for k, raw := range rawPromises {
+		// XXX k is wrong
 		if winners[k].err != nil {
 			continue
 		}


### PR DESCRIPTION
There is quite of bit of chatter between stakepoold and wallet.  In order to minimize network and wallet latency convert critical path wallet calls to async mode.

Ultimately we need the wallet to either batch these or do more independent work.  There should be not that amount of network chatter, period.  This is a lesson learned from SMB.