### PR TITLE
remove voting prioritization

### DIFF
--- a/backend/stakepoold/ntfnhandlers.go
+++ b/backend/stakepoold/ntfnhandlers.go
@@ -7,36 +7,10 @@ import (
 	"github.com/decred/dcrrpcclient"
 )
 
-// checkIfBlockSeen increments the NeedToVote waitgroup by 1 if the block
-// has not been seen yet and records that it has been seen.
-func checkIfBlockSeen(ctx *appContext, ntfnName string, blockHash *chainhash.Hash, blockHeight int64) {
-	hasBeenSeen := true
-
-	ctx.Lock()
-	if !ctx.lastBlockSeenHash.IsEqual(blockHash) || ctx.lastBlockSeenHeight != blockHeight {
-		hasBeenSeen = false
-		ctx.wgNeedToVote.Add(1)
-		ctx.lastBlockSeenHash = blockHash
-		ctx.lastBlockSeenHeight = blockHeight
-	}
-	ctx.Unlock()
-
-	// Log notification information outside of the handler.
-	go func() {
-		log.Debugf("ntfn %s blockHeight %v blockHash %v", ntfnName, blockHeight,
-			blockHash)
-		if !hasBeenSeen {
-			log.Debugf("incremented wgNeedToVote for block height %v hash %v",
-				blockHeight, blockHash)
-		}
-	}()
-}
-
 // Define notification handlers
 func getNodeNtfnHandlers(ctx *appContext, connCfg *dcrrpcclient.ConnConfig) *dcrrpcclient.NotificationHandlers {
 	return &dcrrpcclient.NotificationHandlers{
 		OnNewTickets: func(blockHash *chainhash.Hash, blockHeight int64, stakeDifficulty int64, tickets []*chainhash.Hash) {
-			checkIfBlockSeen(ctx, "OnNewTickets", blockHash, blockHeight)
 			nt := NewTicketsForBlock{
 				blockHash:   blockHash,
 				blockHeight: blockHeight,
@@ -45,7 +19,6 @@ func getNodeNtfnHandlers(ctx *appContext, connCfg *dcrrpcclient.ConnConfig) *dcr
 			ctx.newTicketsChan <- nt
 		},
 		OnSpentAndMissedTickets: func(blockHash *chainhash.Hash, blockHeight int64, stakeDifficulty int64, tickets map[chainhash.Hash]bool) {
-			checkIfBlockSeen(ctx, "OnSpentAndMissedTickets", blockHash, blockHeight)
 			ticketsFixed := make(map[*chainhash.Hash]bool)
 			for ticketHash, spent := range tickets {
 				ticketHash := ticketHash
@@ -59,7 +32,6 @@ func getNodeNtfnHandlers(ctx *appContext, connCfg *dcrrpcclient.ConnConfig) *dcr
 			ctx.spentmissedTicketsChan <- smt
 		},
 		OnWinningTickets: func(blockHash *chainhash.Hash, blockHeight int64, winningTickets []*chainhash.Hash) {
-			checkIfBlockSeen(ctx, "OnWinningTickets", blockHash, blockHeight)
 			wt := WinningTicketsForBlock{
 				blockHash:      blockHash,
 				blockHeight:    blockHeight,


### PR DESCRIPTION
We went back and forth in #178 on different ways to implement prioritize handling of the winning tickets notification/voting over the other notifications.

As we can see from #211, a waitgroup is not the right solution. It essentially makes us stateful but that doesn't work since dcrwallet may send us 0 or 2 voting notifications, rather than the 1 we expect to get 99.9% of the time.

~~Opened for discussion. This is a WIP (mostly because I haven't tested it yet)~~

Closes #211.