### PR TITLE
Update deps to pull in additional logging changes.

### DIFF
--- a/backend/stakepoold/log.go
+++ b/backend/stakepoold/log.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 
@@ -24,8 +23,8 @@ func (logWriter) Write(p []byte) (n int, err error) {
 	os.Stdout.Write(p)
 	// Normally this if isn't required, but the tests in this main package need
 	// to work with uninitialized log rotators.
-	if logRotatorPipe != nil {
-		logRotatorPipe.Write(p)
+	if logRotator != nil {
+		logRotator.Write(p)
 	}
 	return len(p), nil
 }
@@ -47,10 +46,6 @@ var (
 	// logRotator is one of the logging outputs.  It should be closed on
 	// application shutdown.
 	logRotator *rotator.Rotator
-
-	// logRotatorPipe is the write-end pipe for writing to the log rotator.  It
-	// is written to by the Write method of the logWriter type.
-	logRotatorPipe *io.PipeWriter
 
 	clientLog = backendLog.Logger("RPCC")
 	dbLog     = backendLog.Logger("DB")
@@ -82,17 +77,13 @@ func initLogRotator(logFile string) {
 		fmt.Fprintf(os.Stderr, "failed to create log directory: %v\n", err)
 		os.Exit(1)
 	}
-	pr, pw := io.Pipe()
-	r, err := rotator.New(pr, logFile, 10*1024, false, 3)
+	r, err := rotator.New(logFile, 10*1024, false, 3)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create file rotator: %v\n", err)
 		os.Exit(1)
 	}
 
-	go r.Run()
-
 	logRotator = r
-	logRotatorPipe = pw
 }
 
 // setLogLevel sets the logging level for provided subsystem.  Invalid

--- a/backend/stakepoold/server.go
+++ b/backend/stakepoold/server.go
@@ -271,7 +271,6 @@ func runMain() int {
 		log.Infof("CTRL+C hit.  Closing goroutines.")
 		//saveData(ctx)
 		close(ctx.quit)
-		return
 	}()
 
 	ctx.wg.Add(3)

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
 hash: b5a90eed086645c55dcbc833f06e494590dee0fa95b3ff31aaea5e079c81cea1
-updated: 2017-06-20T14:32:28.9277967-04:00
+updated: 2017-06-28T16:07:28.893474-04:00
 imports:
 - name: github.com/agl/ed25519
   version: 278e1ec8e8a6e017cd07577924d6766039146ced
   subpackages:
   - edwards25519
 - name: github.com/btcsuite/btclog
-  version: 30bef3d5a6b4600e2129de8b6527ffcc1ee397ca
+  version: 84c8d2346e9fc8c7b947e243b9c24e6df9fd206a
 - name: github.com/btcsuite/go-flags
   version: 6c288d648c1cc1befcb90cb5511dcacf64ae8e61
 - name: github.com/btcsuite/go-socks
@@ -22,7 +22,7 @@ imports:
 - name: github.com/decred/blake256
   version: a840e32d7c31fe2e0218607334cb120a683951a4
 - name: github.com/decred/dcrd
-  version: ce4b77d3d9e3a4d3393e1fa3baeee5679cad518d
+  version: 713164983204ef44185aa4cd6a48fed096188d46
   subpackages:
   - blockchain
   - blockchain/internal/dbnamespace
@@ -49,13 +49,12 @@ imports:
   - base58
   - hdkeychain
 - name: github.com/decred/dcrwallet
-  version: 56954e8ce2d801e35d5df5524d32983268dc64c2
+  version: fdc45f39a468305fa966b6c7407a7d813a3311ca
   subpackages:
   - apperrors
   - chain
   - internal/zero
   - snacl
-  - wallet/txrules
   - wallet/udb
   - walletdb
 - name: github.com/dgrijalva/jwt-go
@@ -78,7 +77,7 @@ imports:
 - name: github.com/haisum/recaptcha
   version: 7d3b8053900e7a0f549a11e800649a5fa950700f
 - name: github.com/jrick/logrotate
-  version: 4ed05ed86ef17d10ff99cce77481e0fcf6f2c7b0
+  version: a93b200c26cbae3bb09dd0dc2c7c7fe1468a034a
   subpackages:
   - rotator
 - name: github.com/zenazn/goji
@@ -90,7 +89,7 @@ imports:
   - web/middleware
   - web/mutil
 - name: golang.org/x/crypto
-  version: adbae1b6b6fb4b02448a0fc0dbbc9ba2b95b294d
+  version: 84f24dfdf3c414ed893ca1b318d0045ef5a1f607
   subpackages:
   - bcrypt
   - blowfish
@@ -101,7 +100,7 @@ imports:
   - salsa20/salsa
   - scrypt
 - name: golang.org/x/net
-  version: fe686d45ea04bc1bd4eff6a52865ce8757320325
+  version: 8663ed5da4fd087c3cfb99a996e628b72e2f0948
   subpackages:
   - context
   - http2
@@ -111,7 +110,7 @@ imports:
   - lex/httplex
   - trace
 - name: golang.org/x/text
-  version: 4e9ab9ee170f2a39bd66c92b3e0a47ff47a4bc77
+  version: 6353ef0f924300eea566d3438817aa4d3374817e
   subpackages:
   - secure/bidirule
   - transform

--- a/log.go
+++ b/log.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 
@@ -24,7 +23,7 @@ type logWriter struct{}
 
 func (logWriter) Write(p []byte) (n int, err error) {
 	os.Stdout.Write(p)
-	logRotatorPipe.Write(p)
+	logRotator.Write(p)
 	return len(p), nil
 }
 
@@ -46,10 +45,6 @@ var (
 	// logRotator is one of the logging outputs.  It should be closed on
 	// application shutdown.
 	logRotator *rotator.Rotator
-
-	// logRotatorPipe is the write-end pipe for writing to the log rotator.  It
-	// is written to by the Write method of the logWriter type.
-	logRotatorPipe *io.PipeWriter
 
 	controllersLog      = backendLog.Logger("CNTL")
 	log                 = backendLog.Logger("DCRS")
@@ -85,17 +80,13 @@ func initLogRotator(logFile string) {
 		fmt.Fprintf(os.Stderr, "failed to create log directory: %v\n", err)
 		os.Exit(1)
 	}
-	pr, pw := io.Pipe()
-	r, err := rotator.New(pr, logFile, 10*1024, false, 3)
+	r, err := rotator.New(logFile, 10*1024, false, 3)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create file rotator: %v\n", err)
 		os.Exit(1)
 	}
 
-	go r.Run()
-
 	logRotator = r
-	logRotatorPipe = pw
 }
 
 // setLogLevel sets the logging level for provided subsystem.  Invalid


### PR DESCRIPTION
This update adds additional callsite logging options via btclog and
fixes an error with the rotator package that caused it to stop running
when creating any log messages larger than 4096 bytes.

While here, switch to the new Write method of the Rotator object as
this is more efficient than using the Reader interface with a pipe.

Fixes #192.