### PR TITLE
stakepoold: Fix ticket handling to be more accurate.

### DIFF
--- a/backend/stakepoold/grpcserver.go
+++ b/backend/stakepoold/grpcserver.go
@@ -28,7 +28,7 @@ import (
 // possibly also the key in PEM format to the paths specified by the config.  If
 // successful, the new keypair is returned.
 func generateRPCKeyPair(writeKey bool) (tls.Certificate, error) {
-	log.Infof("Generating TLS certificates...")
+	log.Info("Generating TLS certificates...")
 
 	// Create directories for cert and key files if they do not yet exist.
 	certDir, _ := filepath.Split(cfg.RPCCert)

--- a/backend/stakepoold/ntfnhandlers.go
+++ b/backend/stakepoold/ntfnhandlers.go
@@ -7,15 +7,62 @@ import (
 	"github.com/decred/dcrrpcclient"
 )
 
+// checkIfBlockSeen increments the NeedToVote waitgroup by 1 if the block
+// has not been seen yet and records that it has been seen.
+func checkIfBlockSeen(ctx *appContext, ntfnName string, blockHash *chainhash.Hash, blockHeight int64) {
+	hasBeenSeen := true
+
+	ctx.Lock()
+	if !ctx.lastBlockSeenHash.IsEqual(blockHash) || ctx.lastBlockSeenHeight != blockHeight {
+		hasBeenSeen = false
+		ctx.wgNeedToVote.Add(1)
+		ctx.lastBlockSeenHash = blockHash
+		ctx.lastBlockSeenHeight = blockHeight
+	}
+	ctx.Unlock()
+
+	// Log notification information outside of the handler.
+	go func() {
+		log.Debugf("ntfn %s blockHeight %v blockHash %v", ntfnName, blockHeight,
+			blockHash)
+		if !hasBeenSeen {
+			log.Debugf("incremented wgNeedToVote for block height %v hash %v",
+				blockHeight, blockHash)
+		}
+	}()
+}
+
 // Define notification handlers
 func getNodeNtfnHandlers(ctx *appContext, connCfg *dcrrpcclient.ConnConfig) *dcrrpcclient.NotificationHandlers {
 	return &dcrrpcclient.NotificationHandlers{
-		OnWinningTickets: func(blockHash *chainhash.Hash, blockHeight int64,
-			winningTickets []*chainhash.Hash) {
+		OnNewTickets: func(blockHash *chainhash.Hash, blockHeight int64, stakeDifficulty int64, tickets []*chainhash.Hash) {
+			checkIfBlockSeen(ctx, "OnNewTickets", blockHash, blockHeight)
+			nt := NewTicketsForBlock{
+				blockHash:   blockHash,
+				blockHeight: blockHeight,
+				newTickets:  tickets,
+			}
+			ctx.newTicketsChan <- nt
+		},
+		OnSpentAndMissedTickets: func(blockHash *chainhash.Hash, blockHeight int64, stakeDifficulty int64, tickets map[chainhash.Hash]bool) {
+			checkIfBlockSeen(ctx, "OnSpentAndMissedTickets", blockHash, blockHeight)
+			ticketsFixed := make(map[*chainhash.Hash]bool)
+			for ticketHash, spent := range tickets {
+				ticketHash := ticketHash
+				ticketsFixed[&ticketHash] = spent
+			}
+			smt := SpentMissedTicketsForBlock{
+				blockHash:   blockHash,
+				blockHeight: blockHeight,
+				smTickets:   ticketsFixed,
+			}
+			ctx.spentmissedTicketsChan <- smt
+		},
+		OnWinningTickets: func(blockHash *chainhash.Hash, blockHeight int64, winningTickets []*chainhash.Hash) {
+			checkIfBlockSeen(ctx, "OnWinningTickets", blockHash, blockHeight)
 			wt := WinningTicketsForBlock{
 				blockHash:      blockHash,
 				blockHeight:    blockHeight,
-				host:           connCfg.Host,
 				winningTickets: winningTickets,
 			}
 			ctx.winningTicketsChan <- wt

--- a/backend/stakepoold/server.go
+++ b/backend/stakepoold/server.go
@@ -5,13 +5,17 @@
 package main
 
 import (
+	"encoding/gob"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/signal"
 	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -23,6 +27,7 @@ import (
 	"github.com/decred/dcrstakepool/backend/stakepoold/userdata"
 	"github.com/decred/dcrutil"
 	"github.com/decred/dcrutil/hdkeychain"
+	"github.com/decred/dcrwallet/wallet/txrules"
 	"github.com/decred/dcrwallet/wallet/udb"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -30,26 +35,45 @@ import (
 
 type appContext struct {
 	sync.RWMutex
+
 	// locking required
-	ticketsMSA       map[chainhash.Hash]string            // [ticket]multisigaddr
-	userVotingConfig map[string]userdata.UserVotingConfig // [multisigaddr]
+	liveTicketsMSA          map[chainhash.Hash]string            // [ticket]multisigaddr
+	manuallyAddedTicketsMSA map[chainhash.Hash]string            // [ticket]multisigaddr
+	userVotingConfig        map[string]userdata.UserVotingConfig // [multisigaddr]
 
 	// no locking required
-	blockheight        int64
-	coldwalletextpub   *hdkeychain.ExtendedKey
-	dataPath           string
-	feeAddrs           map[string]struct{}
-	nodeConnection     *dcrrpcclient.Client
-	params             *chaincfg.Params
-	wg                 sync.WaitGroup // wait group for go routine exits
-	quit               chan struct{}
-	reloadTickets      chan struct{}
-	reloadUserConfig   chan struct{}
-	userData           *userdata.UserData
-	votingConfig       *VotingConfig
-	walletConnection   *dcrrpcclient.Client
-	winningTicketsChan chan WinningTicketsForBlock
-	testing            bool // enabled only for testing
+	coldwalletextpub       *hdkeychain.ExtendedKey
+	dataPath               string
+	feeAddrs               map[string]struct{}
+	feePercent             float64
+	newTicketsChan         chan NewTicketsForBlock
+	nodeConnection         *dcrrpcclient.Client
+	params                 *chaincfg.Params
+	lastBlockSeenHash      *chainhash.Hash
+	lastBlockSeenHeight    int64
+	wg                     sync.WaitGroup // wait group for go routine exits
+	wgNeedToVote           sync.WaitGroup
+	quit                   chan struct{}
+	reloadTickets          chan struct{}
+	reloadUserConfig       chan struct{}
+	spentmissedTicketsChan chan SpentMissedTicketsForBlock
+	userData               *userdata.UserData
+	votingConfig           *VotingConfig
+	walletConnection       *dcrrpcclient.Client
+	winningTicketsChan     chan WinningTicketsForBlock
+	testing                bool // enabled only for testing
+}
+
+type NewTicketsForBlock struct {
+	blockHash   *chainhash.Hash
+	blockHeight int64
+	newTickets  []*chainhash.Hash
+}
+
+type SpentMissedTicketsForBlock struct {
+	blockHash   *chainhash.Hash
+	blockHeight int64
+	smTickets   map[*chainhash.Hash]bool
 }
 
 // VotingConfig contains global voting defaults.
@@ -62,13 +86,37 @@ type VotingConfig struct {
 type WinningTicketsForBlock struct {
 	blockHash      *chainhash.Hash
 	blockHeight    int64
-	host           string
 	winningTickets []*chainhash.Hash
 }
 
 var (
-	cfg        *config
-	errSuccess = errors.New("success")
+	cfg              *config
+	errDuplicateVote = "-32603: already have transaction "
+	errNoTxInfo      = "-5: No information for transaction"
+	errSuccess       = errors.New("success")
+
+	dataFilenameTemplate = "KIND-DATE-VERSION.gob"
+	// save individual versions of fields in case they're changed in the future
+	// and keep a global version that represents the overall schema version too
+	dataVersionCommon               = "1.0.0"
+	dataVersionLiveTickets          = "1.0.0"
+	dataVersionManuallyAddedTickets = "1.0.0"
+	dataVersionUserVotingConfig     = "1.0.0"
+	saveFilesToKeep                 = 10
+	saveFileSchema                  = struct {
+		LiveTickets          string
+		ManuallyAddedTickets string
+		UserVotingConfig     string
+		Version              string
+	}{
+		LiveTickets:          dataVersionLiveTickets,
+		ManuallyAddedTickets: dataVersionManuallyAddedTickets,
+		UserVotingConfig:     dataVersionUserVotingConfig,
+		Version:              dataVersionCommon,
+	}
+	ticketTypeNew         = "New"
+	ticketTypeSpentMissed = "SpentMissed"
+	votingTargetTime      = 100 * time.Millisecond
 )
 
 // calculateFeeAddresses decodes the string of stake pool payment addresses
@@ -134,15 +182,14 @@ func deriveChildAddresses(key *hdkeychain.ExtendedKey, startIndex, count uint32,
 	return addresses, nil
 }
 
-func runMain() int {
+func runMain() error {
 	// Load configuration and parse command line.  This function also
 	// initializes logging and configures it accordingly.
 	loadedCfg, _, err := loadConfig()
 	if err != nil {
-		return 1
+		return err
 	}
 	cfg = loadedCfg
-	dataPath := filepath.Join(cfg.DataDir, "data.json")
 
 	defer func() {
 		if logRotator != nil {
@@ -150,7 +197,7 @@ func runMain() int {
 		}
 	}()
 
-	log.Infof("Version: %s", version())
+	log.Infof("Version %s (Go version %s)", version(), runtime.Version())
 	log.Infof("Network: %s", activeNetParams.Params.Name)
 	log.Infof("Home dir: %s", cfg.HomeDir)
 
@@ -158,14 +205,14 @@ func runMain() int {
 	err = os.MkdirAll(cfg.DataDir, 0700)
 	if err != nil {
 		log.Errorf("unable to create data directory: %v", cfg.DataDir)
-		return 2
+		return err
 	}
 
 	feeAddrs, err := calculateFeeAddresses(cfg.ColdWalletExtPub,
 		activeNetParams.Params)
 	if err != nil {
 		log.Errorf("Error calculating fee payment addresses: %v", err)
-		return 2
+		return err
 	}
 
 	dcrrpcclient.UseLogger(clientLog)
@@ -174,14 +221,14 @@ func runMain() int {
 	walletConn, walletVer, err := connectWalletRPC(cfg)
 	if err != nil || walletConn == nil {
 		log.Infof("Connection to dcrwallet failed: %v", err)
-		return 2
+		return err
 	}
 	log.Infof("Connected to dcrwallet (JSON-RPC API v%s)",
 		walletVer.String())
 	walletInfoRes, err := walletConn.WalletInfo()
 	if err != nil || walletInfoRes == nil {
-		log.Errorf("Unable to retrieve walletoinfo results")
-		return 3
+		log.Errorf("Unable to retrieve walletinfo results")
+		return err
 	}
 
 	votingConfig := VotingConfig{
@@ -189,47 +236,48 @@ func runMain() int {
 		VoteBitsExtended: walletInfoRes.VoteBitsExtended,
 		VoteVersion:      walletInfoRes.VoteVersion,
 	}
-	log.Infof("VotingConfig: VoteVersion %v VoteBits %v", votingConfig.VoteVersion,
+	log.Infof("default voting config: VoteVersion %v VoteBits %v", votingConfig.VoteVersion,
 		votingConfig.VoteBits)
-
-	// TODO re-work main loop
-	// should be something like this:
-	// loadData()
-	// if ticket/user voting prefs -> enable voting -> refresh
-	// if no ticket/user voting prefs -> pull from db/wallets -> enable voting
 
 	var userdata = &userdata.UserData{}
 	userdata.DBSetConfig(cfg.DBUser, cfg.DBPassword, cfg.DBHost, cfg.DBPort, cfg.DBName)
 
 	userVotingConfig, err := userdata.MySQLFetchUserVotingConfig()
 	if err != nil {
-		log.Infof("could not obtain voting config: %v", err)
-		return 12 // wtf
+		log.Errorf("could not obtain voting config from MySQL: %v", err)
+	} else {
+		log.Infof("loaded prefs for %d users from MySQL", len(userVotingConfig))
+	}
+
+	err = txrules.IsValidPoolFeeRate(cfg.PoolFees)
+	if err != nil {
+		log.Errorf("poolfees is invalid: %v", err)
+		return err
 	}
 
 	ctx := &appContext{
-		blockheight:        0,
-		dataPath:           dataPath,
-		feeAddrs:           feeAddrs,
-		params:             activeNetParams.Params,
-		quit:               make(chan struct{}),
-		reloadUserConfig:   make(chan struct{}),
-		reloadTickets:      make(chan struct{}),
-		userData:           userdata,
-		userVotingConfig:   userVotingConfig,
-		votingConfig:       &votingConfig,
-		walletConnection:   walletConn,
-		winningTicketsChan: make(chan WinningTicketsForBlock),
-		testing:            false,
+		dataPath:               cfg.DataDir,
+		feeAddrs:               feeAddrs,
+		feePercent:             cfg.PoolFees,
+		newTicketsChan:         make(chan NewTicketsForBlock),
+		params:                 activeNetParams.Params,
+		quit:                   make(chan struct{}),
+		reloadUserConfig:       make(chan struct{}),
+		reloadTickets:          make(chan struct{}),
+		spentmissedTicketsChan: make(chan SpentMissedTicketsForBlock),
+		userData:               userdata,
+		userVotingConfig:       userVotingConfig,
+		votingConfig:           &votingConfig,
+		walletConnection:       walletConn,
+		winningTicketsChan:     make(chan WinningTicketsForBlock),
+		testing:                false,
 	}
-
-	ctx.ticketsMSA, _ = walletFetchUserTickets(ctx)
 
 	// Daemon client connection
 	nodeConn, nodeVer, err := connectNodeRPC(ctx, cfg)
 	if err != nil || nodeConn == nil {
 		log.Infof("Connection to dcrd failed: %v", err)
-		return 6
+		return err
 	}
 	ctx.nodeConnection = nodeConn
 
@@ -237,23 +285,80 @@ func runMain() int {
 	curnet, err := nodeConn.GetCurrentNet()
 	if err != nil {
 		log.Errorf("Unable to get current network from dcrd: %v", err)
-		return 7
+		return err
 	}
 	log.Infof("Connected to dcrd (JSON-RPC API v%s) on %v",
 		nodeVer.String(), curnet.String())
 
-	_, height, err := nodeConn.GetBestBlock()
+	// prune save data
+	err = pruneData(ctx)
 	if err != nil {
-		log.Errorf("unable to get bestblock from dcrd: %v", err)
-		return 8
+		log.Warnf("pruneData error: %v", err)
 	}
-	ctx.blockheight = height
 
-	if err = nodeConn.NotifyWinningTickets(); err != nil {
-		fmt.Printf("Failed to register daemon RPC client for  "+
-			"winning tickets notifications: %s\n", err.Error())
-		return 9
+	// load userVotingConfig from disk cache if necessary
+	if len(userVotingConfig) == 0 {
+		err = loadData(ctx, "UserVotingConfig")
+		if err != nil {
+			// we could possibly die out here but it's probably better
+			// to let stakepoold vote with default preferences rather than
+			// not vote at all
+			log.Warnf("unable to load user voting preferences from disk "+
+				"cache: %v", err)
+		} else {
+			log.Infof("Loaded UserVotingConfig for %d users from disk cache",
+				len(userVotingConfig))
+		}
 	}
+
+	// refresh the ticket list and make sure a block didn't come in
+	// while we were getting it
+	for {
+		prevHash, prevHeight, err := nodeConn.GetBestBlock()
+		if err != nil {
+			log.Errorf("unable to get bestblock from dcrd: %v", err)
+			return err
+		}
+		log.Infof("current block height %v hash %v", prevHeight, prevHash)
+
+		ctx.liveTicketsMSA = walletGetTickets(ctx)
+
+		curHash, curHeight, err := nodeConn.GetBestBlock()
+		if err != nil {
+			log.Errorf("unable to get bestblock from dcrd: %v", err)
+			return err
+		}
+
+		// if a block didn't come in while we were processing tickets
+		// then we're fine
+		if prevHash.IsEqual(curHash) && prevHeight == curHeight {
+			break
+		}
+		log.Infof("block %v came in during GetTickets, refreshing...",
+			curHeight)
+	}
+
+	if err = nodeConn.NotifyBlocks(); err != nil {
+		fmt.Printf("Failed to register daemon RPC client for "+
+			"block notifications: %s\n", err.Error())
+		return err
+	}
+	if err = nodeConn.NotifyWinningTickets(); err != nil {
+		fmt.Printf("Failed to register daemon RPC client for "+
+			"winning tickets notifications: %s\n", err.Error())
+		return err
+	}
+	if err = nodeConn.NotifyNewTickets(); err != nil {
+		fmt.Printf("Failed to register daemon RPC client for "+
+			"new tickets notifications: %s\n", err.Error())
+		return err
+	}
+	if err = nodeConn.NotifySpentAndMissedTickets(); err != nil {
+		fmt.Printf("Failed to register daemon RPC client for "+
+			"spent/missed tickets notifications: %s\n", err.Error())
+		return err
+	}
+	log.Info("subscribed to notifications from dcrd")
 
 	if !cfg.NoRPCListen {
 		startGRPCServers(ctx.reloadUserConfig)
@@ -268,15 +373,16 @@ func runMain() int {
 		<-c
 		signal.Stop(c)
 		// Close the channel so multiple goroutines can get the message
-		log.Infof("CTRL+C hit.  Closing goroutines.")
-		//saveData(ctx)
+		log.Info("CTRL+C hit.  Closing goroutines.")
+		saveData(ctx)
 		close(ctx.quit)
 	}()
 
-	ctx.wg.Add(3)
-	go ctx.winningTicketHandler()
-	go ctx.reloadTicketsHandler()
+	ctx.wg.Add(4)
+	go ctx.newTicketHandler()
 	go ctx.reloadUserConfigHandler()
+	go ctx.spentmissedTicketHandler()
+	go ctx.winningTicketHandler()
 
 	if cfg.NoRPCListen {
 		// Initial reload of user voting config
@@ -293,53 +399,295 @@ func runMain() int {
 	// Wait for CTRL+C to signal goroutines to terminate via quit channel.
 	ctx.wg.Wait()
 
-	return 0
+	return nil
 }
 
 func main() {
-	os.Exit(runMain())
+	if err := runMain(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(0)
 }
 
-// saveData saves all the global data to a file so they can be read back
-// in at next run.
+func getDataNames() map[string]string {
+	v := reflect.ValueOf(saveFileSchema)
+
+	saveFiles := make(map[string]string)
+
+	for i := 0; i < v.NumField(); i++ {
+		if v.Type().Field(i).Name == "Version" {
+			continue
+		}
+		saveFiles[v.Type().Field(i).Name] = v.Field(i).Interface().(string)
+	}
+
+	return saveFiles
+}
+
+// pruneData prunes any extra save files.
+func pruneData(ctx *appContext) error {
+	saveFiles := getDataNames()
+
+	if !fileExists(ctx.dataPath) {
+		return fmt.Errorf("datapath %v doesn't exist", ctx.dataPath)
+	}
+
+	for dataKind, dataVersion := range saveFiles {
+		var filesToPrune []string
+
+		files, err := ioutil.ReadDir(ctx.dataPath)
+		if err != nil {
+			return err
+		}
+
+		for i, file := range files {
+			log.Debugf("entry %d => %s", i, file.Name())
+			if strings.HasPrefix(file.Name(), strings.ToLower(dataKind)) &&
+				strings.Contains(file.Name(), dataVersion) &&
+				strings.HasSuffix(file.Name(), ".gob") {
+				filesToPrune = append(filesToPrune, filepath.Join(ctx.dataPath, file.Name()))
+			}
+		}
+
+		if len(filesToPrune) <= saveFilesToKeep {
+			continue
+		}
+
+		filesToPruneCount := len(filesToPrune) - saveFilesToKeep
+		for i, filepath := range filesToPrune {
+			err = os.Remove(filepath)
+			if err != nil {
+				log.Warnf("unable to prune %v: %v", filepath, err)
+			} else {
+				log.Infof("pruned old data file %v", filepath)
+			}
+			if filesToPruneCount == i+1 {
+				break
+			}
+		}
+	}
+
+	return nil
+}
+
+// loadData looks for and attempts to load into memory the most recent save
+// file for a passed data kind.
+func loadData(ctx *appContext, dataKind string) error {
+	dataVersion := ""
+	found := false
+	saveFiles := getDataNames()
+
+	for filenameprefix, dataversion := range saveFiles {
+		if dataKind == filenameprefix {
+			dataVersion = dataversion
+			found = true
+		}
+	}
+
+	if !found {
+		return errors.New("unhandled data kind of " + dataKind)
+	}
+
+	if fileExists(ctx.dataPath) {
+		files, err := ioutil.ReadDir(ctx.dataPath)
+		if err != nil {
+			return err
+		}
+
+		lastseen := ""
+
+		for i, file := range files {
+			log.Debugf("entry %d => %s", i, file.Name())
+			if strings.HasPrefix(file.Name(), strings.ToLower(dataKind)) &&
+				strings.Contains(file.Name(), dataVersion) &&
+				strings.HasSuffix(file.Name(), ".gob") {
+				lastseen = file.Name()
+			}
+		}
+
+		// we could warn/error here but it's not really a problem.
+		// maybe the admin deleted the gob files to reset the cache
+		// or the cache hasn't been initialized yet.
+		if lastseen == "" {
+			return nil
+		}
+
+		fullPath := filepath.Join(ctx.dataPath, lastseen)
+
+		r, err := os.Open(fullPath)
+		if err != nil {
+			return err
+		}
+		dec := gob.NewDecoder(r)
+		switch dataKind {
+		case "LiveTickets":
+			err = dec.Decode(&ctx.liveTicketsMSA)
+			if err != nil {
+				return err
+			}
+		case "ManuallyAddedTickets":
+			err = dec.Decode(&ctx.manuallyAddedTicketsMSA)
+			if err != nil {
+				return err
+			}
+		case "UserVotingConfig":
+			err = dec.Decode(&ctx.userVotingConfig)
+			if err != nil {
+				return err
+			}
+		}
+		log.Infof("Loaded %s from %s", dataKind, fullPath)
+		return nil
+	}
+
+	// shouldn't get here -- data dir is created on startup
+	return errors.New("loadData - path " + ctx.dataPath + " does not exist")
+}
+
+// saveData saves some appContext fields to a file so they can be loaded back
+// into memory at next run.
 func saveData(ctx *appContext) {
 	ctx.Lock()
 	defer ctx.Unlock()
 
-	w, err := os.Create(ctx.dataPath)
+	saveFiles := getDataNames()
+
+	for filenameprefix, dataversion := range saveFiles {
+		t := time.Now()
+		destFilename := strings.Replace(dataFilenameTemplate, "KIND", filenameprefix, -1)
+		destFilename = strings.Replace(destFilename, "DATE", t.Format("2006_01_02_15_04_05"), -1)
+		destFilename = strings.Replace(destFilename, "VERSION", dataversion, -1)
+		destPath := strings.ToLower(filepath.Join(ctx.dataPath, destFilename))
+
+		// Pre-validate whether we'll be saving or not.
+		switch filenameprefix {
+		case "LiveTickets":
+			if len(ctx.liveTicketsMSA) == 0 {
+				log.Warn("saveData: liveTicketsMSA is empty; skipping save")
+				continue
+			}
+		case "ManuallyAddedTickets":
+			if len(ctx.manuallyAddedTicketsMSA) == 0 {
+				// we don't expect to do anything with this yet so don't warn
+				// log.Warn("saveData: manuallyAddedTicketsMSA is empty; skipping save")
+				continue
+			}
+		case "UserVotingConfig":
+			if len(ctx.userVotingConfig) == 0 {
+				log.Warn("saveData: UserVotingConfig is empty; skipping save")
+				continue
+			}
+		default:
+			log.Warn("saveData: passed unhandled data name " + filenameprefix)
+			continue
+		}
+
+		w, err := os.Create(destPath)
+		defer w.Close()
+		if err != nil {
+			log.Errorf("Error opening file %s: %v", ctx.dataPath, err)
+			continue
+		}
+
+		switch filenameprefix {
+		case "LiveTickets":
+			enc := gob.NewEncoder(w)
+			if err := enc.Encode(&ctx.liveTicketsMSA); err != nil {
+				log.Errorf("Failed to encode file %s: %v", ctx.dataPath, err)
+				continue
+			}
+		case "ManuallyAddedTickets":
+			enc := gob.NewEncoder(w)
+			if err := enc.Encode(&ctx.manuallyAddedTicketsMSA); err != nil {
+				log.Errorf("Failed to encode file %s: %v", ctx.dataPath, err)
+				continue
+			}
+		case "UserVotingConfig":
+			enc := gob.NewEncoder(w)
+			if err := enc.Encode(&ctx.userVotingConfig); err != nil {
+				log.Errorf("Failed to encode file %s: %v", ctx.dataPath, err)
+				continue
+			}
+		}
+
+		log.Infof("saveData: successfully saved %v data to %s",
+			filenameprefix, destPath)
+	}
+
+}
+
+// ticketMetadata contains all the bits and pieces required to vote new tickets,
+// to look up new/missed/spent tickets, and to print statistics after usage.
+type ticketMetadata struct {
+	blockHash        *chainhash.Hash
+	blockHeight      int64
+	msa              string                    // multisig
+	ticket           *chainhash.Hash           // ticket
+	spent            bool                      // spent (true) or missed (false)
+	config           userdata.UserVotingConfig // voting config
+	duration         time.Duration             // overall vote duration
+	getDuration      time.Duration             // time to gettransaction
+	txid             *chainhash.Hash           // transaction id
+	ticketType       string                    // new or spentmissed
+	signDuration     time.Duration             // time to generatevote
+	sendDuration     time.Duration             // time to sendrawtransaction
+	err              error                     // log errors along the way
+	voteBits         uint16                    // voteBits
+	voteBitsExtended string                    // voteBits extended
+}
+
+// getticket pulls the transaction information for a ticket from dcrwallet. This is a go routine!
+func (ctx *appContext) getticket(wg *sync.WaitGroup, nt *ticketMetadata) {
+	start := time.Now()
+
+	defer func() {
+		nt.duration = time.Since(start)
+		wg.Done()
+	}()
+
+	// Ask wallet to look up vote transaction to see if it belongs to us
+	log.Debugf("calling GetTransaction for %v ticket %v",
+		strings.ToLower(nt.ticketType), nt.ticket)
+	res, err := ctx.walletConnection.GetTransaction(nt.ticket)
+	nt.getDuration = time.Since(start)
 	if err != nil {
-		log.Errorf("Error opening file %s: %v", ctx.dataPath, err)
+		// suppress "No information for transaction ..." errors
+		if !strings.HasPrefix(err.Error(), errNoTxInfo) {
+			log.Warnf("unexpected GetTransaction error: '%v' for %v",
+				err, nt.ticket)
+		}
 		return
 	}
-	enc := json.NewEncoder(w)
-	defer w.Close()
-	if err := enc.Encode(&ctx); err != nil {
-		log.Errorf("Failed to encode file %s: %v", ctx.dataPath, err)
-		return
+	for i := range res.Details {
+		_, ok := ctx.userVotingConfig[res.Details[i].Address]
+		if ok {
+			// multisigaddress will match if it belongs a pool user
+			nt.msa = res.Details[i].Address
+
+			switch nt.ticketType {
+			case ticketTypeNew:
+				// Probably doesn't make sense to check manuallyAddedTicketsMSA
+				// here since the user/admin won't know about it until later
+				log.Debugf("calling nodeCheckTicketFee for %v", nt.ticket)
+				ticketFeesValid, err := nodeCheckTicketFee(ctx, res.Hex, res.BlockHash)
+				if !ticketFeesValid || err != nil {
+					log.Warnf("ignoring ticket %v for msa %v ticketFeesValid %v err %v",
+						nt.ticket, nt.msa, ticketFeesValid, err)
+					// empty out the multisig address so processNewTickets won't
+					// be able to add this ticket
+					nt.msa = ""
+				}
+			}
+			break
+		}
 	}
-}
-
-// loadData loads the saved data from the saved file.  If empty, missing, or
-// malformed file, just don't load anything and start fresh
-func (ctx *appContext) loadData() {
-	ctx.Lock()
-	defer ctx.Unlock()
-}
-
-// winner contains all the bits and pieces required to vote and to print
-// statistics after usage.
-type winner struct {
-	msa          string                    // multisig
-	ticket       *chainhash.Hash           // ticket
-	config       userdata.UserVotingConfig // voting config
-	signDuration time.Duration
-	sendDuration time.Duration
-	duration     time.Duration // overall vote duration
-	err          error         // log errors along the way
+	log.Debugf("getticket finished for %v ticket %v",
+		strings.ToLower(nt.ticketType), nt.ticket)
 }
 
 // vote Generates a vote and send it off to the network.  This is a go routine!
-func (ctx *appContext) vote(wg *sync.WaitGroup, blockHash *chainhash.Hash, blockHeight int64, w *winner) {
+func (ctx *appContext) vote(wg *sync.WaitGroup, blockHash *chainhash.Hash, blockHeight int64, w *ticketMetadata) {
 	start := time.Now()
 
 	defer func() {
@@ -351,7 +699,7 @@ func (ctx *appContext) vote(wg *sync.WaitGroup, blockHash *chainhash.Hash, block
 	var res *dcrjson.GenerateVoteResult
 	res, w.err = ctx.walletConnection.GenerateVote(blockHash, blockHeight,
 		w.ticket, w.config.VoteBits, ctx.votingConfig.VoteBitsExtended)
-	if w.err != nil {
+	if w.err != nil || res.Hex == "" {
 		return
 	}
 	w.signDuration = time.Since(start)
@@ -368,10 +716,162 @@ func (ctx *appContext) vote(wg *sync.WaitGroup, blockHash *chainhash.Hash, block
 		return
 	}
 
-	// Ask wallet to transmit raw transaction.
+	// Ask node to transmit raw transaction.
 	startSend := time.Now()
-	_, w.err = ctx.nodeConnection.SendRawTransaction(newTx, false)
+	tx, err := ctx.nodeConnection.SendRawTransaction(newTx, false)
+	if err != nil {
+		log.Infof("vote err %v", err)
+		w.err = err
+	} else {
+		w.txid = tx
+	}
 	w.sendDuration = time.Since(startSend)
+}
+
+func (ctx *appContext) processNewTickets(nt NewTicketsForBlock) {
+	start := time.Now()
+	ctx.wgNeedToVote.Wait()
+	log.Debugf("processNewTickets: NeedToVote wait time was %v",
+		time.Since(start))
+
+	// We use pointer because it is the fastest accessor.
+	newtickets := make([]*ticketMetadata, 0, len(nt.newTickets))
+
+	var wg sync.WaitGroup // wait group for go routine exits
+
+	ctx.RLock()
+	for _, tickethash := range nt.newTickets {
+		n := &ticketMetadata{
+			blockHash:   nt.blockHash,
+			blockHeight: nt.blockHeight,
+			ticket:      tickethash,
+			ticketType:  ticketTypeNew,
+		}
+		newtickets = append(newtickets, n)
+
+		wg.Add(1)
+		go ctx.getticket(&wg, n)
+	}
+	ctx.RUnlock()
+
+	wg.Wait()
+
+	addtickets := make(map[chainhash.Hash]string)
+
+	for _, n := range newtickets {
+		if n.err != nil || n.msa == "" {
+			// most likely can't look up the transaction because it's
+			// not in our wallet because it doesn't belong to us
+			continue
+		}
+
+		addtickets[*n.ticket] = n.msa
+	}
+
+	ticketCountNew := 0
+	ticketCountOld := 0
+
+	log.Debug("processNewTickets ctx.Lock")
+	ctx.Lock()
+	ticketCountOld = len(ctx.liveTicketsMSA)
+	for ticket, msa := range addtickets {
+		ctx.liveTicketsMSA[ticket] = msa
+	}
+	ticketCountNew = len(ctx.liveTicketsMSA)
+	ctx.Unlock()
+	log.Debug("processNewTickets ctx.Unlock")
+
+	// Log ticket information outside of the handler.
+	go func() {
+		for ticket, msa := range addtickets {
+			log.Infof("added new ticket %v msa %v", ticket, msa)
+		}
+
+		log.Infof("processNewTickets: height %v block %v duration %v "+
+			"newtickets %v ticketCountOld %v ticketCountNew %v", nt.blockHeight,
+			nt.blockHash, time.Since(start), len(addtickets), ticketCountOld,
+			ticketCountNew)
+	}()
+}
+
+func (ctx *appContext) processSpentMissedTickets(smt SpentMissedTicketsForBlock) {
+	start := time.Now()
+	ctx.wgNeedToVote.Wait()
+	log.Debugf("processSpentMissedTickets: NeedToVote wait time was %v",
+		time.Since(start))
+
+	// We use pointer because it is the fastest accessor.
+	smtickets := make([]*ticketMetadata, 0, len(smt.smTickets))
+
+	var wg sync.WaitGroup // wait group for go routine exits
+
+	ctx.RLock()
+	for ticket, spent := range smt.smTickets {
+		sm := &ticketMetadata{
+			blockHash:   smt.blockHash,
+			blockHeight: smt.blockHeight,
+			spent:       spent,
+			ticket:      ticket,
+			ticketType:  ticketTypeSpentMissed,
+		}
+		smtickets = append(smtickets, sm)
+
+		wg.Add(1)
+		go ctx.getticket(&wg, sm)
+	}
+	ctx.RUnlock()
+
+	wg.Wait()
+
+	var missedtickets []*chainhash.Hash
+	var spenttickets []*chainhash.Hash
+
+	for _, sm := range smtickets {
+		if sm.err != nil || sm.msa == "" {
+			// most likely can't look up the transaction because it's
+			// not in our wallet because it doesn't belong to us
+			continue
+		}
+
+		if !sm.spent {
+			missedtickets = append(missedtickets, sm.ticket)
+			continue
+		}
+
+		spenttickets = append(spenttickets, sm.ticket)
+	}
+
+	ticketCountNew := 0
+	ticketCountOld := 0
+
+	log.Debug("processSpentMissedTickets ctx.Lock")
+	ctx.Lock()
+	ticketCountOld = len(ctx.liveTicketsMSA)
+	for _, ticket := range missedtickets {
+		delete(ctx.liveTicketsMSA, *ticket)
+	}
+	for _, ticket := range spenttickets {
+		delete(ctx.liveTicketsMSA, *ticket)
+	}
+	ticketCountNew = len(ctx.liveTicketsMSA)
+	ctx.Unlock()
+	log.Debug("processSpentMissedTickets ctx.Unlock")
+
+	// Log ticket information outside of the handler.
+	go func() {
+		for _, ticket := range missedtickets {
+			log.Infof("removed missed ticket %v", ticket)
+		}
+		for _, ticket := range spenttickets {
+			log.Infof("removed spent ticket %v", ticket)
+		}
+
+		log.Infof("processSpentMissedTickets: height %v block %v "+
+			"duration %v spenttickets %v missedtickets %v ticketCountOld %v "+
+			"ticketCountNew %v", smt.blockHeight, smt.blockHash,
+			time.Since(start), len(spenttickets), len(missedtickets),
+			ticketCountOld, ticketCountNew)
+	}()
 }
 
 // processWinningTickets is called every time a new block comes in to handle
@@ -381,32 +881,15 @@ func (ctx *appContext) vote(wg *sync.WaitGroup, blockHash *chainhash.Hash, block
 func (ctx *appContext) processWinningTickets(wt WinningTicketsForBlock) {
 	start := time.Now()
 
-	// We always have to reload so signal the other end on the way out.
-	// Maybe we can change this to a go routine so that we are not gated on
-	// the function finishing first.  Reason it is deferred now is to make
-	// sure the wallet isn't busy while processing the higher priority
-	// voting activity.
-	defer func() {
-		// Don't block on messaging.  We want to make sure we can
-		// handle the next call ASAP.
-		select {
-		case ctx.reloadTickets <- struct{}{}:
-		default:
-			// We log this in order to detect if we potentially
-			// have a deadlock.
-			log.Infof("Reload tickets message not sent")
-		}
-	}()
-
 	// We use pointer because it is the fastest accessor.
-	winners := make([]*winner, 0, len(wt.winningTickets))
+	winners := make([]*ticketMetadata, 0, len(wt.winningTickets))
 
 	var wg sync.WaitGroup // wait group for go routine exits
 
 	ctx.RLock()
 	for _, ticket := range wt.winningTickets {
 		// Look up multi sig address.
-		msa, ok := ctx.ticketsMSA[*ticket]
+		msa, ok := ctx.liveTicketsMSA[*ticket]
 		if !ok {
 			log.Debugf("unmanaged winning ticket: %v", ticket)
 			if ctx.testing {
@@ -445,7 +928,7 @@ func (ctx *appContext) processWinningTickets(wt WinningTicketsForBlock) {
 			}
 		}
 
-		w := &winner{
+		w := &ticketMetadata{
 			msa:    msa,
 			ticket: ticket,
 			config: voteCfg,
@@ -458,55 +941,47 @@ func (ctx *appContext) processWinningTickets(wt WinningTicketsForBlock) {
 		}
 
 		wg.Add(1)
+		log.Debugf("calling GenerateVote with blockHash %v blockHeight %v "+
+			"ticket %v VoteBits %v VoteBitsExtended %v ",
+			wt.blockHash, wt.blockHeight, w.ticket, w.config.VoteBits,
+			ctx.votingConfig.VoteBitsExtended)
 		go ctx.vote(&wg, wt.blockHash, wt.blockHeight, w)
 	}
 	ctx.RUnlock()
 
 	wg.Wait()
 
-	end := time.Now()
+	ctx.wgNeedToVote.Done()
 
 	// Log ticket information outside of the handler.
 	go func() {
-		var winnerCount, loserCount int
+		var dupeCount, errorCount, votedCount int
+
 		for _, w := range winners {
 			if w.err == nil {
-				winnerCount++
+				votedCount++
 				w.err = errSuccess
 			} else {
-				loserCount++
+				// don't count duplicate votes as errors
+				if strings.HasPrefix(w.err.Error(), errDuplicateVote) {
+					// copy the txid into our metadata struct so it gets printed
+					// properly
+					voteErrParts := strings.Split(w.err.Error(), errDuplicateVote)
+					w.txid, _ = chainhash.NewHashFromStr(voteErrParts[1])
+					dupeCount++
+				} else {
+					errorCount++
+				}
 			}
-			log.Infof("winning ticket %v msa %v duration %v (%v + %v [+ %v]): %v",
-				w.ticket, w.msa, w.duration, w.signDuration, w.sendDuration,
-				w.duration-w.signDuration-w.sendDuration, w.err)
+			log.Infof("voted ticket %v (hash: %v bits: %v) msa %v duration %v "+
+				"(%v + %v): %v", w.ticket, w.txid, w.config.VoteBits, w.msa,
+				w.duration, w.signDuration, w.sendDuration, w.err)
 		}
 		log.Infof("processWinningTickets: height %v block %v "+
-			"duration %v success %v failure %v", wt.blockHeight,
-			wt.blockHash, end.Sub(start), winnerCount, loserCount)
+			"duration %v newvotes %v duplicatevotes %v errors %v",
+			wt.blockHeight, wt.blockHash, time.Since(start), votedCount,
+			dupeCount, errorCount)
 	}()
-}
-
-func (ctx *appContext) reloadTicketsHandler() {
-	defer ctx.wg.Done()
-
-	for {
-		select {
-		case <-ctx.reloadTickets:
-			start := time.Now()
-			newTickets, msg := walletFetchUserTickets(ctx)
-			end := time.Now()
-
-			// replace tickets
-			ctx.Lock()
-			ctx.ticketsMSA = newTickets
-			ctx.Unlock()
-
-			log.Infof("walletFetchUserTickets: %v %v", msg,
-				end.Sub(start))
-		case <-ctx.quit:
-			return
-		}
-	}
 }
 
 func (ctx *appContext) reloadUserConfigHandler() {
@@ -518,9 +993,8 @@ func (ctx *appContext) reloadUserConfigHandler() {
 			start := time.Now()
 			newUserConfig, err :=
 				ctx.userData.MySQLFetchUserVotingConfig()
-			end := time.Now()
 			log.Infof("MySQLFetchUserVotingConfig: %v",
-				end.Sub(start))
+				time.Since(start))
 
 			if err != nil {
 				log.Errorf("unable to reload user config due "+
@@ -529,9 +1003,37 @@ func (ctx *appContext) reloadUserConfigHandler() {
 			}
 
 			// replace UserVotingConfig
+			log.Debug("reloadUserConfigHandler ctx.Lock")
 			ctx.Lock()
 			ctx.userVotingConfig = newUserConfig
 			ctx.Unlock()
+			log.Debug("reloadUserConfigHandler ctx.Unlock")
+		case <-ctx.quit:
+			return
+		}
+	}
+}
+
+func (ctx *appContext) newTicketHandler() {
+	defer ctx.wg.Done()
+
+	for {
+		select {
+		case nt := <-ctx.newTicketsChan:
+			go ctx.processNewTickets(nt)
+		case <-ctx.quit:
+			return
+		}
+	}
+}
+
+func (ctx *appContext) spentmissedTicketHandler() {
+	defer ctx.wg.Done()
+
+	for {
+		select {
+		case smt := <-ctx.spentmissedTicketsChan:
+			go ctx.processSpentMissedTickets(smt)
 		case <-ctx.quit:
 			return
 		}

--- a/backend/stakepoold/server_test.go
+++ b/backend/stakepoold/server_test.go
@@ -92,7 +92,7 @@ var (
 func init() {
 
 	c = &appContext{
-		ticketsMSA: make(map[chainhash.Hash]string),
+		liveTicketsMSA: make(map[chainhash.Hash]string),
 		votingConfig: &VotingConfig{
 			VoteBits:         1,
 			VoteBitsExtended: "05000000",
@@ -124,7 +124,7 @@ func init() {
 		ticket := &chainhash.Hash{b[0], b[1], b[2], b[3]}
 
 		// use ticket as the key
-		c.ticketsMSA[*ticket] = msa
+		c.liveTicketsMSA[*ticket] = msa
 
 		// last 5 tickets win
 		if i > ticketCount-6 {

--- a/backend/stakepoold/version.go
+++ b/backend/stakepoold/version.go
@@ -17,7 +17,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 // These constants define the application version and follow the semantic
 // versioning 2.0.0 spec (http://semver.org/).
 const (
-	appMajor uint = 0
+	appMajor uint = 1
 	appMinor uint = 1
 	appPatch uint = 0
 

--- a/sample-stakepoold.conf
+++ b/sample-stakepoold.conf
@@ -1,7 +1,12 @@
-; Not currently used but will be in the future when fee enforcement is moved
-; over from dcrwallet.
-ColdWalletExtPub=xpub...
-PoolFees=7.5
+; Specified extended public key is used to generate fee payment addresses
+; which are presented to the user.
+; Should match dcrstakepool's coldwalletextpub configuration and dcrwallet's
+; stakepoolcoldextkey configuration.
+;coldwalletextpub=xpub
+
+; Fees as a percentage. 7.5 = 7.5%.  Precision of 2, 7.99 = 7.99%.
+; Should match dcrstakepool and dcrwallet's configuration.
+;poolfees=7.5
 
 ; Stay on testnet until everything is well tested.  Ideally, you should run
 ; on testnet with lots of tickets as a benchmark to ensure votes are cast


### PR DESCRIPTION
This reworks the ticket handling of stakepoold.

Previously, it would do stakepooluserinfo for every user on startup and every block thereafter.

This switches it to use gettickets on startup and then add/remove tickets based on the OnNewTickets / OnSpentAndMissedTickets notifications.

stakepoold's ticket count now stays in sync with the live ticket count from getstakeinfo.

This also adds caching so voting can resume immediately.

Closes #177.
Closes #179.