### PR TITLE
Do not ignore invalid or missing P2SH multisig on /tickets

### DIFF
--- a/controllers/main.go
+++ b/controllers/main.go
@@ -1662,8 +1662,8 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 	user, _ := models.GetUserById(dbMap, session.Values["UserId"].(int64))
 
 	if user.MultiSigAddress == "" {
-		c.Env["Error"] = "No multisig data has been generated"
 		log.Info("Multisigaddress empty")
+		return "/address", http.StatusSeeOther
 	}
 
 	if controller.RPCIsStopped() {
@@ -1673,8 +1673,8 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 	// Get P2SH Address
 	multisig, err := dcrutil.DecodeAddress(user.MultiSigAddress, controller.params)
 	if err != nil {
-		c.Env["Error"] = "Invalid multisig data in database"
 		log.Infof("Invalid address %v in database: %v", user.MultiSigAddress, err)
+		return "/error", http.StatusSeeOther
 	}
 
 	log.Infof("Tickets GET from %v, multisig %v", remoteIP,


### PR DESCRIPTION
Reported by jyap on slack:

```
08:00:07 2017-06-12 [INF] CNTL: updated voteBits for user 249 from 1 to 19
08:00:08 2017-06-12 [INF] CNTL: updated voteBits for user 249 from 19 to 19
08:00:13 2017-06-12 [INF] CNTL: updated voteBits for user 249 from 19 to 19
08:00:16 2017-06-12 [INF] CNTL: updated voteBits for user 249 from 19 to 19
08:00:38 2017-06-12 [INF] CNTL: Multisigaddress empty
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x8d4f36]

goroutine 172 [running]:
github.com/decred/dcrstakepool/vendor/github.com/decred/dcrrpcclient.(*Client).StakePoolUserInfoAsync(0xc4200d9540, 0x0, 0x0, 0xc4206741a0)
        //gopath/src/github.com/decred/dcrstakepool/vendor/github.com/decred/dcrrpcclient/wallet.go:3243 +0x26
github.com/decred/dcrstakepool/vendor/github.com/decred/dcrrpcclient.(*Client).StakePoolUserInfo(0xc4200d9540, 0x0, 0x0, 0xc4206741c0, 0x3, 0x3)
        //gopath/src/github.com/decred/dcrstakepool/vendor/github.com/decred/dcrrpcclient/wallet.go:3250 +0x3f
github.com/decred/dcrstakepool/controllers.(*walletSvrManager).executeInSequence(0xc4200db4a0, 0x7, 0xaa81c0, 0xc420674160, 0xa0e980, 0xc4206cc600)
        //gopath/src/github.com/decred/dcrstakepool/controllers/dcrclient.go:584 +0x3e99
github.com/decred/dcrstakepool/controllers.(*walletSvrManager).walletRPCHandler(0xc4200db4a0)
        //gopath/src/github.com/decred/dcrstakepool/controllers/dcrclient.go:201 +0x779
created by github.com/decred/dcrstakepool/controllers.(*walletSvrManager).Start
        //gopath/src/github.com/decred/dcrstakepool/controllers/dcrclient.go:1009 +0x11a
```