### PR TITLE
Repress logs for unfound ticket lookups.

### DIFF
--- a/backend/stakepoold/server.go
+++ b/backend/stakepoold/server.go
@@ -95,7 +95,7 @@ type WinningTicketsForBlock struct {
 var (
 	cfg              *config
 	errDuplicateVote = "-32603: already have transaction "
-	errNoTxInfo      = "-5: No information for transaction"
+	errNoTxInfo      = "-5: no information for transaction"
 	errSuccess       = errors.New("success")
 
 	dataFilenameTemplate = "KIND-DATE-VERSION.gob"


### PR DESCRIPTION
The error string created by the dcrwallet JSON-RPC gettransaction when a
transaction is not found changed in the 1.3.0 release.  This change modifies
stakepoold to repress the newly-formatted errors from being logged.

While here, include a gofmt fix from Go 1.11.