### PR TITLE
server: use gorilla for csrf

### DIFF
--- a/controllers/main.go
+++ b/controllers/main.go
@@ -31,6 +31,7 @@ import (
 	wallettypes "github.com/decred/dcrwallet/rpc/jsonrpc/types"
 	"github.com/decred/dcrwallet/wallet/v2/udb"
 	"github.com/go-gorp/gorp"
+	"github.com/gorilla/csrf"
 	"github.com/zenazn/goji/web"
 
 	"google.golang.org/grpc"
@@ -451,6 +452,7 @@ func (controller *MainController) APIVoting(c web.C, r *http.Request) ([]string,
 func (controller *MainController) isAdmin(c web.C, r *http.Request) (bool, error) {
 	remoteIP := getClientIP(r, controller.realIPHeader)
 	session := controller.GetSession(c)
+	c.Env[csrf.TemplateTag] = csrf.TemplateField(r)
 
 	if session.Values["UserId"] == nil {
 		return false, fmt.Errorf("%s request with no session from %s",
@@ -755,6 +757,7 @@ func (controller *MainController) handlePotentialFatalError(fn string, err error
 func (controller *MainController) Address(c web.C, r *http.Request) (string, int) {
 	t := controller.GetTemplate(c)
 	session := controller.GetSession(c)
+	c.Env[csrf.TemplateTag] = csrf.TemplateField(r)
 
 	if session.Values["UserId"] == nil {
 		return "/", http.StatusSeeOther
@@ -776,6 +779,7 @@ func (controller *MainController) Address(c web.C, r *http.Request) (string, int
 // AddressPost is address form submit route.
 func (controller *MainController) AddressPost(c web.C, r *http.Request) (string, int) {
 	session := controller.GetSession(c)
+	c.Env[csrf.TemplateTag] = csrf.TemplateField(r)
 	remoteIP := getClientIP(r, controller.realIPHeader)
 
 	if session.Values["UserId"] == nil {
@@ -1020,6 +1024,7 @@ func (controller *MainController) AdminStatus(c web.C, r *http.Request) (string,
 func (controller *MainController) AdminTickets(c web.C, r *http.Request) (string, int) {
 	t := controller.GetTemplate(c)
 	session := controller.GetSession(c)
+	c.Env[csrf.TemplateTag] = csrf.TemplateField(r)
 	dbMap := controller.GetDbMap(c)
 
 	isAdmin, err := controller.isAdmin(c, r)
@@ -1057,6 +1062,7 @@ func (controller *MainController) AdminTickets(c web.C, r *http.Request) (string
 // AdminTicketsPost validates and processes the form posted from AdminTickets.
 func (controller *MainController) AdminTicketsPost(c web.C, r *http.Request) (string, int) {
 	session := controller.GetSession(c)
+	c.Env[csrf.TemplateTag] = csrf.TemplateField(r)
 	dbMap := controller.GetDbMap(c)
 	remoteIP := getClientIP(r, controller.realIPHeader)
 
@@ -1181,6 +1187,7 @@ func (controller *MainController) AdminTicketsPost(c web.C, r *http.Request) (st
 func (controller *MainController) EmailUpdate(c web.C, r *http.Request) (string, int) {
 	t := controller.GetTemplate(c)
 	session := controller.GetSession(c)
+	c.Env[csrf.TemplateTag] = csrf.TemplateField(r)
 	dbMap := controller.GetDbMap(c)
 
 	render := func() string {
@@ -1252,6 +1259,7 @@ func (controller *MainController) EmailUpdate(c web.C, r *http.Request) (string,
 func (controller *MainController) EmailVerify(c web.C, r *http.Request) (string, int) {
 	t := controller.GetTemplate(c)
 	session := controller.GetSession(c)
+	c.Env[csrf.TemplateTag] = csrf.TemplateField(r)
 	dbMap := controller.GetDbMap(c)
 
 	render := func() string {
@@ -1354,6 +1362,7 @@ func (controller *MainController) Index(c web.C, r *http.Request) (string, int) 
 func (controller *MainController) PasswordReset(c web.C, r *http.Request) (string, int) {
 	c.Env["Title"] = "Decred Voting Service - Password Reset"
 	session := controller.GetSession(c)
+	c.Env[csrf.TemplateTag] = csrf.TemplateField(r)
 	c.Env["FlashError"] = append(session.Flashes("passwordresetError"), session.Flashes("captchaFailed")...)
 	c.Env["FlashSuccess"] = session.Flashes("passwordresetSuccess")
 	c.Env["IsPasswordReset"] = true
@@ -1374,6 +1383,7 @@ func (controller *MainController) PasswordReset(c web.C, r *http.Request) (strin
 func (controller *MainController) PasswordResetPost(c web.C, r *http.Request) (string, int) {
 	email := r.FormValue("email")
 	session := controller.GetSession(c)
+	c.Env[csrf.TemplateTag] = csrf.TemplateField(r)
 	dbMap := controller.GetDbMap(c)
 
 	if !controller.IsCaptchaDone(c) {
@@ -1430,6 +1440,7 @@ func (controller *MainController) PasswordResetPost(c web.C, r *http.Request) (s
 func (controller *MainController) PasswordUpdate(c web.C, r *http.Request) (string, int) {
 	t := controller.GetTemplate(c)
 	session := controller.GetSession(c)
+	c.Env[csrf.TemplateTag] = csrf.TemplateField(r)
 
 	render := func() string {
 		c.Env["Title"] = "Decred Voting Service - Password Update"
@@ -1456,6 +1467,7 @@ func (controller *MainController) PasswordUpdate(c web.C, r *http.Request) (stri
 // the password reset email. The token is validated and the password is changed.
 func (controller *MainController) PasswordUpdatePost(c web.C, r *http.Request) (string, int) {
 	session := controller.GetSession(c)
+	c.Env[csrf.TemplateTag] = csrf.TemplateField(r)
 	dbMap := controller.GetDbMap(c)
 	remoteIP := getClientIP(r, controller.realIPHeader)
 
@@ -1512,6 +1524,7 @@ func (controller *MainController) PasswordUpdatePost(c web.C, r *http.Request) (
 // Settings renders the settings page.
 func (controller *MainController) Settings(c web.C, r *http.Request) (string, int) {
 	session := controller.GetSession(c)
+	c.Env[csrf.TemplateTag] = csrf.TemplateField(r)
 	dbMap := controller.GetDbMap(c)
 
 	if session.Values["UserId"] == nil {
@@ -1554,6 +1567,7 @@ func (controller *MainController) Settings(c web.C, r *http.Request) (string, in
 // SettingsPost handles changing the user's email address or password.
 func (controller *MainController) SettingsPost(c web.C, r *http.Request) (string, int) {
 	session := controller.GetSession(c)
+	c.Env[csrf.TemplateTag] = csrf.TemplateField(r)
 	dbMap := controller.GetDbMap(c)
 	remoteIP := getClientIP(r, controller.realIPHeader)
 
@@ -1661,6 +1675,7 @@ func (controller *MainController) SettingsPost(c web.C, r *http.Request) (string
 func (controller *MainController) SignIn(c web.C, r *http.Request) (string, int) {
 	t := controller.GetTemplate(c)
 	session := controller.GetSession(c)
+	c.Env[csrf.TemplateTag] = csrf.TemplateField(r)
 
 	// Tell main.html what route is being rendered
 	c.Env["IsSignIn"] = true
@@ -1680,6 +1695,7 @@ func (controller *MainController) SignInPost(c web.C, r *http.Request) (string, 
 	email, password := r.FormValue("email"), r.FormValue("password")
 
 	session := controller.GetSession(c)
+	c.Env[csrf.TemplateTag] = csrf.TemplateField(r)
 	dbMap := controller.GetDbMap(c)
 	remoteIP := getClientIP(r, controller.realIPHeader)
 
@@ -1721,6 +1737,7 @@ func (controller *MainController) SignUp(c web.C, r *http.Request) (string, int)
 	}
 
 	session := controller.GetSession(c)
+	c.Env[csrf.TemplateTag] = csrf.TemplateField(r)
 	c.Env["FlashError"] = append(session.Flashes("signupError"), session.Flashes("captchaFailed")...)
 	c.Env["FlashSuccess"] = session.Flashes("signupSuccess")
 	c.Env["CaptchaID"] = captcha.New()
@@ -1742,6 +1759,7 @@ func (controller *MainController) SignUpPost(c web.C, r *http.Request) (string, 
 	}
 
 	session := controller.GetSession(c)
+	c.Env[csrf.TemplateTag] = csrf.TemplateField(r)
 	if !controller.IsCaptchaDone(c) {
 		session.AddFlash("You must complete the captcha.", "signupError")
 		return controller.SignUp(c, r)
@@ -1904,6 +1922,7 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 
 	t := controller.GetTemplate(c)
 	session := controller.GetSession(c)
+	c.Env[csrf.TemplateTag] = csrf.TemplateField(r)
 	remoteIP := getClientIP(r, controller.realIPHeader)
 
 	if session.Values["UserId"] == nil {
@@ -2032,6 +2051,7 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 // Voting renders the voting page.
 func (controller *MainController) Voting(c web.C, r *http.Request) (string, int) {
 	session := controller.GetSession(c)
+	c.Env[csrf.TemplateTag] = csrf.TemplateField(r)
 	dbMap := controller.GetDbMap(c)
 
 	if session.Values["UserId"] == nil {
@@ -2065,6 +2085,7 @@ func (controller *MainController) Voting(c web.C, r *http.Request) (string, int)
 // VotingPost form submit route.
 func (controller *MainController) VotingPost(c web.C, r *http.Request) (string, int) {
 	session := controller.GetSession(c)
+	c.Env[csrf.TemplateTag] = csrf.TemplateField(r)
 	dbMap := controller.GetDbMap(c)
 
 	if session.Values["UserId"] == nil {
@@ -2118,6 +2139,7 @@ func (controller *MainController) VotingPost(c web.C, r *http.Request) (string, 
 // Logout the user.
 func (controller *MainController) Logout(c web.C, r *http.Request) (string, int) {
 	session := controller.GetSession(c)
+	c.Env[csrf.TemplateTag] = csrf.TemplateField(r)
 
 	session.Values["UserId"] = nil
 

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/go-sql-driver/mysql v1.4.0
 	github.com/golang/protobuf v1.2.0
 	github.com/gorilla/context v1.1.1
+	github.com/gorilla/csrf v1.5.1
 	github.com/gorilla/sessions v1.1.2
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/jrick/logrotate v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
+github.com/gorilla/csrf v1.5.1 h1:UASc2+EB0T51tvl6/2ls2ciA8/qC7KdTO7DsOEKbttQ=
+github.com/gorilla/csrf v1.5.1/go.mod h1:HTDW7xFOO1aHddQUmghe9/2zTvg7AYCnRCs7MxTGu/0=
 github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.1.2 h1:4esMHhwKLQ9Odtku/p+onvH+eRJFWjV4y3iTDVWrZNU=
@@ -143,10 +145,13 @@ github.com/mattn/go-sqlite3 v1.10.0 h1:jbhqpg7tQe4SupckyijYiy0mJJ/pRyHvXf7JdWK86
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/onsi/ginkgo v1.6.0 h1:Ix8l273rp3QzYgXSR+c8d1fTG7UPgYkOSELPhiY/YGw=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.1 h1:PZSj/UFNaVp3KxrzHOcS7oyuWA7LoOY/77yCTEFu21U=
 github.com/onsi/gomega v1.4.1/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3 h1:RE1xgDvH7imwFD45h+u2SgIfERHlS2yNG4DObb5BSKU=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
+github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/poy/onpar v0.0.0-20181125144932-f2f06780798d h1:dG+BIeP2sDXC2AsX+P1Xvftxy+b4iYTfrDDkAIQB7VM=

--- a/sample-dcrstakepool.conf
+++ b/sample-dcrstakepool.conf
@@ -11,8 +11,8 @@ adminips=127.0.0.1
 ; Multiple values can be used and are separated by a comma.
 ;adminuserids=1,2,3
 
-; Secret string used to encrypt API tokens.  Can use openssl rand -hex 32
-; to generate one.
+; Secret string used to encrypt API and to generate CSRF tokens.
+; Can use openssl rand -hex 32 to generate one.
 ;apisecret=
 
 ; baseurl to use when emailing verification links.

--- a/system/controller.go
+++ b/system/controller.go
@@ -27,10 +27,6 @@ func (controller *Controller) GetDbMap(c web.C) *gorp.DbMap {
 	return c.Env["DbMap"].(*gorp.DbMap)
 }
 
-func (controller *Controller) IsXhr(c web.C) bool {
-	return c.Env["IsXhr"].(bool)
-}
-
 func (controller *Controller) IsCaptchaDone(c web.C) bool {
 	done, ok := c.Env["CaptchaDone"].(bool)
 	return done && ok

--- a/system/core.go
+++ b/system/core.go
@@ -20,27 +20,12 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
-// CSRF token constants
-const (
-	CSRFCookie = "XSRF-TOKEN"
-	CSRFHeader = "X-XSRF-TOKEN"
-	CSRFKey    = "csrf_token"
-)
-
 type Application struct {
-	APISecret      string
-	Template       *template.Template
-	TemplatesPath  string
-	Store          *sessions.CookieStore
-	DbMap          *gorp.DbMap
-	CsrfProtection *CsrfProtection
-}
-
-type CsrfProtection struct {
-	Key    string
-	Cookie string
-	Header string
-	Secure bool
+	APISecret     string
+	Template      *template.Template
+	TemplatesPath string
+	Store         *sessions.CookieStore
+	DbMap         *gorp.DbMap
 }
 
 // GojiWebHandlerFunc is an adaptor that allows an http.HanderFunc where a
@@ -73,13 +58,6 @@ func (application *Application) Init(APISecret string, baseURL string,
 		DBHost,
 		DBPort,
 		DBName)
-
-	application.CsrfProtection = &CsrfProtection{
-		Key:    CSRFKey,
-		Cookie: CSRFCookie,
-		Header: CSRFHeader,
-		Secure: cookieSecure,
-	}
 
 	application.APISecret = APISecret
 }
@@ -172,10 +150,6 @@ func saveSession(c web.C, w http.ResponseWriter, r *http.Request) error {
 func (application *Application) APIHandler(apiFun func(web.C, *http.Request) *APIResponse) web.HandlerFunc {
 	return func(c web.C, w http.ResponseWriter, r *http.Request) {
 		apiResp := apiFun(c, r)
-
-		if err := saveSession(c, w, r); err != nil {
-			log.Errorf("Can't save session: %v", err)
-		}
 
 		if apiResp != nil {
 			WriteAPIResponse(apiResp, http.StatusOK, w)

--- a/views/address.html
+++ b/views/address.html
@@ -99,7 +99,7 @@ $ dcrctl {{ if eq .Network "testnet"}}--testnet{{end}} --wallet validateaddress 
 			<div class="form-group">
                                 <button id="signup" name="signup" class="btn btn-primary">Submit Address</button>
                         </div>
-                <input type="hidden" name="{{.CsrfKey}}" value={{.CsrfToken}}>
+                {{ $.csrfField }}
                 </form>
 {{ end }}
     </div>

--- a/views/admin/tickets.html
+++ b/views/admin/tickets.html
@@ -25,7 +25,7 @@
       <div class="form-group">
           <button id="addTickets" name="action" class="btn btn-primary" value="Add">Add Tickets To Live Voting List</button>
       </div>
-      <input type="hidden" name="{{$.CsrfKey}}" value={{$.CsrfToken}}>
+      {{ $.csrfField }}
     </form>
     {{else}}
     <p><strong>Currently there are no ignored low fee tickets.</strong></p>
@@ -45,7 +45,8 @@
       <div class="form-group">
           <button id="rmTickets" name="action" class="btn btn-primary" value="Remove">Remove Tickets From Live Voting List</button>
       </div>
-      <input type="hidden" name="{{$.CsrfKey}}" value={{$.CsrfToken}}>
+      {{ $.csrfField }}
+      
     </form>
     {{else}}
     <p><strong>Currently there are no added low fee tickets.</strong></p>

--- a/views/auth/signin.html
+++ b/views/auth/signin.html
@@ -36,7 +36,7 @@
         <p><a href="/signup">New user?</a></p>
   </div>
 </div>
-	<input type="hidden" name="{{.CsrfKey}}" value={{.CsrfToken}}>
+	{{ $.csrfField }}
     </form>
     </div> 
     </div>

--- a/views/auth/signup.html
+++ b/views/auth/signup.html
@@ -37,7 +37,7 @@
             <p><a href="/passwordreset">Forgot your password?</a></p>
           </div>
         </div>
-        <input type="hidden" name="{{.CsrfKey}}" value={{.CsrfToken}}>
+        {{ $.csrfField }}
       </form>
       {{else}}
         <p>To sign up, first complete the captcha:</p>

--- a/views/captcha.html
+++ b/views/captcha.html
@@ -19,7 +19,7 @@
                 <button name=captchaSubmit type=submit class="btn btn-primary">Submit</button>
             </div>
         </div>
-        <input type="hidden" name="{{.CsrfKey}}" value={{.CsrfToken}}>
+        {{ $.csrfField }}
         </form>
     </div>
 </div>

--- a/views/passwordreset.html
+++ b/views/passwordreset.html
@@ -22,7 +22,7 @@
             <button id="resetpassword" name="signin" class="btn btn-primary">Reset Password</button>
           </div>
         </div>
-        <input type="hidden" name="{{.CsrfKey}}" value={{.CsrfToken}}>
+        {{ $.csrfField }}
       </form>
       {{else}}
         <p>To reset your password, first complete the captcha:</p>

--- a/views/passwordupdate.html
+++ b/views/passwordupdate.html
@@ -29,7 +29,7 @@
 			<button id="updatepassword" name="signin" class="btn btn-primary">Update Password</button>
 			</div>
 		</div>
-		<input type="hidden" name="{{.CsrfKey}}" value={{.CsrfToken}}>
+		{{ $.csrfField }}
 	</form>
 	{{end}}
    </div>

--- a/views/settings.html
+++ b/views/settings.html
@@ -48,7 +48,7 @@
       <div class="form-group">
             <button id="updateEmail" name="updateEmail" value="true" class="btn btn-primary">Change Email Address</button>
       </div>
-      <input type="hidden" name="{{.CsrfKey}}" value={{.CsrfToken}}>
+      {{ $.csrfField }}
     </form>
     {{else}}
       <p>To change your email address, first complete the captcha:</p>
@@ -80,7 +80,7 @@
         <label class="control-label" for="updatepassword"></label>
         <button id="updatepassword" name="updatePassword" value="true" class="btn btn-primary">Update Password</button>
       </div>
-      <input type="hidden" name="{{.CsrfKey}}" value={{.CsrfToken}}>
+      {{ $.csrfField }}
     </form>
   </div> <!-- forms column -->
  </div> <!-- row -->

--- a/views/voting.html
+++ b/views/voting.html
@@ -31,7 +31,7 @@
     <div class="form-group">
         <button id="updateVoting" name="updateVoting" class="btn btn-primary">Update Voting Preferences</button>
     </div>
-    <input type="hidden" name="{{$.CsrfKey}}" value={{$.CsrfToken}}>
+    {{ $.csrfField }}
     </form>
     {{else}}
     <p><strong>There are no active agendas to vote on currently.</strong></p>


### PR DESCRIPTION
Replace custom implementation of CSRF with [gorilla/csrf](https://github.com/gorilla/csrf).

- Reuse the existing config item "apisecret" to generate CSRF tokens.
- In `core.go`, dont attempt to save a session in the API handler because API requests do not utilize sessions.
- Make use of "route groups" so that not all middlewares have to run against all routes. This simplifies existing middleware, and allows us to apply CSRF to only html routes and not API routes.

Closes #309 