### PR TITLE
Abort stakepoold startup if cannot get tickets

### DIFF
--- a/backend/stakepoold/rpcclient.go
+++ b/backend/stakepoold/rpcclient.go
@@ -111,7 +111,7 @@ func connectWalletRPC(cfg *config) (*rpcclient.Client, semver, error) {
 	return dcrwClient, walletVer, nil
 }
 
-func walletGetTickets(ctx *appContext, currentHeight int64) (map[chainhash.Hash]string, map[chainhash.Hash]string) {
+func walletGetTickets(ctx *appContext, currentHeight int64) (map[chainhash.Hash]string, map[chainhash.Hash]string, error) {
 	blockHashToHeightCache := make(map[chainhash.Hash]int32)
 
 	// This is suboptimal to copy and needs fixing.
@@ -133,7 +133,7 @@ func walletGetTickets(ctx *appContext, currentHeight int64) (map[chainhash.Hash]
 
 	if err != nil {
 		log.Warnf("GetTickets failed: %v", err)
-		return ignoredLowFeeTickets, liveTickets
+		return ignoredLowFeeTickets, liveTickets, err
 	}
 
 	type promise struct {
@@ -231,5 +231,5 @@ func walletGetTickets(ctx *appContext, currentHeight int64) (map[chainhash.Hash]
 		len(ignoredLowFeeTickets), normalFee, len(liveTickets),
 		len(tickets))
 
-	return ignoredLowFeeTickets, liveTickets
+	return ignoredLowFeeTickets, liveTickets, nil
 }

--- a/backend/stakepoold/server.go
+++ b/backend/stakepoold/server.go
@@ -437,7 +437,11 @@ func runMain() error {
 		}
 		log.Infof("current block height %v hash %v", curHeight, curHash)
 
-		ctx.ignoredLowFeeTicketsMSA, ctx.liveTicketsMSA = walletGetTickets(ctx, curHeight)
+		ctx.ignoredLowFeeTicketsMSA, ctx.liveTicketsMSA, err = walletGetTickets(ctx, curHeight)
+		if err != nil {
+			log.Errorf("unable to get tickets: %v", err)
+			return err
+		}
 
 		afterHash, afterHeight, err := nodeConn.GetBestBlock()
 		if err != nil {


### PR DESCRIPTION
If stakepoold starts while dcrd RPC is inactive, it will fail to get any
tickets but will continue to start nonetheless. Therefore it won't watch
for any tickets and this will lead to missed votes.

This commit ensures that stakepoold won't silently ignore this error. It
is recommended to use a process supervisor to keep restarting stakepoold
until the RPC is ready.

---

Log snippet of the issue (note the `result null` which should be an array of ticket hashes):

```
[INF] STPK: Calling GetTickets...
[TRC] RPCC: Sending command [gettickets] with id 3
[TRC] RPCC: Received response for id 3 (result null)
[INF] STPK: GetTickets: took 1.014074ms
[WRN] STPK: GetTickets failed: -1: Chain RPC is inactive
```