### PR TITLE
bugfix: init grpcConnections with zero len

### DIFF
--- a/server.go
+++ b/server.go
@@ -104,10 +104,10 @@ func runMain() int {
 
 	// Supported API versions are advertised in the API stats result
 	APIVersionsSupported := []int{1, 2}
-	
-       var grpcConnections []*grpc.ClientConn
-       if cfg.EnableStakepoold && len(cfg.StakepooldHosts) > 0 {
-               grpcConnections = make([]*grpc.ClientConn, len(cfg.StakepooldHosts))
+
+	var grpcConnections []*grpc.ClientConn
+	if cfg.EnableStakepoold && len(cfg.StakepooldHosts) > 0 {
+		grpcConnections = make([]*grpc.ClientConn, len(cfg.StakepooldHosts))
 		for i := range cfg.StakepooldHosts {
 			grpcConnections[i], err = stakepooldclient.ConnectStakepooldGRPC(cfg.StakepooldHosts, cfg.StakepooldCerts, i)
 			if err != nil {
@@ -116,7 +116,7 @@ func runMain() int {
 			}
 		}
 	}
-	
+
 	controller, err := controllers.NewMainController(activeNetParams.Params,
 		cfg.AdminIPs, cfg.AdminUserIDs, cfg.APISecret, APIVersionsSupported, cfg.BaseURL,
 		cfg.ClosePool, cfg.ClosePoolMsg, cfg.EnableStakepoold,

--- a/server.go
+++ b/server.go
@@ -105,7 +105,7 @@ func runMain() int {
 	// Supported API versions are advertised in the API stats result
 	APIVersionsSupported := []int{1, 2}
 
-	grpcConnections := make([]*grpc.ClientConn, len(cfg.StakepooldHosts))
+	grpcConnections := make([]*grpc.ClientConn, 0, len(cfg.StakepooldHosts))
 
 	if cfg.EnableStakepoold {
 		for i := range cfg.StakepooldHosts {

--- a/server.go
+++ b/server.go
@@ -105,7 +105,7 @@ func runMain() int {
 	// Supported API versions are advertised in the API stats result
 	APIVersionsSupported := []int{1, 2}
 
-	grpcConnections := make([]*grpc.ClientConn, 0, len(cfg.StakepooldHosts))
+	grpcConnections := make([]*grpc.ClientConn, len(cfg.StakepooldHosts))
 
 	if cfg.EnableStakepoold {
 		for i := range cfg.StakepooldHosts {
@@ -115,6 +115,8 @@ func runMain() int {
 				return 8
 			}
 		}
+	} else {
+		grpcConnections = make([]*grpc.ClientConn, 0)
 	}
 
 	controller, err := controllers.NewMainController(activeNetParams.Params,

--- a/server.go
+++ b/server.go
@@ -104,10 +104,10 @@ func runMain() int {
 
 	// Supported API versions are advertised in the API stats result
 	APIVersionsSupported := []int{1, 2}
-
-	grpcConnections := make([]*grpc.ClientConn, len(cfg.StakepooldHosts))
-
-	if cfg.EnableStakepoold {
+	
+       var grpcConnections []*grpc.ClientConn
+       if cfg.EnableStakepoold && len(cfg.StakepooldHosts) > 0 {
+               grpcConnections = make([]*grpc.ClientConn, len(cfg.StakepooldHosts))
 		for i := range cfg.StakepooldHosts {
 			grpcConnections[i], err = stakepooldclient.ConnectStakepooldGRPC(cfg.StakepooldHosts, cfg.StakepooldCerts, i)
 			if err != nil {
@@ -115,10 +115,8 @@ func runMain() int {
 				return 8
 			}
 		}
-	} else {
-		grpcConnections = make([]*grpc.ClientConn, 0)
 	}
-
+	
 	controller, err := controllers.NewMainController(activeNetParams.Params,
 		cfg.AdminIPs, cfg.AdminUserIDs, cfg.APISecret, APIVersionsSupported, cfg.BaseURL,
 		cfg.ClosePool, cfg.ClosePoolMsg, cfg.EnableStakepoold,


### PR DESCRIPTION
Hello. @dajohi 
This PR is about #231, now we reinit the grpcConnections with zero len when disable stakepoold to avoid  nil deference:)