### PR TITLE
replace recaptcha with self-hosted captcha

### DIFF
--- a/config.go
+++ b/config.go
@@ -20,29 +20,27 @@ import (
 )
 
 const (
-	defaultBaseURL          = "http://127.0.0.1:8000"
-	defaultClosePoolMsg     = "The voting service is temporarily closed to new signups."
-	defaultConfigFilename   = "dcrstakepool.conf"
-	defaultDataDirname      = "data"
-	defaultLogLevel         = "info"
-	defaultLogDirname       = "logs"
-	defaultLogFilename      = "dcrstakepool.log"
-	defaultCookieSecure     = false
-	defaultDBHost           = "localhost"
-	defaultDBName           = "stakepool"
-	defaultDBPort           = "3306"
-	defaultDBUser           = "stakepool"
-	defaultListen           = ":8000"
-	defaultPoolEmail        = "admin@example.com"
-	defaultPoolFees         = 7.5
-	defaultPoolLink         = "https://forum.decred.org/threads/rfp-6-setup-and-operate-10-stake-pools.1361/"
-	defaultPublicPath       = "public"
-	defaultTemplatePath     = "views"
-	defaultRecaptchaSecret  = "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe"
-	defaultRecaptchaSitekey = "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"
-	defaultSMTPHost         = ""
-	defaultMinServers       = 2
-	defaultMaxVotedAge      = 8640
+	defaultBaseURL        = "http://127.0.0.1:8000"
+	defaultClosePoolMsg   = "The voting service is temporarily closed to new signups."
+	defaultConfigFilename = "dcrstakepool.conf"
+	defaultDataDirname    = "data"
+	defaultLogLevel       = "info"
+	defaultLogDirname     = "logs"
+	defaultLogFilename    = "dcrstakepool.log"
+	defaultCookieSecure   = false
+	defaultDBHost         = "localhost"
+	defaultDBName         = "stakepool"
+	defaultDBPort         = "3306"
+	defaultDBUser         = "stakepool"
+	defaultListen         = ":8000"
+	defaultPoolEmail      = "admin@example.com"
+	defaultPoolFees       = 7.5
+	defaultPoolLink       = "https://forum.decred.org/threads/rfp-6-setup-and-operate-10-stake-pools.1361/"
+	defaultPublicPath     = "public"
+	defaultTemplatePath   = "views"
+	defaultSMTPHost       = ""
+	defaultMinServers     = 2
+	defaultMaxVotedAge    = 8640
 )
 
 var (
@@ -85,8 +83,6 @@ type config struct {
 	DBName             string   `long:"dbname" description:"Name of database"`
 	PublicPath         string   `long:"publicpath" description:"Path to the public folder which contains css/fonts/images/javascript."`
 	TemplatePath       string   `long:"templatepath" description:"Path to the views folder which contains html files."`
-	RecaptchaSecret    string   `long:"recaptchasecret" description:"Recaptcha Secret"`
-	RecaptchaSitekey   string   `long:"recaptchasitekey" description:"Recaptcha Sitekey"`
 	PoolEmail          string   `long:"poolemail" description:"Email address to for support inquiries"`
 	PoolFees           float64  `long:"poolfees" description:"The per-ticket fees the user must send to the pool with their tickets"`
 	PoolLink           string   `long:"poollink" description:"URL for support inquiries such as forum, IRC, etc"`
@@ -282,30 +278,28 @@ func newConfigParser(cfg *config, so *serviceOptions, options flags.Options) *fl
 func loadConfig() (*config, []string, error) {
 	// Default config.
 	cfg := config{
-		BaseURL:          defaultBaseURL,
-		ClosePool:        false,
-		ClosePoolMsg:     defaultClosePoolMsg,
-		ConfigFile:       defaultConfigFile,
-		DebugLevel:       defaultLogLevel,
-		DataDir:          defaultDataDir,
-		LogDir:           defaultLogDir,
-		CookieSecure:     defaultCookieSecure,
-		DBHost:           defaultDBHost,
-		DBName:           defaultDBName,
-		DBPort:           defaultDBPort,
-		DBUser:           defaultDBUser,
-		Listen:           defaultListen,
-		PoolEmail:        defaultPoolEmail,
-		PoolFees:         defaultPoolFees,
-		PoolLink:         defaultPoolLink,
-		PublicPath:       defaultPublicPath,
-		TemplatePath:     defaultTemplatePath,
-		RecaptchaSecret:  defaultRecaptchaSecret,
-		RecaptchaSitekey: defaultRecaptchaSitekey,
-		SMTPHost:         defaultSMTPHost,
-		Version:          version(),
-		MinServers:       defaultMinServers,
-		MaxVotedAge:      defaultMaxVotedAge,
+		BaseURL:      defaultBaseURL,
+		ClosePool:    false,
+		ClosePoolMsg: defaultClosePoolMsg,
+		ConfigFile:   defaultConfigFile,
+		DebugLevel:   defaultLogLevel,
+		DataDir:      defaultDataDir,
+		LogDir:       defaultLogDir,
+		CookieSecure: defaultCookieSecure,
+		DBHost:       defaultDBHost,
+		DBName:       defaultDBName,
+		DBPort:       defaultDBPort,
+		DBUser:       defaultDBUser,
+		Listen:       defaultListen,
+		PoolEmail:    defaultPoolEmail,
+		PoolFees:     defaultPoolFees,
+		PoolLink:     defaultPoolLink,
+		PublicPath:   defaultPublicPath,
+		TemplatePath: defaultTemplatePath,
+		SMTPHost:     defaultSMTPHost,
+		Version:      version(),
+		MinServers:   defaultMinServers,
+		MaxVotedAge:  defaultMaxVotedAge,
 	}
 
 	// Service options which are only added on Windows.

--- a/controllers/captcha.go
+++ b/controllers/captcha.go
@@ -1,0 +1,77 @@
+package controllers
+
+import (
+	"bytes"
+	"net/http"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/dchest/captcha"
+	"github.com/zenazn/goji/web"
+)
+
+type CaptchaHandler struct {
+	ImgWidth  int
+	ImgHeight int
+}
+
+func (controller *MainController) CaptchaServe(c web.C, w http.ResponseWriter, r *http.Request) {
+	// Get the captcha id by stripping the file extension.
+	_, file := path.Split(r.URL.Path)
+	ext := path.Ext(file)
+	id := strings.TrimSuffix(file, ext)
+	if ext != ".png" || id == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	h := controller.captchaHandler
+
+	if r.FormValue("reload") != "" {
+		captcha.Reload(id)
+	}
+
+	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+	w.Header().Set("Pragma", "no-cache")
+	w.Header().Set("Expires", "0")
+
+	var content bytes.Buffer
+	w.Header().Set("Content-Type", "image/png")
+	err := captcha.WriteImage(&content, id, h.ImgWidth, h.ImgHeight)
+	if err != nil {
+		http.Error(w, "failed to generate captcha image", http.StatusInternalServerError)
+	}
+
+	http.ServeContent(w, r, id+ext, time.Time{}, bytes.NewReader(content.Bytes()))
+}
+
+func (controller *MainController) CaptchaVerify(c web.C, w http.ResponseWriter, r *http.Request) {
+	id, solution := r.FormValue("captchaId"), r.FormValue("captchaSolution")
+	if id == "" {
+		http.Error(w, "invalid captcha id", http.StatusBadRequest)
+		return
+	}
+
+	session := controller.GetSession(c)
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	var status int
+	if captcha.VerifyString(id, solution) {
+		session.Values["CaptchaDone"] = true
+		status = http.StatusFound
+	} else {
+		session.Values["CaptchaDone"] = false
+		status = http.StatusBadRequest
+	}
+
+	if err := session.Save(r, w); err != nil {
+		log.Criticalf("session.Save() failed: %v", err)
+		http.Error(w, "failed to save session", http.StatusInternalServerError)
+	}
+
+	ref := r.Referer()
+	if ref == "" {
+		ref = "/"
+	}
+	http.Redirect(w, r, ref, status)
+}

--- a/controllers/captcha.go
+++ b/controllers/captcha.go
@@ -55,13 +55,12 @@ func (controller *MainController) CaptchaVerify(c web.C, w http.ResponseWriter, 
 
 	session := controller.GetSession(c)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	var status int
 	if captcha.VerifyString(id, solution) {
 		session.Values["CaptchaDone"] = true
-		status = http.StatusFound
 	} else {
 		session.Values["CaptchaDone"] = false
-		status = http.StatusBadRequest
+		session.AddFlash("Captcha verification failed. Please try again.",
+			"captchaFailed")
 	}
 
 	if err := session.Save(r, w); err != nil {
@@ -73,5 +72,5 @@ func (controller *MainController) CaptchaVerify(c web.C, w http.ResponseWriter, 
 	if ref == "" {
 		ref = "/"
 	}
-	http.Redirect(w, r, ref, status)
+	http.Redirect(w, r, ref, http.StatusFound)
 }

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -1362,7 +1362,7 @@ func (controller *MainController) Index(c web.C, r *http.Request) (string, int) 
 // PasswordReset renders the password reset page.
 func (controller *MainController) PasswordReset(c web.C, r *http.Request) (string, int) {
 	session := controller.GetSession(c)
-	c.Env["FlashError"] = session.Flashes("passwordresetError")
+	c.Env["FlashError"] = append(session.Flashes("passwordresetError"), session.Flashes("captchaFailed")...)
 	c.Env["FlashSuccess"] = session.Flashes("passwordresetSuccess")
 	c.Env["IsPasswordReset"] = true
 	if controller.smtpHost == "" {
@@ -1385,7 +1385,7 @@ func (controller *MainController) PasswordResetPost(c web.C, r *http.Request) (s
 	dbMap := controller.GetDbMap(c)
 
 	if !controller.IsCaptchaDone(c) {
-		session.AddFlash("Captcha error", "passwordresetError")
+		session.AddFlash("You must complete the captcha.", "passwordresetError")
 		return controller.PasswordReset(c, r)
 	}
 
@@ -1565,7 +1565,7 @@ func (controller *MainController) Settings(c web.C, r *http.Request) (string, in
 
 	c.Env["Admin"], _ = controller.isAdmin(c, r)
 	c.Env["APIToken"] = user.APIToken
-	c.Env["FlashError"] = session.Flashes("settingsError")
+	c.Env["FlashError"] = append(session.Flashes("settingsError"), session.Flashes("captchaFailed")...)
 	c.Env["FlashSuccess"] = session.Flashes("settingsSuccess")
 	c.Env["IsSettings"] = true
 	if user.MultiSigAddress == "" {
@@ -1610,7 +1610,7 @@ func (controller *MainController) SettingsPost(c web.C, r *http.Request) (string
 		log.Infof("user requested email change from %v to %v", user.Email, newEmail)
 
 		if !controller.IsCaptchaDone(c) {
-			session.AddFlash("Captcha error", "settingsError")
+			session.AddFlash("You must complete the captcha.", "settingsError")
 			return controller.Settings(c, r)
 		}
 
@@ -1776,7 +1776,7 @@ func (controller *MainController) SignUp(c web.C, r *http.Request) (string, int)
 	}
 
 	session := controller.GetSession(c)
-	c.Env["FlashError"] = session.Flashes("signupError")
+	c.Env["FlashError"] = append(session.Flashes("signupError"), session.Flashes("captchaFailed")...)
 	c.Env["FlashSuccess"] = session.Flashes("signupSuccess")
 	c.Env["CaptchaID"] = captcha.New()
 
@@ -1798,7 +1798,7 @@ func (controller *MainController) SignUpPost(c web.C, r *http.Request) (string, 
 
 	session := controller.GetSession(c)
 	if !controller.IsCaptchaDone(c) {
-		session.AddFlash("Captcha error", "signupError")
+		session.AddFlash("You must complete the captcha.", "signupError")
 		return controller.SignUp(c, r)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/decred/dcrstakepool
 
 require (
 	github.com/btcsuite/go-flags v0.0.0-20150116065318-6c288d648c1c
+	github.com/dchest/captcha v0.0.0-20170622155422-6a29415a8364
 	github.com/decred/dcrd/blockchain/stake v1.1.0
 	github.com/decred/dcrd/certgen v1.0.2
 	github.com/decred/dcrd/chaincfg v1.3.0
@@ -19,7 +20,6 @@ require (
 	github.com/golang/protobuf v1.2.0
 	github.com/gorilla/context v1.1.1
 	github.com/gorilla/sessions v1.1.2
-	github.com/haisum/recaptcha v0.0.0-20170327142240-7d3b8053900e
 	github.com/jrick/logrotate v1.0.0
 	github.com/lib/pq v1.0.0 // indirect
 	github.com/mattn/go-sqlite3 v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
 github.com/dchest/blake256 v1.0.0/go.mod h1:xXNWCE1jsAP8DAjP+rKw2MbeqLczjI3TRx2VK+9OEYY=
+github.com/dchest/captcha v0.0.0-20170622155422-6a29415a8364 h1:U+BMqUt8LFgyrF0/NKgPZdr1sGZ3j6uBECpOGcISpFI=
+github.com/dchest/captcha v0.0.0-20170622155422-6a29415a8364/go.mod h1:QGrK8vMWWHQYQ3QU9bw9Y9OPNfxccGzfb41qjvVeXtY=
 github.com/dchest/siphash v1.2.0 h1:YWOShuhvg0GqbQpMa60QlCGtEyf7O7HC1Jf0VjdQ60M=
 github.com/dchest/siphash v1.2.0/go.mod h1:q+IRvb2gOSrUnYoPqHiyHXS0FOBBOdl6tONBlVnOnt4=
 github.com/decred/base58 v1.0.0 h1:BVi1FQCThIjZ0ehG+I99NJ51o0xcc9A/fDKhmJxY6+w=
@@ -117,8 +119,6 @@ github.com/gorilla/sessions v1.1.2 h1:4esMHhwKLQ9Odtku/p+onvH+eRJFWjV4y3iTDVWrZN
 github.com/gorilla/sessions v1.1.2/go.mod h1:8KCfur6+4Mqcc6S0FEfKuN15Vl5MgXW92AE8ovaJD0w=
 github.com/gorilla/websocket v1.2.0 h1:VJtLvh6VQym50czpZzx07z/kw9EgAxI3x1ZB8taTMQQ=
 github.com/gorilla/websocket v1.2.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/haisum/recaptcha v0.0.0-20170327142240-7d3b8053900e h1:SLxmrOPIeLANjk9W0BRT9I9w6YAaSTV/RhGAvCfV4io=
-github.com/haisum/recaptcha v0.0.0-20170327142240-7d3b8053900e/go.mod h1:4C2PL8L8RP6rj5QpimHOsQcMh1fecsamFK5aY2V7VBQ=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/sample-dcrstakepool.conf
+++ b/sample-dcrstakepool.conf
@@ -66,9 +66,6 @@ adminips=127.0.0.1
 ; Should match dcrwallet's configuration.
 ;poolfees=7.5
 
-; Recaptcha configuration.
-; recaptchax=
-
 ; Mail server to use.  Default is an empty string which disables email-based
 ; features like email verification of new users, password resets, and email
 ; address changes.  This mode is intended to primarily be used for testing.

--- a/sample-dcrstakepool.conf
+++ b/sample-dcrstakepool.conf
@@ -67,9 +67,7 @@ adminips=127.0.0.1
 ;poolfees=7.5
 
 ; Recaptcha configuration.
-; Register at https://www.google.com/recaptcha/admin
-;recaptchasitekey=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
-;recaptchasecret=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
+; recaptchax=
 
 ; Mail server to use.  Default is an empty string which disables email-based
 ; features like email verification of new users, password resets, and email

--- a/system/controller.go
+++ b/system/controller.go
@@ -28,6 +28,11 @@ func (controller *Controller) IsXhr(c web.C) bool {
 	return c.Env["IsXhr"].(bool)
 }
 
+func (controller *Controller) IsCaptchaDone(c web.C) bool {
+	done, ok := c.Env["CaptchaDone"].(bool)
+	return done && ok
+}
+
 func (controller *Controller) Parse(t *template.Template, name string, data interface{}) string {
 	var doc bytes.Buffer
 	err := t.ExecuteTemplate(&doc, name, data)

--- a/system/middleware.go
+++ b/system/middleware.go
@@ -82,6 +82,19 @@ func (application *Application) ApplyAPI(c *web.C, h http.Handler) http.Handler 
 	return http.HandlerFunc(fn)
 }
 
+func (application *Application) ApplyCaptcha(c *web.C, h http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		session := c.Env["Session"].(*sessions.Session)
+		if done, ok := session.Values["CaptchaDone"].(bool); ok {
+			c.Env["CaptchaDone"] = done
+		} else {
+			c.Env["CaptchaDone"] = false
+		}
+		h.ServeHTTP(w, r)
+	}
+	return http.HandlerFunc(fn)
+}
+
 func (application *Application) ApplyAuth(c *web.C, h http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		session := c.Env["Session"].(*sessions.Session)

--- a/views/auth/signup.html
+++ b/views/auth/signup.html
@@ -1,52 +1,71 @@
 {{define "auth/signup"}}
 <div class="wrapper">
-    <div class="row">
+  <div class="row">
     <div class="col-xs-15 col-md-8 col-lg-8 notication-col center-block">
-       {{if .SMTPDisabled }}<div class="well well-notification  orange-notification">Mail server not configured.  You will not receive an email verification link.</div>{{end}}
-	{{range .FlashError}}<div class="well well-notification  orange-notification">{{.}}</div>{{end}}
-	{{range .FlashSuccess}}<div class="well well-notification green-notification">{{.}}</div>{{end}}
-	{{if .IsClosed }}<div class="well well-notification  orange-notification">{{.ClosePoolMsg}}</div>{{end}}
-    </div>
+      {{if .SMTPDisabled }}<div class="well well-notification  orange-notification">Mail server not configured.  You will not receive an email verification link.</div>{{end}}
+      {{range .FlashError}}<div class="well well-notification  orange-notification">{{.}}</div>{{end}}
+      {{range .FlashSuccess}}<div class="well well-notification green-notification">{{.}}</div>{{end}}
+      {{if .IsClosed }}<div class="well well-notification  orange-notification">{{.ClosePoolMsg}}</div>{{end}}
+    </div> <!-- notication-col, etc. -->
     <div class="col-sm-15 col-md-6 text-left center-block">
-    <h1 style="{{if .FlashSuccess}}display: none;{{end}}">Sign Up</h1>
-    <form method="post" class="form-horizontal">
-  <div class="form-group" style="{{if .FlashSuccess}}display: none;{{end}}">
-    <label class="control-label col-sm-2" for="email">Email:</label>
-	<div class="col-sm-13">
-      <input name="email" type="email" class="form-control" placeholder="Email" required>
-	</div>
-  </div>
-  <div class="form-group" style="{{if .FlashSuccess}}display: none;{{end}}">
-    <label class="control-label col-sm-2" for="password">Password:</label>
-	<div class="col-sm-13">
-      <input name="password" type="password" class="form-control" id="password" placeholder="Password" required>
-	</div>
-  </div>
-  <div class="form-group" style="{{if .FlashSuccess}}display: none;{{end}}">
-    <label class="control-label col-sm-2" for="passwordrepeat">Password:</label>
-	<div class="col-sm-13">
-      <input name="passwordrepeat" type="password" class="form-control" placeholder="Password" required>
-	</div>
-  </div>
-
-  <div class="form-group" style="{{if .FlashSuccess}}display: none;{{end}}">
-     <div class="g-recaptcha pull-right" style="margin-right:8px" data-sitekey="{{.RecaptchaSiteKey}}" data-theme="light"></div>
-  </div>
-
-<div class="row">
-  <div class="form-group col-sm-8" style="{{if .FlashSuccess}}display: none;{{end}}">
-    <div class="col-md-button sign-in-button">
-      <button id="signin" name="signin" type="submit" class="btn btn-primary" {{if .IsClosed }}disabled{{end}}>Sign Up</button>
-    </div>
-  </div>
-
-  <div class="form-group col-sm-7 pull-right" style="{{if .FlashSuccess}}display: none;{{end}}">
-        <p><a href="/passwordreset">Forgot your password?</a></p>
-  </div>
-</div>
-	<input type="hidden" name="{{.CsrfKey}}" value={{.CsrfToken}}>
-    </form>
-    </div> 
-    </div>
-</div>
+      {{if .CaptchaDone}}
+      <h1 style="{{if .FlashSuccess}}display: none;{{end}}">Sign Up</h1>
+      <form method="post" class="form-horizontal">
+        <div class="form-group" style="{{if .FlashSuccess}}display: none;{{end}}">
+          <label class="control-label col-sm-2" for="email">Email:</label>
+          <div class="col-sm-13">
+            <input name="email" type="email" class="form-control" placeholder="Email" required>
+          </div>
+        </div>
+        <div class="form-group" style="{{if .FlashSuccess}}display: none;{{end}}">
+          <label class="control-label col-sm-2" for="password">Password:</label>
+          <div class="col-sm-13">
+              <input name="password" type="password" class="form-control" id="password" placeholder="Password" required>
+          </div>
+        </div>
+        <div class="form-group" style="{{if .FlashSuccess}}display: none;{{end}}">
+          <label class="control-label col-sm-2" for="passwordrepeat">Password:</label>
+          <div class="col-sm-13">
+              <input name="passwordrepeat" type="password" class="form-control" placeholder="Password" required>
+          </div>
+        </div>
+        <div class="row">
+          <div class="form-group col-sm-8" style="{{if .FlashSuccess}}display: none;{{end}}">
+            <div class="col-md-button sign-in-button">
+              <button id="signin" name="signin" type="submit" class="btn btn-primary" {{if .IsClosed }}disabled{{end}}>Sign Up</button>
+            </div>
+          </div>
+            <p><a href="/passwordreset">Forgot your password?</a></p>
+          </div>
+        </div>
+        <input type="hidden" name="{{.CsrfKey}}" value={{.CsrfToken}}>
+      </form>
+      {{else}}
+      <p>To sign up, first complete the captcha:</p>
+      <div class="row">
+        <div class="col-sm-10 center-block">
+          <img id=image src="/captchas/{{.CaptchaID}}.png" alt="your captcha image">
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-sm-15 text-left center-block">
+          <form action="/verifyhuman" method="post" class="form-horizontal">
+            <div class="form-group center-block">
+              <label class="control-label col-sm-4" for="captchaSolution">Text in picture:</label>
+              <div class="col-sm-8">
+                <input name=captchaSolution class="form-control">
+                <input type=hidden name=captchaId value="{{.CaptchaID}}">
+              </div>
+              <div class="col-md-button center-block text-middle">
+                <button name=captchaSubmit type=submit class="btn btn-primary">Submit</button>
+              </div>
+            </div>
+            <input type="hidden" name="{{.CsrfKey}}" value={{.CsrfToken}}>
+          </form>
+        </div>
+      </div>
+      {{end}}
+    </div> <!-- forms column -->
+  </div> <!-- row -->
+</div> <!-- wrapper -->
 {{end}}

--- a/views/footer.html
+++ b/views/footer.html
@@ -11,7 +11,6 @@
 <script src="assets/js/complete.js"></script>
 {{if .IsTickets }}
     <script src="assets/js/dataTables.responsive.js"></script>{{end}}
-{{if or (.IsPasswordReset) (.IsSignUp) (.IsSettings) }}<script src="https://www.google.com/recaptcha/api.js"></script>{{end}}
 {{if .IsStats }}
     <script src="assets/js/d3.min.js" charset="utf-8"></script>
     <script src="assets/js/d3pie.min.js"></script>

--- a/views/passwordreset.html
+++ b/views/passwordreset.html
@@ -1,36 +1,56 @@
 {{define "passwordreset"}}
 <div class="wrapper">
   <div class="row main-row">
-   <div class="col-xs-15 col-md-8 col-lg-8 notication-col center-block">
-	{{if .SMTPDisabled }}<div class="well well-notification  orange-notification">Mail server not configured.  You will not receive an password reset link.</div>{{end}}
-	{{range .FlashError}}<div class="well well-notification  orange-notification">{{.}}</div>{{end}}
-	{{range .FlashSuccess}}<div class="well well-notification green-notification">{{.}}</div>{{end}}
+    <div class="col-xs-15 col-md-8 col-lg-8 notication-col center-block">
+      {{if .SMTPDisabled }}<div class="well well-notification  orange-notification">Mail server not configured.  You will not receive an password reset link.</div>{{end}}
+      {{range .FlashError}}<div class="well well-notification  orange-notification">{{.}}</div>{{end}}
+      {{range .FlashSuccess}}<div class="well well-notification green-notification">{{.}}</div>{{end}}
     </div>
     <div class="col-sm-12 col-md-10 col-lg-6 center-block">
-	<h1>Password Reset</h1>
-	{{if .FlashSuccess}}
-	<p><span style="font-size: larger;">Check your email inbox, and click the link in the email you received to reset your password.</span></p>
-	{{end}}
-	<form method="post" class="form-horizontal">
-		<div class="form-group" style="{{if .FlashSuccess}}display: none;{{end}}">
-			<label for="inputEmail3" class="control-label">Email:</label>
-      			<input name="email" type="email" class="form-control sing-in-control email-control" id="email" placeholder="Email" required>
-  		</div>
-		<div class="form-group" style="{{if .FlashSuccess}}display: none;{{end}}">
-			<label class="col-md-4 control-label" for=""></label>
-			<div class="col-md-6">
-			<div class="g-recaptcha" data-sitekey="{{.RecaptchaSiteKey}}" data-theme="light"></div>
-			</div>
-		</div>
-		<div class="form-group" style="{{if .FlashSuccess}}display: none;{{end}}">
-			<label class="col-md-4 control-label" for="resetpassword"></label>
-			<div class="col-md-4">
-			<button id="resetpassword" name="signin" class="btn btn-primary">Reset Password</button>
-			</div>
-		</div>
-		<input type="hidden" name="{{.CsrfKey}}" value={{.CsrfToken}}>
-	</form>
-   </div>
-  </div>
-</div>
+      <h1>Password Reset</h1>
+      {{if .FlashSuccess}}
+      <p><span style="font-size: larger;">Check your email inbox, and click the link in the email you received to reset your password.</span></p>
+      {{end}}
+      {{if .CaptchaDone}}
+      <form method="post" class="form-horizontal">
+        <div class="form-group" style="{{if .FlashSuccess}}display: none;{{end}}">
+          <label for="inputEmail3" class="control-label">Email:</label>
+          <input name="email" type="email" class="form-control sing-in-control email-control" id="email" placeholder="Email" required>
+        </div>
+        <div class="form-group" style="{{if .FlashSuccess}}display: none;{{end}}">
+          <label class="col-md-4 control-label" for="resetpassword"></label>
+          <div class="col-md-4">
+            <button id="resetpassword" name="signin" class="btn btn-primary">Reset Password</button>
+          </div>
+        </div>
+        <input type="hidden" name="{{.CsrfKey}}" value={{.CsrfToken}}>
+      </form>
+      {{else}}
+      <p>To reset your password, first complete the captcha:</p>
+      <div class="row">
+        <div class="col-sm-10 center-block">
+          <img id=image src="/captchas/{{.CaptchaID}}.png" alt="your captcha image">
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-sm-15 text-left center-block">
+          <form action="/verifyhuman" method="post" class="form-horizontal">
+            <div class="form-group center-block">
+              <label class="control-label col-sm-4" for="captchaSolution">Text in picture:</label>
+              <div class="col-sm-8">
+                <input name=captchaSolution class="form-control">
+                <input type=hidden name=captchaId value="{{.CaptchaID}}">
+              </div>
+              <div class="col-md-button center-block text-middle">
+                <button name=captchaSubmit type=submit class="btn btn-primary">Submit</button>
+              </div>
+            </div>
+            <input type="hidden" name="{{.CsrfKey}}" value={{.CsrfToken}}>
+          </form>
+        </div>
+      </div>
+      {{end}}
+    </div> <!-- forms column -->
+  </div> <!-- row -->
+</div> <!-- wrapper -->
 {{end}}

--- a/views/settings.html
+++ b/views/settings.html
@@ -27,67 +27,85 @@
   <div class="col-sm-15 col-md-10 text-left center-block">
     <h1>Settings</h1>
  
-	<p><strong>API Token:</strong></p>
-	<pre>{{ .APIToken }}</pre>
-<hr />
+    <p><strong>API Token:</strong></p>
+    <pre>{{ .APIToken }}</pre>
+    <hr />
 
-	<h2>Change Email Address</h2>
-        <form method="post" class="form-horizontal">
-	 <div class="form-group">
-	  <label class="control-label col-sm-2" for="email">New Email:</label>
-	<div class="col-sm-13">
-	  <input id="email" name="email" placeholder="New Email Address" type="email" class="form-control" required>
-	</div>
-	 </div>
-	 <div class="form-group">
-	  <label class="control-label col-sm-2" for="emailpassword">Password:</label>
-	<div class="col-sm-13">
-	  <input id="emailpassword" name="password" placeholder="Password" type="password" class="form-control" required>
-	</div>
-	 </div>
-	<div class="form-group">
-         <div class="g-recaptcha pull-right" style="padding-right: 15px;" data-sitekey="{{.RecaptchaSiteKey}}" data-theme="light"></div>
-	</div>
-	<div class="form-group">
-         <button id="updateEmail" name="updateEmail" value="true" class="btn btn-primary">Change Email Address</button>
-	</div>
-	 <input type="hidden" name="{{.CsrfKey}}" value={{.CsrfToken}}>
-	</form>
+    <h2>Change Email Address</h2>
+    {{if .CaptchaDone}}
+    <form method="post" class="form-horizontal">
+      <div class="form-group">
+        <label class="control-label col-sm-2" for="email">New Email:</label>
+        <div class="col-sm-13">
+          <input id="email" name="email" placeholder="New Email Address" type="email" class="form-control" required>
+        </div>
+      </div>
+      <div class="form-group">
+        <label class="control-label col-sm-2" for="emailpassword">Password:</label>
+        <div class="col-sm-13">
+          <input id="emailpassword" name="password" placeholder="Password" type="password" class="form-control" required>
+        </div>
+      </div>
+      <div class="form-group">
+            <button id="updateEmail" name="updateEmail" value="true" class="btn btn-primary">Change Email Address</button>
+      </div>
+      <input type="hidden" name="{{.CsrfKey}}" value={{.CsrfToken}}>
+    </form>
+    {{else}}
+    <p>To change your email address, first complete the captcha:</p>
+    <div class="row">
+      <div class="col-sm-10 center-block">
+        <img id=image src="/captchas/{{.CaptchaID}}.png" alt="your captcha image">
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-sm-15 text-left center-block">
+        <form action="/verifyhuman" method="post" class="form-horizontal">
+          <div class="form-group center-block">
+            <label class="control-label col-sm-4" for="captchaSolution">Text in picture:</label>
+            <div class="col-sm-8">
+              <input name=captchaSolution class="form-control">
+              <input type=hidden name=captchaId value="{{.CaptchaID}}">
+            </div>
+            <div class="col-md-button center-block text-middle">
+              <button name=captchaSubmit type=submit class="btn btn-primary">Submit</button>
+            </div>
+          </div>
+          <input type="hidden" name="{{.CsrfKey}}" value={{.CsrfToken}}>
+        </form>
+      </div>
+    </div>
+    {{end}}
 
-<hr />
-	<h2>Change Password</h2>
-       <form class="form-horizontal" method="post">
-	<div class="form-group">
-          <label for="curpassword" class="control-label col-sm-2">Current<br />Password</label>
-	<div class="col-sm-13">
+    <hr />
+    <h2>Change Password</h2>
+    <form class="form-horizontal" method="post">
+      <div class="form-group">
+        <label for="curpassword" class="control-label col-sm-2">Current<br />Password</label>
+        <div class="col-sm-13">
           <input id="curpassword" name="password" type="password" placeholder="Current Password" class="form-control" required>
-	</div>
         </div>
-        <div class="form-group">
-          <label class="control-label col-sm-2" for="newpassword">New<br />Password</label>
-	<div class="col-sm-13">
+      </div>
+      <div class="form-group">
+        <label class="control-label col-sm-2" for="newpassword">New<br />Password</label>
+        <div class="col-sm-13">
           <input id="newpassword" name="newpassword" type="password" placeholder="New Password" class="form-control" required>
-	</div>
-	</div>
-	<div class="form-group">
-          <label class="control-label col-sm-2" for="newpasswordrepeat">Repeat New Password</label>
-	<div class="col-sm-13">
+        </div>
+      </div>
+      <div class="form-group">
+        <label class="control-label col-sm-2" for="newpasswordrepeat">Repeat New Password</label>
+        <div class="col-sm-13">
           <input id="newpasswordrepeat" name="newpasswordrepeat" type="password" placeholder="Repeat New Password" class="form-control" required>
-	</div>
         </div>
-        <div class="form-group">
-          <label class="control-label" for="updatepassword"></label>
-          <button id="updatepassword" name="updatePassword" value="true" class="btn btn-primary">Update Password</button>
-        </div>
-        <input type="hidden" name="{{.CsrfKey}}" value={{.CsrfToken}}>
-       </form>
-
-
-
-
-  </div>
-
- </div>
-</div>
+      </div>
+      <div class="form-group">
+        <label class="control-label" for="updatepassword"></label>
+        <button id="updatepassword" name="updatePassword" value="true" class="btn btn-primary">Update Password</button>
+      </div>
+      <input type="hidden" name="{{.CsrfKey}}" value={{.CsrfToken}}>
+    </form>
+  </div> <!-- forms column -->
+ </div> <!-- row -->
+</div> <!-- wrapper -->
 {{end}}
 


### PR DESCRIPTION
This replaces Google's reCAPTCHA with a self hosted captcha.

**NOTE**:  This is needs review and testing.  It works for me though.

Create controllers/captcha.go, where the captcha GET and POST handlers
are implemented for retrieving images and verifying responses.
Create `CaptchaHandler` type with image size spec, and add it as a field
of `MainController`.
Create `ApplyCaptcha` captcha middleware.
Add GET route for `/captchas` for serving the captcha images.
Add POST route for `/verifyhuman` for verifying captcha responses and
redirecting to the previous page with the session updated.
Modify http handlers to display new captcha: `PasswordReset`, `SignUp`, and
`Settings`.
Modify http handlers to check for captcha verification:
`PasswordResetPost`, `SignUpPost`, and `SettingsPost`.
Unrelated: remove unused empty `responseHeaderMap`.
Comment on how insane `core/(*Application).Route` is.