### PR TITLE
SMTP should not require user/pass auth

### DIFF
--- a/controllers/main.go
+++ b/controllers/main.go
@@ -144,7 +144,17 @@ func NewMainController(params *chaincfg.Params, adminIPs []string,
 		ImgWidth:  257,
 	}
 
-	smtpUrl := fmt.Sprintf("smtp://%s:%s@%s", smtpUsername, smtpPassword, smtpHost)
+	// Format: smtp://[username[:password]@]host
+        smtpUrl := "smtp://"
+        if smtpUsername != "" {
+             smtpUrl += smtpUsername
+             if smtpPassword != "" {
+                 smtpUrl += ":" + smtpPassword
+             }
+             smtpUrl += "@"
+        }
+        smtpUrl += smtpHost
+	
 	tlsConfig := tls.Config{}
 	smtpServer, err := goemail.NewSMTP(smtpUrl, &tlsConfig)
 	if err != nil {


### PR DESCRIPTION
The sprintf that was here would result in a string that assumes a blank user and password. smtp://:@host  This can cause an issue for local email relay if password is not required, yet net/smtp will receive a blank password from the parsed url.