### PR TITLE
handle user with all invalid tickets case properly

### DIFF
--- a/controllers/main.go
+++ b/controllers/main.go
@@ -1775,7 +1775,9 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 				}
 			}
 		}
+	}
 
+	if spui != nil && len(spui.InvalidTickets) > 0 {
 		for _, ticket := range spui.InvalidTickets {
 			ticketInfoInvalid = append(ticketInfoInvalid, TicketInfoInvalid{ticket})
 		}

--- a/views/tickets.html
+++ b/views/tickets.html
@@ -286,7 +286,7 @@ dcrctl {{ if eq .Network "testnet"}}--testnet{{end}} --wallet purchaseticket "de
         Invalid Tickets</a>
       </h4>
     </div>
-    <div id="collapse-invalidlist" class="panel-collapse collapse">
+    <div id="collapse-invalidlist" class="panel-collapse collapse {{if .TicketsInvalid }}in{{end}}">
       <div class="panel-body">
 			{{if not .TicketsInvalid}}
 			<p><strong>No tickets.</strong></p>


### PR DESCRIPTION
If a user had all invalid tickets and none of any other kind, we wouldn't even hit the part of the loop where they are added.

Closes #205.