### PR TITLE
Accelerate tickets page

### DIFF
--- a/config.go
+++ b/config.go
@@ -42,6 +42,7 @@ const (
 	defaultRecaptchaSitekey = "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"
 	defaultSMTPHost         = ""
 	defaultMinServers       = 2
+	defaultMaxVotedAge      = 8640
 )
 
 var (
@@ -105,6 +106,7 @@ type config struct {
 	AdminIPs           []string `long:"adminips" description:"Expected admin host"`
 	MinServers         int      `long:"minservers" description:"Minimum number of wallets connected needed to avoid errors"`
 	EnableStakepoold   bool     `long:"enablestakepoold" description:"Enable communication with stakepoold"`
+	MaxVotedAge        int64    `long:"maxvotedage" description:"Maximum vote age (blocks since vote) to include in voted tickets table"`
 }
 
 // serviceOptions defines the configuration options for the daemon as a service
@@ -302,6 +304,7 @@ func loadConfig() (*config, []string, error) {
 		SMTPHost:         defaultSMTPHost,
 		Version:          version(),
 		MinServers:       defaultMinServers,
+		MaxVotedAge:      defaultMaxVotedAge,
 	}
 
 	// Service options which are only added on Windows.

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -1736,6 +1736,7 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 		c.Env["Flash"] = session.Flashes("main")
 		return controller.Parse(t, "main", c.Env), http.StatusInternalServerError
 	}
+	minVotedHeight := height - maxVotedAge
 
 	// If the user has tickets, get their info
 	if spui != nil && len(spui.Tickets) > 0 {
@@ -1760,7 +1761,7 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 				})
 			case "voted":
 				numVoted++
-				if int64(ticket.SpentByHeight)+maxVotedAge >= height {
+				if int64(ticket.SpentByHeight) >= minVotedHeight {
 					ticketInfoVoted = append(ticketInfoVoted, TicketInfoHistoric{
 						Ticket:        ticket.Ticket,
 						SpentBy:       ticket.SpentBy,
@@ -1787,7 +1788,8 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 	c.Env["TicketsLive"] = ticketInfoLive
 	c.Env["TicketsExpired"] = ticketInfoExpired
 	c.Env["TicketsMissed"] = ticketInfoMissed
-	c.Env["TicketsCount"] = numVoted
+	c.Env["TicketsVotedCount"] = numVoted
+	c.Env["TicketsVotedArchivedCount"] = numVoted - len(ticketInfoVoted)
 	c.Env["TicketsVoted"] = ticketInfoVoted
 	widgets := controller.Parse(t, "tickets", c.Env)
 

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -1716,7 +1716,6 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 		user.MultiSigAddress)
 
 	w := controller.rpcServers
-	// TODO: Tell the user if there is a cool-down
 
 	start := time.Now()
 
@@ -1732,6 +1731,7 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 	log.Debugf(":: StakePoolUserInfo (msa = %v) execution time: %v",
 		user.MultiSigAddress, time.Since(start))
 
+	// Compute the oldest (min) ticket spend height to include in the table
 	_, height, err := w.GetBestBlock()
 	if err != nil {
 		log.Infof("RPC GetBestBlock failed: %v", err)
@@ -1780,8 +1780,10 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 		}
 	}
 
-	// Sort live tickets
-	sort.Sort(ByTicketHeight(ticketInfoLive))
+	// Sort live tickets. This is commented because the JS tables will perform
+	// their own sorting anyway. However, depending on the UI implementation, it
+	// may be desirable to sort it here.
+	// sort.Sort(ByTicketHeight(ticketInfoLive))
 
 	// Sort historic (voted and revoked) tickets
 	sort.Sort(BySpentByHeight(ticketInfoVoted))

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -1674,6 +1674,7 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 	var ticketInfoInvalid []TicketInfoInvalid
 	var ticketInfoLive []TicketInfoLive
 	var ticketInfoVoted, ticketInfoExpired, ticketInfoMissed []TicketInfoHistoric
+	var numVoted int
 
 	responseHeaderMap := make(map[string]string)
 	c.Env["ResponseHeaderMap"] = responseHeaderMap
@@ -1748,12 +1749,13 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 					TicketHeight:  ticket.TicketHeight,
 				})
 			case "voted":
-				ticketInfoVoted = append(ticketInfoVoted, TicketInfoHistoric{
-					Ticket:        ticket.Ticket,
-					SpentBy:       ticket.SpentBy,
-					SpentByHeight: ticket.SpentByHeight,
-					TicketHeight:  ticket.TicketHeight,
-				})
+				numVoted++
+				// 	ticketInfoVoted = append(ticketInfoVoted, TicketInfoHistoric{
+				// 		Ticket:        ticket.Ticket,
+				// 		SpentBy:       ticket.SpentBy,
+				// 		SpentByHeight: ticket.SpentByHeight,
+				// 		TicketHeight:  ticket.TicketHeight,
+				// 	})
 			}
 		}
 
@@ -1766,13 +1768,14 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 	sort.Sort(ByTicketHeight(ticketInfoLive))
 
 	// Sort historic (voted and revoked) tickets
-	sort.Sort(BySpentByHeight(ticketInfoVoted))
+	//sort.Sort(BySpentByHeight(ticketInfoVoted))
 	sort.Sort(BySpentByHeight(ticketInfoMissed))
 
 	c.Env["TicketsInvalid"] = ticketInfoInvalid
 	c.Env["TicketsLive"] = ticketInfoLive
 	c.Env["TicketsExpired"] = ticketInfoExpired
 	c.Env["TicketsMissed"] = ticketInfoMissed
+	c.Env["TicketsCount"] = numVoted
 	c.Env["TicketsVoted"] = ticketInfoVoted
 	widgets := controller.Parse(t, "tickets", c.Env)
 
@@ -1939,3 +1942,11 @@ func (controller *MainController) IsValidVoteBits(userVoteBits uint16) bool {
 	return userVoteBits&^usedBits == 0
 }
 
+func stringSliceContains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -1718,7 +1718,9 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 	w := controller.rpcServers
 	// TODO: Tell the user if there is a cool-down
 
-	spui, err := w.StakePoolUserInfo(multisig)
+	start := time.Now()
+
+	spui, err := w.StakePoolUserInfo(multisig, true)
 	if err != nil {
 		// Render page with message to try again later
 		log.Infof("RPC StakePoolUserInfo failed: %v", err)

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -1664,9 +1664,8 @@ type TicketInfoInvalid struct {
 // TicketInfoLive represents live or immature (mined) tickets that have yet to
 // be spent by either a vote or revocation.
 type TicketInfoLive struct {
-	Ticket       string
 	TicketHeight uint32
-	VoteBits     uint16
+	Ticket       string
 }
 
 // Tickets renders the tickets page.
@@ -1728,6 +1727,9 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 		return controller.Parse(t, "main", c.Env), http.StatusInternalServerError
 	}
 
+	log.Debugf(":: StakePoolUserInfo (msa = %v) execution time: %v",
+		user.MultiSigAddress, time.Since(start))
+
 	_, height, err := w.GetBestBlock()
 	if err != nil {
 		log.Infof("RPC GetBestBlock failed: %v", err)
@@ -1743,8 +1745,8 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 			switch ticket.Status {
 			case "live":
 				ticketInfoLive = append(ticketInfoLive, TicketInfoLive{
-					Ticket:       ticket.Ticket,
 					TicketHeight: ticket.TicketHeight,
+					Ticket:       ticket.Ticket,
 				})
 			case "expired":
 				ticketInfoExpired = append(ticketInfoExpired, TicketInfoHistoric{

--- a/controllers/main_go18_test.go
+++ b/controllers/main_go18_test.go
@@ -1,0 +1,117 @@
+// +build go1.8
+
+package controllers
+
+import (
+	mrand "math/rand"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func randHashString() string {
+	var b [64]byte
+	const hexvals = "123456789abcdef"
+	for i := range b {
+		b[i] = hexvals[mrand.Intn(len(hexvals))]
+	}
+	return string(b[:])
+}
+
+func TestSortByTicketHeight(t *testing.T) {
+	// Create a large list of tickets to sort, voted over many blocks
+	ticketCount, maxTxHeight := 55000, int64(123000)
+
+	ticketInfoLive := make([]TicketInfoLive, 0, ticketCount)
+	for i := 0; i < ticketCount; i++ {
+		ticketInfoLive = append(ticketInfoLive, TicketInfoLive{
+			TicketHeight: uint32(mrand.Int63n(maxTxHeight)),
+			Ticket:       randHashString(), // could be nothing unless we sort with it
+		})
+	}
+
+	// Make a copy to sort with ref method
+	ticketInfoLive2 := make([]TicketInfoLive, len(ticketInfoLive))
+	copy(ticketInfoLive2, ticketInfoLive)
+
+	// Sort with ByTicketHeight, the test subject
+	sort.Sort(ByTicketHeight(ticketInfoLive))
+
+	// Sort using convenience function added in go1.8
+	sort.Slice(ticketInfoLive2, func(i, j int) bool {
+		return ticketInfoLive2[i].TicketHeight < ticketInfoLive2[j].TicketHeight
+	})
+	// compare
+	if !reflect.DeepEqual(ticketInfoLive, ticketInfoLive2) {
+		t.Error("Sort with ByTicketHeight failed")
+	}
+
+	// Check if sorted using convenience function added in go1.8
+	if !sort.SliceIsSorted(ticketInfoLive, func(i, j int) bool {
+		return ticketInfoLive[i].TicketHeight < ticketInfoLive[j].TicketHeight
+	}) {
+		t.Error("Sort with ByTicketHeight failed")
+	}
+}
+
+func BenchmarkSortByTicketHeight100(b *testing.B)   { benchmarkSortByTicketHeight(100, b) }
+func BenchmarkSortByTicketHeight500(b *testing.B)   { benchmarkSortByTicketHeight(500, b) }
+func BenchmarkSortByTicketHeight1000(b *testing.B)  { benchmarkSortByTicketHeight(1000, b) }
+func BenchmarkSortByTicketHeight2500(b *testing.B)  { benchmarkSortByTicketHeight(2500, b) }
+func BenchmarkSortByTicketHeight5000(b *testing.B)  { benchmarkSortByTicketHeight(5000, b) }
+func BenchmarkSortByTicketHeight10000(b *testing.B) { benchmarkSortByTicketHeight(10000, b) }
+func BenchmarkSortByTicketHeight20000(b *testing.B) { benchmarkSortByTicketHeight(20000, b) }
+
+func benchmarkSortByTicketHeight(ticketCount int, b *testing.B) {
+	// Create a large list of tickets to sort, voted over many blocks
+	maxTxHeight := int64(53000)
+
+	ticketInfoLive := make([]TicketInfoLive, 0, ticketCount)
+	for i := 0; i < ticketCount; i++ {
+		ticketInfoLive = append(ticketInfoLive, TicketInfoLive{
+			TicketHeight: uint32(mrand.Int63n(maxTxHeight)),
+			Ticket:       randHashString(), // could be nothing unless we sort with it
+		})
+	}
+
+	for i := 0; i < b.N; i++ {
+		// Make a copy to sort
+		ticketInfoLive2 := make([]TicketInfoLive, len(ticketInfoLive))
+		copy(ticketInfoLive2, ticketInfoLive)
+
+		// Sort with ByTicketHeight, the test subject
+		sort.Sort(ByTicketHeight(ticketInfoLive2))
+	}
+}
+
+func BenchmarkSortBySpentByHeight100(b *testing.B)   { benchmarkSortBySpentByHeight(100, b) }
+func BenchmarkSortBySpentByHeight500(b *testing.B)   { benchmarkSortBySpentByHeight(500, b) }
+func BenchmarkSortBySpentByHeight1000(b *testing.B)  { benchmarkSortBySpentByHeight(1000, b) }
+func BenchmarkSortBySpentByHeight2500(b *testing.B)  { benchmarkSortBySpentByHeight(2500, b) }
+func BenchmarkSortBySpentByHeight5000(b *testing.B)  { benchmarkSortBySpentByHeight(5000, b) }
+func BenchmarkSortBySpentByHeight10000(b *testing.B) { benchmarkSortBySpentByHeight(10000, b) }
+func BenchmarkSortBySpentByHeight20000(b *testing.B) { benchmarkSortBySpentByHeight(20000, b) }
+
+func benchmarkSortBySpentByHeight(ticketCount int, b *testing.B) {
+	// Create a large list of tickets to sort, voted over many blocks
+	maxTxHeight := int64(53000)
+
+	ticketInfoVoted := make([]TicketInfoHistoric, 0, ticketCount)
+	for i := 0; i < ticketCount; i++ {
+		ticketInfoVoted = append(ticketInfoVoted, TicketInfoHistoric{
+			Ticket:        randHashString(), // could be nothing unless we sort with it
+			SpentBy:       randHashString(),
+			SpentByHeight: uint32(mrand.Int63n(maxTxHeight)),
+			TicketHeight:  uint32(mrand.Int63n(maxTxHeight)),
+		})
+	}
+
+	for i := 0; i < b.N; i++ {
+		// Make a copy to sort
+		ticketInfoVoted2 := make([]TicketInfoHistoric, len(ticketInfoVoted))
+		copy(ticketInfoVoted2, ticketInfoVoted)
+
+		// Sort with BySpentByHeight, the test subject
+		sort.Sort(BySpentByHeight(ticketInfoVoted2))
+	}
+}

--- a/controllers/main_test.go
+++ b/controllers/main_test.go
@@ -1,6 +1,9 @@
 package controllers
 
 import (
+	mrand "math/rand"
+	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/decred/dcrd/chaincfg"
@@ -25,5 +28,49 @@ func TestGetNetworkName(t *testing.T) {
 		t.Errorf("Incorrect network name: expected %s, got %s", "mainnet",
 			netName)
 	}
+}
 
+func randHashString() string {
+	var b [64]byte
+	const hexvals = "123456789abcdef"
+	for i := range b {
+		b[i] = hexvals[mrand.Intn(len(hexvals))]
+	}
+	return string(b[:])
+}
+
+func TestSortByTicketHeight(t *testing.T) {
+	// Create a large list of tickets to sort, voted over many blocks
+	ticketCount, maxTxHeight := 55000, int64(123000)
+
+	ticketInfoLive := make([]TicketInfoLive, 0, ticketCount)
+	for i := 0; i < ticketCount; i++ {
+		ticketInfoLive = append(ticketInfoLive, TicketInfoLive{
+			TicketHeight: uint32(mrand.Int63n(maxTxHeight)),
+			Ticket:       randHashString(), // could be nothing unless we sort with it
+		})
+	}
+
+	// Make a copy to sort with ref method
+	ticketInfoLive2 := make([]TicketInfoLive, len(ticketInfoLive))
+	copy(ticketInfoLive2, ticketInfoLive)
+
+	// Sort with ByTicketHeight, the test subject
+	sort.Sort(ByTicketHeight(ticketInfoLive))
+
+	// Sort using convenience function added in go1.8
+	sort.Slice(ticketInfoLive2, func(i, j int) bool {
+		return ticketInfoLive2[i].TicketHeight < ticketInfoLive2[j].TicketHeight
+	})
+	// compare
+	if !reflect.DeepEqual(ticketInfoLive, ticketInfoLive2) {
+		t.Error("Sort with ByTicketHeight failed")
+	}
+
+	// Check if sorted using convenience function added in go1.8
+	if !sort.SliceIsSorted(ticketInfoLive, func(i, j int) bool {
+		return ticketInfoLive[i].TicketHeight < ticketInfoLive[j].TicketHeight
+	}) {
+		t.Error("Sort with ByTicketHeight failed")
+	}
 }

--- a/controllers/main_test.go
+++ b/controllers/main_test.go
@@ -1,9 +1,6 @@
 package controllers
 
 import (
-	mrand "math/rand"
-	"reflect"
-	"sort"
 	"testing"
 
 	"github.com/decred/dcrd/chaincfg"
@@ -27,112 +24,5 @@ func TestGetNetworkName(t *testing.T) {
 	if netName != "mainnet" {
 		t.Errorf("Incorrect network name: expected %s, got %s", "mainnet",
 			netName)
-	}
-}
-
-func randHashString() string {
-	var b [64]byte
-	const hexvals = "123456789abcdef"
-	for i := range b {
-		b[i] = hexvals[mrand.Intn(len(hexvals))]
-	}
-	return string(b[:])
-}
-
-func TestSortByTicketHeight(t *testing.T) {
-	// Create a large list of tickets to sort, voted over many blocks
-	ticketCount, maxTxHeight := 55000, int64(123000)
-
-	ticketInfoLive := make([]TicketInfoLive, 0, ticketCount)
-	for i := 0; i < ticketCount; i++ {
-		ticketInfoLive = append(ticketInfoLive, TicketInfoLive{
-			TicketHeight: uint32(mrand.Int63n(maxTxHeight)),
-			Ticket:       randHashString(), // could be nothing unless we sort with it
-		})
-	}
-
-	// Make a copy to sort with ref method
-	ticketInfoLive2 := make([]TicketInfoLive, len(ticketInfoLive))
-	copy(ticketInfoLive2, ticketInfoLive)
-
-	// Sort with ByTicketHeight, the test subject
-	sort.Sort(ByTicketHeight(ticketInfoLive))
-
-	// Sort using convenience function added in go1.8
-	sort.Slice(ticketInfoLive2, func(i, j int) bool {
-		return ticketInfoLive2[i].TicketHeight < ticketInfoLive2[j].TicketHeight
-	})
-	// compare
-	if !reflect.DeepEqual(ticketInfoLive, ticketInfoLive2) {
-		t.Error("Sort with ByTicketHeight failed")
-	}
-
-	// Check if sorted using convenience function added in go1.8
-	if !sort.SliceIsSorted(ticketInfoLive, func(i, j int) bool {
-		return ticketInfoLive[i].TicketHeight < ticketInfoLive[j].TicketHeight
-	}) {
-		t.Error("Sort with ByTicketHeight failed")
-	}
-}
-
-func BenchmarkSortByTicketHeight100(b *testing.B)   { benchmarkSortByTicketHeight(100, b) }
-func BenchmarkSortByTicketHeight500(b *testing.B)   { benchmarkSortByTicketHeight(500, b) }
-func BenchmarkSortByTicketHeight1000(b *testing.B)  { benchmarkSortByTicketHeight(1000, b) }
-func BenchmarkSortByTicketHeight2500(b *testing.B)  { benchmarkSortByTicketHeight(2500, b) }
-func BenchmarkSortByTicketHeight5000(b *testing.B)  { benchmarkSortByTicketHeight(5000, b) }
-func BenchmarkSortByTicketHeight10000(b *testing.B) { benchmarkSortByTicketHeight(10000, b) }
-func BenchmarkSortByTicketHeight20000(b *testing.B) { benchmarkSortByTicketHeight(20000, b) }
-
-func benchmarkSortByTicketHeight(ticketCount int, b *testing.B) {
-	// Create a large list of tickets to sort, voted over many blocks
-	maxTxHeight := int64(53000)
-
-	ticketInfoLive := make([]TicketInfoLive, 0, ticketCount)
-	for i := 0; i < ticketCount; i++ {
-		ticketInfoLive = append(ticketInfoLive, TicketInfoLive{
-			TicketHeight: uint32(mrand.Int63n(maxTxHeight)),
-			Ticket:       randHashString(), // could be nothing unless we sort with it
-		})
-	}
-
-	for i := 0; i < b.N; i++ {
-		// Make a copy to sort
-		ticketInfoLive2 := make([]TicketInfoLive, len(ticketInfoLive))
-		copy(ticketInfoLive2, ticketInfoLive)
-
-		// Sort with ByTicketHeight, the test subject
-		sort.Sort(ByTicketHeight(ticketInfoLive2))
-	}
-}
-
-func BenchmarkSortBySpentByHeight100(b *testing.B)   { benchmarkSortBySpentByHeight(100, b) }
-func BenchmarkSortBySpentByHeight500(b *testing.B)   { benchmarkSortBySpentByHeight(500, b) }
-func BenchmarkSortBySpentByHeight1000(b *testing.B)  { benchmarkSortBySpentByHeight(1000, b) }
-func BenchmarkSortBySpentByHeight2500(b *testing.B)  { benchmarkSortBySpentByHeight(2500, b) }
-func BenchmarkSortBySpentByHeight5000(b *testing.B)  { benchmarkSortBySpentByHeight(5000, b) }
-func BenchmarkSortBySpentByHeight10000(b *testing.B) { benchmarkSortBySpentByHeight(10000, b) }
-func BenchmarkSortBySpentByHeight20000(b *testing.B) { benchmarkSortBySpentByHeight(20000, b) }
-
-func benchmarkSortBySpentByHeight(ticketCount int, b *testing.B) {
-	// Create a large list of tickets to sort, voted over many blocks
-	maxTxHeight := int64(53000)
-
-	ticketInfoVoted := make([]TicketInfoHistoric, 0, ticketCount)
-	for i := 0; i < ticketCount; i++ {
-		ticketInfoVoted = append(ticketInfoVoted, TicketInfoHistoric{
-			Ticket:        randHashString(), // could be nothing unless we sort with it
-			SpentBy:       randHashString(),
-			SpentByHeight: uint32(mrand.Int63n(maxTxHeight)),
-			TicketHeight:  uint32(mrand.Int63n(maxTxHeight)),
-		})
-	}
-
-	for i := 0; i < b.N; i++ {
-		// Make a copy to sort
-		ticketInfoVoted2 := make([]TicketInfoHistoric, len(ticketInfoVoted))
-		copy(ticketInfoVoted2, ticketInfoVoted)
-
-		// Sort with BySpentByHeight, the test subject
-		sort.Sort(BySpentByHeight(ticketInfoVoted2))
 	}
 }

--- a/controllers/main_test.go
+++ b/controllers/main_test.go
@@ -74,3 +74,65 @@ func TestSortByTicketHeight(t *testing.T) {
 		t.Error("Sort with ByTicketHeight failed")
 	}
 }
+
+func BenchmarkSortByTicketHeight100(b *testing.B)   { benchmarkSortByTicketHeight(100, b) }
+func BenchmarkSortByTicketHeight500(b *testing.B)   { benchmarkSortByTicketHeight(500, b) }
+func BenchmarkSortByTicketHeight1000(b *testing.B)  { benchmarkSortByTicketHeight(1000, b) }
+func BenchmarkSortByTicketHeight2500(b *testing.B)  { benchmarkSortByTicketHeight(2500, b) }
+func BenchmarkSortByTicketHeight5000(b *testing.B)  { benchmarkSortByTicketHeight(5000, b) }
+func BenchmarkSortByTicketHeight10000(b *testing.B) { benchmarkSortByTicketHeight(10000, b) }
+func BenchmarkSortByTicketHeight20000(b *testing.B) { benchmarkSortByTicketHeight(20000, b) }
+
+func benchmarkSortByTicketHeight(ticketCount int, b *testing.B) {
+	// Create a large list of tickets to sort, voted over many blocks
+	maxTxHeight := int64(53000)
+
+	ticketInfoLive := make([]TicketInfoLive, 0, ticketCount)
+	for i := 0; i < ticketCount; i++ {
+		ticketInfoLive = append(ticketInfoLive, TicketInfoLive{
+			TicketHeight: uint32(mrand.Int63n(maxTxHeight)),
+			Ticket:       randHashString(), // could be nothing unless we sort with it
+		})
+	}
+
+	for i := 0; i < b.N; i++ {
+		// Make a copy to sort
+		ticketInfoLive2 := make([]TicketInfoLive, len(ticketInfoLive))
+		copy(ticketInfoLive2, ticketInfoLive)
+
+		// Sort with ByTicketHeight, the test subject
+		sort.Sort(ByTicketHeight(ticketInfoLive2))
+	}
+}
+
+func BenchmarkSortBySpentByHeight100(b *testing.B)   { benchmarkSortBySpentByHeight(100, b) }
+func BenchmarkSortBySpentByHeight500(b *testing.B)   { benchmarkSortBySpentByHeight(500, b) }
+func BenchmarkSortBySpentByHeight1000(b *testing.B)  { benchmarkSortBySpentByHeight(1000, b) }
+func BenchmarkSortBySpentByHeight2500(b *testing.B)  { benchmarkSortBySpentByHeight(2500, b) }
+func BenchmarkSortBySpentByHeight5000(b *testing.B)  { benchmarkSortBySpentByHeight(5000, b) }
+func BenchmarkSortBySpentByHeight10000(b *testing.B) { benchmarkSortBySpentByHeight(10000, b) }
+func BenchmarkSortBySpentByHeight20000(b *testing.B) { benchmarkSortBySpentByHeight(20000, b) }
+
+func benchmarkSortBySpentByHeight(ticketCount int, b *testing.B) {
+	// Create a large list of tickets to sort, voted over many blocks
+	maxTxHeight := int64(53000)
+
+	ticketInfoVoted := make([]TicketInfoHistoric, 0, ticketCount)
+	for i := 0; i < ticketCount; i++ {
+		ticketInfoVoted = append(ticketInfoVoted, TicketInfoHistoric{
+			Ticket:        randHashString(), // could be nothing unless we sort with it
+			SpentBy:       randHashString(),
+			SpentByHeight: uint32(mrand.Int63n(maxTxHeight)),
+			TicketHeight:  uint32(mrand.Int63n(maxTxHeight)),
+		})
+	}
+
+	for i := 0; i < b.N; i++ {
+		// Make a copy to sort
+		ticketInfoVoted2 := make([]TicketInfoHistoric, len(ticketInfoVoted))
+		copy(ticketInfoVoted2, ticketInfoVoted)
+
+		// Sort with BySpentByHeight, the test subject
+		sort.Sort(BySpentByHeight(ticketInfoVoted2))
+	}
+}

--- a/sample-dcrstakepool.conf
+++ b/sample-dcrstakepool.conf
@@ -120,3 +120,7 @@ adminips=127.0.0.1
 
 ; Path to the root folder/directory which contains the HTML templates.
 ;templatepath=views
+
+; Maximum age of voted tickets to show on tickets page. Specify a threshold in
+; number of blocks since the spend/vote height.
+;maxvotedage=8640

--- a/server.go
+++ b/server.go
@@ -116,11 +116,12 @@ func runMain() int {
 	controller, err := controllers.NewMainController(activeNetParams.Params,
 		cfg.AdminIPs, cfg.APISecret, APIVersionsSupported, cfg.BaseURL,
 		cfg.ClosePool, cfg.ClosePoolMsg, cfg.EnableStakepoold,
-		cfg.ColdWalletExtPub, grpcConnections, cfg.PoolEmail, cfg.PoolFees,
+		cfg.ColdWalletExtPub, grpcConnections, cfg.PoolFees, cfg.PoolEmail,
 		cfg.PoolLink, cfg.RecaptchaSecret, cfg.RecaptchaSitekey, cfg.SMTPFrom,
 		cfg.SMTPHost, cfg.SMTPUsername, cfg.SMTPPassword, cfg.Version,
 		cfg.WalletHosts, cfg.WalletCerts, cfg.WalletUsers, cfg.WalletPasswords,
-		cfg.MinServers, cfg.RealIPHeader, cfg.VotingWalletExtPub)
+		cfg.MinServers, cfg.RealIPHeader, cfg.VotingWalletExtPub,
+		cfg.MaxVotedAge)
 	if err != nil {
 		application.Close()
 		log.Errorf("Failed to initialize the main controller: %v",

--- a/views/tickets.html
+++ b/views/tickets.html
@@ -134,7 +134,7 @@ dcrctl {{ if eq .Network "testnet"}}--testnet{{end}} --wallet purchaseticket "de
     <div id="collapse-votedlist" class="panel-collapse collapse {{if .TicketsVoted}}in{{end}}">
       <div class="panel-body">
 			{{if not .TicketsVoted}}
-			<p><strong>No voted tickets.</strong></p>
+			<p><strong>Number of voted tickets: {{.TicketsCount}}.</strong></p>
 			{{end}}
 			{{if .TicketsVoted}}
 			<div class="table-responsive">

--- a/views/tickets.html
+++ b/views/tickets.html
@@ -133,9 +133,8 @@ dcrctl {{ if eq .Network "testnet"}}--testnet{{end}} --wallet purchaseticket "de
     </div>
     <div id="collapse-votedlist" class="panel-collapse collapse {{if .TicketsVoted}}in{{end}}">
       <div class="panel-body">
-			{{if not .TicketsVoted}}
-			<p><strong>Number of voted tickets: {{.TicketsCount}}.</strong></p>
-			{{end}}
+			<p><strong>{{.TicketsVotedCount}} total tickets voted ({{.TicketsVotedArchivedCount}} archived and not shown).</strong></p>
+			
 			{{if .TicketsVoted}}
 			<div class="table-responsive">
 			<table id="ticketsvoted" class="table table-condensed datatablesort responsive">


### PR DESCRIPTION
Aims to address, in part, issue https://github.com/decred/dcrstakepool/issues/56

Reduced scope of this PR:

 - [x] Support returning a truncated limited list of the tickets, especially ancient voted tickets.  Doing this may be done either by sorting (which also gives a pre-sorted list to html/js) or by thresholding by spent age and only adding recent enough tickets to the html template data (the slices).  The latter is implemented in this PR, but the code to support ticket sorting is also added.
 - [x] The tickets page uses maps when not necessary and slices would be more efficient.  Slices also allow sorting (which may be commented out) for different ticket types.
 - [x] When using `StakePoolUserInfo` to get the tickets list for display on the /tickets page, do not bother getting it from all wallets and performing they "syncness" check.  This should be left to startup checks (or another maintenance routine), and should not hold up display of the web site when a valid response comes from the first (make it the fastest one!) wallet.

Possible goals for follow-up changes:

- Cache live tickets, but not voted. For each user.  Memory is not a constraint for millions of tickets, and CPU will not be either as the users will be in their own buckets.
- Put voted tickets on a separate page: (a) all voted on separate page and none on main tickets page, or (b)  all on the other page and with the most recent on main tickets page.
- To do (b) in the previous, cache the most recent voted tickets for each user.
- Allow downloading a CSV (or whatever) list of historical tickets.
- Maintaining the live/voted/etc tickets caches intelligently (i.e. without simply regenerating the lists if X minutes have passed) is desirable but not required.
- Write benchmarks for the sorters so it is clear when it becomes a burden on the server. (seems to be around 700 tickets in a slice).
