### PR TITLE
Network Stake Info API endpoint

### DIFF
--- a/controllers/main.go
+++ b/controllers/main.go
@@ -370,18 +370,6 @@ func (controller *MainController) APIPurchaseInfo(c web.C,
 // APINetworkStakeInfo fetches various network PoS related info
 func (controller *MainController) APINetworkStakeInfo(c web.C,
 	r *http.Request) (*poolapi.NetworkStakeInfo, codes.Code, string, error) {
-	dbMap := controller.GetDbMap(c)
-
-	if c.Env["APIUserID"] == nil {
-		return nil, codes.Unauthenticated, "networkStakeInfo error", errors.New("invalid api token")
-	}
-
-	user, _ := models.GetUserById(dbMap, c.Env["APIUserID"].(int64))
-
-	if len(user.UserPubKeyAddr) == 0 {
-		return nil, codes.FailedPrecondition, "networkStakeInfo error", errors.New("no address submitted")
-	}
-
 	esd, err := controller.rpcServers.EstimateStakeDiff()
 	if err != nil {
 		log.Infof("RPC EstimateStakeDifficulty failed: %v", err)

--- a/poolapi/apijson.go
+++ b/poolapi/apijson.go
@@ -45,3 +45,12 @@ type Stats struct {
 	UserCountActive      int64   `json:"UserCountActive"`
 	Version              string  `json:"Version"`
 }
+
+type NetworkStakeInfo struct {
+	Height       int64   `json:"Height"`
+	TicketPrice  float64 `json:"TicketPrice"`
+	NextEstimate float64 `json:"NextEstimate"`
+	NextMin      float64 `json:"NextMin"`
+	NextMax      float64 `json:"NextMax"`
+	WindowIndex  uint32  `json:"WindowIndex"`
+}


### PR DESCRIPTION
The idea is to provide some pertinent information to API clients.

Needs:

- [ ] some docs.
- [ ] handle non-working testnet implementation of EstimateStakeDiff.
