### PR TITLE
Remove superfluous assignment

### DIFF
--- a/controllers/main.go
+++ b/controllers/main.go
@@ -2134,7 +2134,6 @@ func (controller *MainController) Voting(c web.C, r *http.Request) (string, int)
 	c.Env["FlashError"] = session.Flashes("votingError")
 	c.Env["FlashSuccess"] = session.Flashes("votingSuccess")
 	c.Env["IsVoting"] = true
-	c.Env["User"] = user
 	c.Env["VoteVersion"] = controller.voteVersion
 
 	widgets := controller.Parse(t, "voting", c.Env)


### PR DESCRIPTION
`Env["User"]` is already set globally by the [ApplyAuth](https://github.com/decred/dcrstakepool/blob/1a3c844122667b585d42479e7da48ea68145450b/system/middleware.go#L96) middleware.