### PR TITLE
controller: Never rescan during script imports

### DIFF
--- a/controllers/dcrclient.go
+++ b/controllers/dcrclient.go
@@ -337,7 +337,7 @@ func (w *walletSvrManager) executeInSequence(fn functionName, msg interface{}) i
 			if w.servers[i] == nil {
 				continue
 			}
-			err := s.ImportScriptRescanFrom(ism.script, true, ism.height)
+			err := s.ImportScriptRescan(ism.script, false)
 			isErrors[i] = err
 		}
 

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -145,16 +145,16 @@ func NewMainController(params *chaincfg.Params, adminIPs []string,
 	}
 
 	// Format: smtp://[username[:password]@]host
-        smtpUrl := "smtp://"
-        if smtpUsername != "" {
-             smtpUrl += smtpUsername
-             if smtpPassword != "" {
-                 smtpUrl += ":" + smtpPassword
-             }
-             smtpUrl += "@"
-        }
-        smtpUrl += smtpHost
-	
+	smtpUrl := "smtp://"
+	if smtpUsername != "" {
+		smtpUrl += smtpUsername
+		if smtpPassword != "" {
+			smtpUrl += ":" + smtpPassword
+		}
+		smtpUrl += "@"
+	}
+	smtpUrl += smtpHost
+
 	tlsConfig := tls.Config{}
 	smtpServer, err := goemail.NewSMTP(smtpUrl, &tlsConfig)
 	if err != nil {


### PR DESCRIPTION
The only scripts that are imported by the controller are ones that were just
created from a createmultisig RPC, and should not have any history that requires
a rescan to find previous outputs.  Remove the rescan request from the
importscript parameters to prevent the wallet (which no longer serializes and
batches rescan jobs) to prevent extraneous resource usage for unnecessary
rescans.