### PR TITLE
Add option to run stakepoold without gRPC server

### DIFF
--- a/backend/stakepoold/config.go
+++ b/backend/stakepoold/config.go
@@ -77,7 +77,8 @@ type config struct {
 	WalletPassword   string  `long:"walletpassword" description:"Password for wallet server"`
 	WalletCert       string  `long:"walletcert" description:"Certificate path for wallet server"`
 	Version          string
-	RPCListeners     []string `long:"rpclisten" description:"Add an interface/port to listen for RPC connections (default port: 9109, testnet: 19109)"`
+	NoRPCListen      bool     `long:"norpclisten" description:"Do not start a gRPC server. User voting preferences update on a ticker"`
+	RPCListeners     []string `long:"rpclisten" description:"Add an interface/port to listen for RPC connections (default port: 9113, testnet: 19113)"`
 	RPCCert          string   `long:"rpccert" description:"File containing the certificate file"`
 	RPCKey           string   `long:"rpckey" description:"File containing the certificate key"`
 }


### PR DESCRIPTION
This certainly would not be a recommended mode of operation, but with the current model of stakepoold connecting directly to MySQL for user voting configuration, it's possible to run an extra pool wallet without changing dcrstakepool config, while honoring user voting prefs.

The idea here is to reload every N minutes from MySQL if the `--norpclisten` flag is set.  This will also prevent the gRPC server from starting.

The first commit splits the timing of `vote()` into sign, send, and total.  This is unrelated to the gRPC change.

I'm pretty sure merging this is not the right idea, but I wanted to put it out there because it provides a quick way to fire up another wallet that will vote as desired without messing with the main server much, if at all.

Note there is also a doc correction in this (9109 -> 9113 and 19109 -> 19113).