### PR TITLE
Bump wallet RPC API version to 5.0.0

### DIFF
--- a/backend/stakepoold/rpcclient.go
+++ b/backend/stakepoold/rpcclient.go
@@ -12,7 +12,7 @@ import (
 )
 
 var requiredChainServerAPI = semver{major: 3, minor: 1, patch: 0}
-var requiredWalletAPI = semver{major: 4, minor: 1, patch: 0}
+var requiredWalletAPI = semver{major: 5, minor: 0, patch: 0}
 
 func connectNodeRPC(ctx *appContext, cfg *config) (*rpcclient.Client, semver, error) {
 	var nodeVer semver

--- a/backend/stakepoold/server.go
+++ b/backend/stakepoold/server.go
@@ -334,9 +334,9 @@ func runMain() error {
 
 	addedLowFeeTicketsMSA, errMySQLFetchAddedLowFeeTickets := userData.MySQLFetchAddedLowFeeTickets()
 	if errMySQLFetchAddedLowFeeTickets != nil {
-		log.Errorf("could not obtain voting config from MySQL: %v", err)
+		log.Errorf("could not obtain low fee tickets from MySQL: %v", err)
 	} else {
-		log.Infof("loaded prefs for %d users from MySQL", len(addedLowFeeTicketsMSA))
+		log.Infof("loaded low fee tickets for %d users from MySQL", len(addedLowFeeTicketsMSA))
 	}
 
 	userVotingConfig, errMySQLFetchUserVotingConfig := userData.MySQLFetchUserVotingConfig()


### PR DESCRIPTION
Wallet legacy RPC version was bumped from 4.1.0 to 5.0.0 in dcrwallet commit: https://github.com/decred/dcrwallet/commit/c1da68c40d2d4260beca96e8ed75cc91cfa0d0ce
(sendtosstx was removed, and this was not used by dcrstakepool/stakepoold)

Also fix some incorrect logging messages.
  