### PR TITLE
config: use cfg.HomeDir to replace defaultHomeDir

### DIFF
--- a/backend/stakepoold/config.go
+++ b/backend/stakepoold/config.go
@@ -365,7 +365,7 @@ func loadConfig() (*config, []string, error) {
 
 	// Create the home directory if it doesn't already exist.
 	funcName := "loadConfig"
-	err = os.MkdirAll(defaultHomeDir, 0700)
+	err = os.MkdirAll(cfg.HomeDir, 0700)
 	if err != nil {
 		// Show a nicer error message if it's because a symlink is
 		// linked to a directory that does not exist (probably because


### PR DESCRIPTION
Now we use the defaultHomeDir to create dir, it could failed when user change the home dir to another.