### PR TITLE
Delete password reset tokens on email change

### DIFF
--- a/helpers/auth.go
+++ b/helpers/auth.go
@@ -21,6 +21,11 @@ func EmailChangeComplete(dbMap *gorp.DbMap, token models.UserToken) error {
 		return err
 	}
 
+	_, err = dbMap.Exec("DELETE FROM PasswordReset WHERE UserId = ?", emailChange.UserId)
+	if err != nil {
+		return err
+	}
+
 	_, err = dbMap.Exec("DELETE FROM EmailChange WHERE Token = ?", token.String())
 	return err
 }


### PR DESCRIPTION
Fixes #320 

This will delete all reset tokens of user when their email gets changed.