### PR TITLE
[WIP] use captcha fork with options and faster ServeHTTP

### DIFF
--- a/controllers/captcha.go
+++ b/controllers/captcha.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
 package controllers
 
 import (
@@ -7,13 +11,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dchest/captcha"
+	"github.com/chappjc/captcha"
 	"github.com/zenazn/goji/web"
 )
 
 type CaptchaHandler struct {
 	ImgWidth  int
 	ImgHeight int
+	Opts      *captcha.DistortionOpts
 }
 
 func (controller *MainController) CaptchaServe(c web.C, w http.ResponseWriter, r *http.Request) {
@@ -26,8 +31,6 @@ func (controller *MainController) CaptchaServe(c web.C, w http.ResponseWriter, r
 		return
 	}
 
-	h := controller.captchaHandler
-
 	if r.FormValue("reload") != "" {
 		captcha.Reload(id)
 	}
@@ -38,7 +41,8 @@ func (controller *MainController) CaptchaServe(c web.C, w http.ResponseWriter, r
 
 	var content bytes.Buffer
 	w.Header().Set("Content-Type", "image/png")
-	err := captcha.WriteImage(&content, id, h.ImgWidth, h.ImgHeight)
+	ch := controller.captchaHandler
+	err := captcha.WriteImage(&content, id, ch.ImgWidth, ch.ImgHeight, ch.Opts)
 	if err != nil {
 		http.Error(w, "failed to generate captcha image", http.StatusInternalServerError)
 	}

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,8 @@ module github.com/decred/dcrstakepool
 
 require (
 	github.com/apoydence/onpar v0.0.0-20181125144932-f2f06780798d // indirect
+	github.com/chappjc/captcha v0.0.0-20190221063140-b35d3e125a40
 	github.com/dajohi/goemail v0.0.0-20190207191308-61faa215f94d
-	github.com/dchest/captcha v0.0.0-20170622155422-6a29415a8364
 	github.com/decred/dcrd/blockchain/stake v1.1.0
 	github.com/decred/dcrd/certgen v1.0.2
 	github.com/decred/dcrd/chaincfg v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/btcsuite/goleveldb v1.0.0 h1:Tvd0BfvqX9o823q1j2UZ/epQo09eJh6dTcRp79il
 github.com/btcsuite/goleveldb v1.0.0/go.mod h1:QiK9vBlgftBg6rWQIj6wFzbPfRjiykIEhBH4obrXJ/I=
 github.com/btcsuite/snappy-go v1.0.0 h1:ZxaA6lo2EpxGddsA8JwWOcxlzRybb444sgmeJQMJGQE=
 github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
+github.com/chappjc/captcha v0.0.0-20190221063140-b35d3e125a40 h1:SJ+/4jNEaqS2CFAr4TKYtFfQEDe1VMwTfrBe2rGUoJA=
+github.com/chappjc/captcha v0.0.0-20190221063140-b35d3e125a40/go.mod h1:jrJoELmo410yfiTnMo3AYNSjToCtq+IAc/c3wtXhgkI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/dajohi/goemail v0.0.0-20190207191308-61faa215f94d h1:erd++vWXw2JEXelnwMBlTjOrllgTby+Oxg17Td8KUTg=
 github.com/dajohi/goemail v0.0.0-20190207191308-61faa215f94d/go.mod h1:YyX3pgj9VJX6VQYu8Cbs0GYHzgFUs8q0vX5pLmFvops=
@@ -19,8 +21,6 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
 github.com/dchest/blake256 v1.0.0/go.mod h1:xXNWCE1jsAP8DAjP+rKw2MbeqLczjI3TRx2VK+9OEYY=
-github.com/dchest/captcha v0.0.0-20170622155422-6a29415a8364 h1:U+BMqUt8LFgyrF0/NKgPZdr1sGZ3j6uBECpOGcISpFI=
-github.com/dchest/captcha v0.0.0-20170622155422-6a29415a8364/go.mod h1:QGrK8vMWWHQYQ3QU9bw9Y9OPNfxccGzfb41qjvVeXtY=
 github.com/dchest/siphash v1.2.0 h1:YWOShuhvg0GqbQpMa60QlCGtEyf7O7HC1Jf0VjdQ60M=
 github.com/dchest/siphash v1.2.0/go.mod h1:q+IRvb2gOSrUnYoPqHiyHXS0FOBBOdl6tONBlVnOnt4=
 github.com/decred/base58 v1.0.0 h1:BVi1FQCThIjZ0ehG+I99NJ51o0xcc9A/fDKhmJxY6+w=


### PR DESCRIPTION
It would be nice if all VSPs did not have identical captcha parameters (distortion and other image characteristics).

TODO: set from config and use the updated ServeHTTP