### PR TITLE
mention wallet/script dependency and voting docs

### DIFF
--- a/views/address.html
+++ b/views/address.html
@@ -2,14 +2,33 @@
 <div class="wrapper">
     <div class="row">
   <div class="col-xs-15 col-md-8 col-lg-8 notication-col center-block">
-    {{range .Flash}}<div class="well well-notification  orange-notification">{{.}}</div>{{end}}
+    {{range .Flash}}<div class="well well-notification orange-notification">{{.}}</div>{{end}}
   </div>
     <div class="col-sm-15 col-md-10 text-left center-block">
        <h1>{{if .User.MultiSigAddress }}Address Submitted{{else}}Submit Address{{end}}</h1>
+     <p><strong>When you submit an address, the stake pool binds that address
+        from your wallet together with an address from the stake pool's voting
+        wallet.  This is done by creating a 1-of-2 multisignature script which
+        lets you, the pool, or both parties vote.  This "binding" of the wallets
+        means that if you ever delete your current wallet and create a new
+        wallet with a different seed, importing your multisignature script will
+        not work because it contains an address that is not present in your new
+        wallet.  Please contact your stake pool administrator or support staff
+        if you need to re-register with a new address from a new wallet.</strong></p>
 {{if .User.MultiSigAddress}}
      <div style="overflow:auto">
-        <p>Your public key address has been accepted and cannot be changed at this time.</p>
-        <p><b>Public Key Address:</b></p><p>{{ .User.UserPubKeyAddr }}</p>
+        <p><span style="font-size: larger;"><strong>Your public key address has
+        been accepted and registration is complete.  Please contact your stake
+        pool administrator or support staff if you need to re-register with a
+        new address from a new wallet.</strong></span></p>
+        <p><strong>Public Key Address:</strong> &nbsp;<strong>{{ .User.UserPubKeyAddr }}</strong></p>
+        <p><strong>If you wish to verify that this address belongs to your
+        wallet, you may run the following command:</strong></p>
+        <div class="cmd"><pre>
+$ dcrctl {{ if eq .Network "testnet"}}--testnet{{end}} --wallet validateaddress {{ .User.UserPubKeyAddr }}
+        </pre></div>
+        <p><strong>In the result, you will see fields such as "ismine" and
+        "account" if the address is present.</strong></p>
      </div>
 {{ else }}
         <p><strong>The official Decred GUI wallets
@@ -28,7 +47,7 @@
 
         <p>The directions below require that you
         have setup the Decred software and have obtained Decred that you can
-        purchase tickets with. The
+        purchase tickets with.  The
         <a href="https://docs.decred.org/getting-started/beginner-guide/">Getting Started</a>
         section of the <a href="https://docs.decred.org/">Decred Docs website</a>
         has operating system specific directions that covers all of the necessary
@@ -68,9 +87,9 @@ $ dcrctl {{ if eq .Network "testnet"}}--testnet{{end}} --wallet validateaddress 
         <p>Copy and paste the <b>pubkeyaddr</b>
         that starts with
         <b>{{ if eq .Network "mainnet"}}D{{end}}{{ if eq .Network "testnet"}}T{{end}}k</b>
-        into the form below. Once your 1-of-2 multisig P2SH address has been generated,
+        into the form below. If the registration process is successful, then
         instructions will be given on how to purchase tickets that the pool and
-        yourself can use to vote.</p>
+        yourself can vote with when called upon to do so by the network.</p>
 
                 <form method="post" class="form-horizontal">
                         <div class="form-group">

--- a/views/tickets.html
+++ b/views/tickets.html
@@ -55,37 +55,51 @@
 			The <a href="https://docs.decred.org/getting-started/user-guides/dcrwallet-tickets/">dcrwallet instructions</a>
       are the most helpful if you wish to continue on the command-line path.</p>
 			<p><strong><u>Step 2</u></strong></p>
-			<p>Your P2SH multisignature script for delegating votes has been generated. Please first import it locally into your wallet using <b>dcrctl</b> for safe keeping, so you can recover your funds and vote in the unlikely event of a pool failure:</p>
+			<p>Your multisignature script for delegating votes has been generated.
+			Please first import it locally into your wallet using <b>dcrctl</b> for
+			safe keeping, so you can recover your funds and vote in the unlikely
+			event of a pool failure:</p>
 
 			<p>dcrctl --wallet importscript "script"</p>
 			<p>For example:</p>
 			<div class="cmd"><pre>$ dcrctl {{ if eq .Network "testnet"}}--testnet{{end}} --wallet importscript {{ .User.MultiSigScript }}</pre></div>
 
-			<p>After successfully importing the script into your wallet, you may generate tickets delegated to the pool in either of two ways:</p>
+			<p>After successfully importing the script into your wallet, you may
+				purchase tickets with voting rights delegated to the pool in either of
+				two ways:</p>
 
 			<p><strong><u>Step 3</u></strong></p>
-			<p><strong>Option A - dcrwallet - Automatic purchasing</strong> (Recommended)</p>
+			<p><strong>Option A - dcrwallet - Automatic purchasing</strong></p>
 			<p>Stop dcrwallet if it is currently running and add the following to <strong>dcrwallet.conf</strong>:</p>
 <pre>
 [Application Options]
-enableticketbuyer=1
+enableticketbuyer=true
 pooladdress={{ .User.UserFeeAddr }}
 poolfees={{ .PoolFees }}
 ticketaddress={{ .User.MultiSigAddress }}
 [Ticket Buyer Options]
-ticketbuyer.maxpriceabsolute=58
+ticketbuyer.maxpriceabsolute=100
 </pre>
       <p>Unlock dcrwallet and it will automatically purchase stake tickets delegated to the pool address.</p>
 
-			<p><strong>Option B - dcrwallet - Manual purchasing</strong> (Not recommended)</p>
+			<p><strong>Option B - dcrwallet - Manual purchasing</strong></p>
 			<p>Start a wallet with funds available and manually purchase tickets with the following command using <strong>dcrctl</strong>:</p>
 			<p>dcrctl {{ if eq .Network "testnet"}}--testnet{{end}} --wallet purchaseticket "fromaccount" spendlimit minconf ticketaddress numtickets poolfeeaddress poolfeeamt</p>
 <pre>
-dcrctl {{ if eq .Network "testnet"}}--testnet{{end}} --wallet purchaseticket "default" 58 1 {{ .User.MultiSigAddress }} 1 {{ .User.UserFeeAddr }} {{ .PoolFees}}</pre>
+dcrctl {{ if eq .Network "testnet"}}--testnet{{end}} --wallet purchaseticket "default" 100 1 {{ .User.MultiSigAddress }} 1 {{ .User.UserFeeAddr }} {{ .PoolFees}}</pre>
 			<p>Will purchase a ticket delegated to the the multisig address which
 				allows either your or the pool to vote when the ticket is called. This
 				uses funds from the default account only if the current network price
-				for a ticket is less than 58.0 coins.</p>
+				for a ticket is less than 100.0 coins.</p>
+
+			<p><strong><u>Step 4 (Optional)</u></strong></p>
+			<p><strong>Voting</strong></p>
+			<p>If you wish to cast votes yourself, please review the guides
+			<a href="https://docs.decred.org/getting-started/user-guides/agenda-voting/#how-to-vote">How To Vote</a>
+			and
+			<a href="https://docs.decred.org/getting-started/user-guides/agenda-voting/#solo-voting">Solo-Voting</a>.
+			The preferences you set on this stake pool's <a href="/voting">voting page</a>
+			only affect the stake pool's voting wallets and not your own.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Mention that the generated multisigscript depends on both wallets and tell them to talk to the pool admin/support staff if they need to change it.

Closes #195.

Some other minor stuff:

- Point to voting docs in case they want to self-vote with the CLI wallet.
- Update example price to be more realistic.
- No longer explicitly recommend auto-ticketbuying over manual now that the ticket pricing algorithm is more sane.