### PR TITLE
Correct licensing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2017 The Decred developers
+Copyright (c) 2015-2018 The Decred developers
 Copyright (c) 2016, Jonathan Chappelow
 Copyright (c) 2014 Pawel Szymanski (pawel@mikesz.com)
 Copyright (c) HARUYAMA Seigo <hauyama@unixuser.org>
@@ -22,3 +22,20 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+The ISC License (ISC)
+
+Copyright (c) 2013-2016 The btcsuite developers
+Copyright (c) 2015-2018 The Decred developers
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -330,7 +330,8 @@ is used for this project.
 
 ## License
 
-dcrstakepool is licensed under the [copyfree](http://copyfree.org) ISC License.
+dcrstakepool is licensed under the [copyfree](http://copyfree.org) MIT/X11 and
+ISC Licenses.
 
 ## Version History
 - 1.1.0 - Architecture change.


### PR DESCRIPTION
This project contains code governed by the MIT/X11 and ISC licenses.
The ISC license and copyrights have been added to the LICENSE file in
the root of the project, and the README has been updated to reflect
the current licensing.