### PR TITLE
Tidy up RPC server

### DIFF
--- a/backend/stakepoold/grpcserver.go
+++ b/backend/stakepoold/grpcserver.go
@@ -188,7 +188,7 @@ func openRPCKeyPair() (tls.Certificate, error) {
 	return tls.LoadX509KeyPair(cfg.RPCCert, cfg.RPCKey)
 }
 
-func startGRPCServers(grpcCommandQueueChan chan *rpcserver.GRPCCommandQueue) (*grpc.Server, error) {
+func startGRPCServers(appContext *rpcserver.AppContext) (*grpc.Server, error) {
 	var (
 		server  *grpc.Server
 		keyPair tls.Certificate
@@ -208,7 +208,7 @@ func startGRPCServers(grpcCommandQueueChan chan *rpcserver.GRPCCommandQueue) (*g
 	creds := credentials.NewServerTLSFromCert(&keyPair)
 	server = grpc.NewServer(grpc.Creds(creds), grpc.UnaryInterceptor(interceptUnary))
 	rpcserver.StartVersionService(server)
-	rpcserver.StartStakepooldService(grpcCommandQueueChan, server)
+	rpcserver.StartStakepooldService(appContext, server)
 	for _, lis := range listeners {
 		lis := lis
 		go func() {

--- a/backend/stakepoold/ntfnhandlers.go
+++ b/backend/stakepoold/ntfnhandlers.go
@@ -5,18 +5,19 @@ import (
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/rpcclient/v2"
+	"github.com/decred/dcrstakepool/backend/stakepoold/rpc/rpcserver"
 )
 
 // Define notification handlers
-func getNodeNtfnHandlers(ctx *appContext) *rpcclient.NotificationHandlers {
+func getNodeNtfnHandlers(ctx *rpcserver.AppContext) *rpcclient.NotificationHandlers {
 	return &rpcclient.NotificationHandlers{
 		OnNewTickets: func(blockHash *chainhash.Hash, blockHeight int64, _ int64, tickets []*chainhash.Hash) {
-			nt := NewTicketsForBlock{
-				blockHash:   blockHash,
-				blockHeight: blockHeight,
-				newTickets:  tickets,
+			nt := rpcserver.NewTicketsForBlock{
+				BlockHash:   blockHash,
+				BlockHeight: blockHeight,
+				NewTickets:  tickets,
 			}
-			ctx.newTicketsChan <- nt
+			ctx.NewTicketsChan <- nt
 		},
 		OnSpentAndMissedTickets: func(blockHash *chainhash.Hash, blockHeight int64, _ int64, tickets map[chainhash.Hash]bool) {
 			ticketsFixed := make(map[*chainhash.Hash]bool)
@@ -24,20 +25,20 @@ func getNodeNtfnHandlers(ctx *appContext) *rpcclient.NotificationHandlers {
 				ticketHash := ticketHash
 				ticketsFixed[&ticketHash] = spent
 			}
-			smt := SpentMissedTicketsForBlock{
-				blockHash:   blockHash,
-				blockHeight: blockHeight,
-				smTickets:   ticketsFixed,
+			smt := rpcserver.SpentMissedTicketsForBlock{
+				BlockHash:   blockHash,
+				BlockHeight: blockHeight,
+				SmTickets:   ticketsFixed,
 			}
-			ctx.spentmissedTicketsChan <- smt
+			ctx.SpentmissedTicketsChan <- smt
 		},
 		OnWinningTickets: func(blockHash *chainhash.Hash, blockHeight int64, winningTickets []*chainhash.Hash) {
-			wt := WinningTicketsForBlock{
-				blockHash:      blockHash,
-				blockHeight:    blockHeight,
-				winningTickets: winningTickets,
+			wt := rpcserver.WinningTicketsForBlock{
+				BlockHash:      blockHash,
+				BlockHeight:    blockHeight,
+				WinningTickets: winningTickets,
 			}
-			ctx.winningTicketsChan <- wt
+			ctx.WinningTicketsChan <- wt
 		},
 	}
 }

--- a/backend/stakepoold/rpc/rpcserver/context.go
+++ b/backend/stakepoold/rpc/rpcserver/context.go
@@ -525,11 +525,11 @@ func (ctx *AppContext) processSpentMissedTickets(smt SpentMissedTicketsForBlock)
 	}()
 }
 
-// processWinningTickets is called every time a new block comes in to handle
+// ProcessWinningTickets is called every time a new block comes in to handle
 // voting.  The function requires ASAP processing for each vote and therefore
 // it is not sequential and hard to read.  This is unfortunate but a reality of
 // speeding up code.
-func (ctx *AppContext) processWinningTickets(wt WinningTicketsForBlock) {
+func (ctx *AppContext) ProcessWinningTickets(wt WinningTicketsForBlock) {
 	start := time.Now()
 
 	// We use pointer because it is the fastest accessor.
@@ -622,7 +622,7 @@ func (ctx *AppContext) processWinningTickets(wt WinningTicketsForBlock) {
 				"(%v + %v): %v", w.ticket, w.txid, w.config.VoteBits, w.msa,
 				w.duration, w.signDuration, w.sendDuration, w.err)
 		}
-		log.Infof("processWinningTickets: height %v block %v "+
+		log.Infof("ProcessWinningTickets: height %v block %v "+
 			"duration %v newvotes %v duplicatevotes %v errors %v",
 			wt.BlockHeight, wt.BlockHash, time.Since(start), votedCount,
 			dupeCount, errorCount)
@@ -661,7 +661,7 @@ func (ctx *AppContext) WinningTicketHandler() {
 	for {
 		select {
 		case wt := <-ctx.WinningTicketsChan:
-			go ctx.processWinningTickets(wt)
+			go ctx.ProcessWinningTickets(wt)
 		case <-ctx.Quit:
 			return
 		}

--- a/backend/stakepoold/rpc/rpcserver/context.go
+++ b/backend/stakepoold/rpc/rpcserver/context.go
@@ -1,0 +1,713 @@
+package rpcserver
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/decred/dcrd/blockchain/stake"
+	"github.com/decred/dcrd/chaincfg"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/dcrutil"
+	wallettypes "github.com/decred/dcrwallet/rpc/jsonrpc/types"
+
+	"github.com/decred/dcrd/rpcclient/v2"
+	"github.com/decred/dcrd/wire"
+	"github.com/decred/dcrstakepool/backend/stakepoold/userdata"
+	"github.com/decred/dcrwallet/wallet/v2/txrules"
+)
+
+var (
+	errSuccess            = errors.New("success")
+	errNoTxInfo           = "-5: no information for transaction"
+	errDuplicateVote      = "-32603: already have transaction "
+	ticketTypeNew         = "New"
+	ticketTypeSpentMissed = "SpentMissed"
+)
+
+type AppContext struct {
+	sync.RWMutex
+
+	// locking required
+	AddedLowFeeTicketsMSA   map[chainhash.Hash]string            // [ticket]multisigaddr
+	IgnoredLowFeeTicketsMSA map[chainhash.Hash]string            // [ticket]multisigaddr
+	LiveTicketsMSA          map[chainhash.Hash]string            // [ticket]multisigaddr
+	UserVotingConfig        map[string]userdata.UserVotingConfig // [multisigaddr]
+
+	// no locking required
+	DataPath               string
+	FeeAddrs               map[string]struct{}
+	PoolFees               float64
+	GrpcCommandQueueChan   chan *GRPCCommandQueue
+	NewTicketsChan         chan NewTicketsForBlock
+	NodeConnection         *rpcclient.Client
+	Params                 *chaincfg.Params
+	Wg                     sync.WaitGroup // wait group for go routine exits
+	Quit                   chan struct{}
+	SpentmissedTicketsChan chan SpentMissedTicketsForBlock
+	UserData               *userdata.UserData
+	VotingConfig           *VotingConfig
+	WalletConnection       *rpcclient.Client
+	WinningTicketsChan     chan WinningTicketsForBlock
+	Testing                bool // enabled only for testing
+}
+
+type NewTicketsForBlock struct {
+	BlockHash   *chainhash.Hash
+	BlockHeight int64
+	NewTickets  []*chainhash.Hash
+}
+
+type SpentMissedTicketsForBlock struct {
+	BlockHash   *chainhash.Hash
+	BlockHeight int64
+	SmTickets   map[*chainhash.Hash]bool
+}
+
+// VotingConfig contains global voting defaults.
+type VotingConfig struct {
+	VoteBits         uint16
+	VoteVersion      uint32
+	VoteBitsExtended string
+}
+
+type WinningTicketsForBlock struct {
+	BlockHash      *chainhash.Hash
+	BlockHeight    int64
+	WinningTickets []*chainhash.Hash
+}
+
+// ticketMetadata contains all the bits and pieces required to vote new tickets,
+// to look up new/missed/spent tickets, and to print statistics after usage.
+type ticketMetadata struct {
+	blockHash    *chainhash.Hash
+	blockHeight  int64
+	msa          string                    // multisig
+	ticket       *chainhash.Hash           // ticket
+	spent        bool                      // spent (true) or missed (false)
+	config       userdata.UserVotingConfig // voting config
+	duration     time.Duration             // overall vote duration
+	getDuration  time.Duration             // time to gettransaction
+	hex          string                    // hex encoded tx data
+	txid         *chainhash.Hash           // transaction id
+	ticketType   string                    // new or spentmissed
+	signDuration time.Duration             // time to generatevote
+	sendDuration time.Duration             // time to sendrawtransaction
+	err          error                     // log errors along the way
+}
+
+// EvaluateStakePoolTicket evaluates a voting service ticket to see if it's
+// acceptable to the voting service. The ticket must pay out to the voting
+// service cold wallet, and must have a sufficient fee.
+func (ctx *AppContext) EvaluateStakePoolTicket(tx *wire.MsgTx, blockHeight int32) (bool, error) {
+	// Check the first commitment output (txOuts[1])
+	// and ensure that the address found there exists
+	// in the list of approved addresses. Also ensure
+	// that the fee exists and is of the amount
+	// requested by the pool.
+	commitmentOut := tx.TxOut[1]
+	commitAddr, err := stake.AddrFromSStxPkScrCommitment(
+		commitmentOut.PkScript, ctx.Params)
+	if err != nil {
+		return false, fmt.Errorf("Failed to parse commit out addr: %s",
+			err.Error())
+	}
+
+	// Extract the fee from the ticket.
+	in := dcrutil.Amount(0)
+	for i := range tx.TxOut {
+		if i%2 != 0 {
+			commitAmt, err := stake.AmountFromSStxPkScrCommitment(
+				tx.TxOut[i].PkScript)
+			if err != nil {
+				return false, fmt.Errorf("Failed to parse commit "+
+					"out amt for commit in vout %v: %s", i, err.Error())
+			}
+			in += commitAmt
+		}
+	}
+	out := dcrutil.Amount(0)
+	for i := range tx.TxOut {
+		out += dcrutil.Amount(tx.TxOut[i].Value)
+	}
+	fees := in - out
+
+	_, exists := ctx.FeeAddrs[commitAddr.EncodeAddress()]
+	if exists {
+		commitAmt, err := stake.AmountFromSStxPkScrCommitment(
+			commitmentOut.PkScript)
+		if err != nil {
+			return false, fmt.Errorf("failed to parse commit "+
+				"out amt: %s", err.Error())
+		}
+
+		// Calculate the fee required based on the current
+		// height and the required amount from the pool.
+		feeNeeded := txrules.StakePoolTicketFee(dcrutil.Amount(
+			tx.TxOut[0].Value), fees, blockHeight, ctx.PoolFees,
+			ctx.Params)
+		if commitAmt < feeNeeded {
+			log.Warnf("User %s submitted ticket %v which "+
+				"has less fees than are required to use this "+
+				"Voting service and is being skipped (required: %v"+
+				", found %v)", commitAddr.EncodeAddress(),
+				tx.TxHash(), feeNeeded, commitAmt)
+
+			// Reject the entire transaction if it didn't
+			// pay the pool server fees.
+			return false, nil
+		}
+	} else {
+		log.Warnf("Unknown pool commitment address %s for ticket %v",
+			commitAddr.EncodeAddress(), tx.TxHash())
+		return false, nil
+	}
+
+	log.Debugf("Accepted valid voting service ticket %v committing %v in fees",
+		tx.TxHash(), tx.TxOut[0].Value)
+
+	return true, nil
+}
+
+// MsgTxFromHex returns a wire.MsgTx struct built from the transaction hex string
+func MsgTxFromHex(txhex string) (*wire.MsgTx, error) {
+	txBytes, err := hex.DecodeString(txhex)
+	if err != nil {
+		return nil, err
+	}
+	msgTx := wire.NewMsgTx()
+	if err = msgTx.Deserialize(bytes.NewReader(txBytes)); err != nil {
+		return nil, err
+	}
+	return msgTx, nil
+}
+
+// getticket pulls the transaction information for a ticket from dcrwallet. This is a go routine!
+func (ctx *AppContext) getticket(wg *sync.WaitGroup, nt *ticketMetadata) {
+	start := time.Now()
+
+	defer func() {
+		nt.duration = time.Since(start)
+		wg.Done()
+	}()
+
+	// Ask wallet to look up vote transaction to see if it belongs to us
+	log.Debugf("calling GetTransaction for %v ticket %v",
+		strings.ToLower(nt.ticketType), nt.ticket)
+	res, err := ctx.WalletConnection.GetTransaction(nt.ticket)
+	nt.getDuration = time.Since(start)
+	if err != nil {
+		// suppress "No information for transaction ..." errors
+		if !strings.HasPrefix(err.Error(), errNoTxInfo) {
+			log.Warnf("unexpected GetTransaction error: '%v' for %v",
+				err, nt.ticket)
+		}
+		return
+	}
+	for i := range res.Details {
+		_, ok := ctx.UserVotingConfig[res.Details[i].Address]
+		if ok {
+			// multisigaddress will match if it belongs a pool user
+			nt.msa = res.Details[i].Address
+
+			if nt.ticketType == ticketTypeNew {
+				// TODO(maybe): we could check if the ticket was added to the
+				// low fee list here but since it was just mined, it should be
+				// extremely unlikely to have been added before it was mined.
+
+				// save for fee checking
+				nt.hex = res.Hex
+
+			}
+			break
+		}
+	}
+	log.Debugf("getticket finished for %v ticket %v",
+		strings.ToLower(nt.ticketType), nt.ticket)
+}
+
+func (ctx *AppContext) updateTicketData(newAddedLowFeeTicketsMSA map[chainhash.Hash]string) {
+	log.Debug("updateTicketData ctx.Lock")
+	ctx.Lock()
+
+	// apply unconditional updates
+	for tickethash, msa := range newAddedLowFeeTicketsMSA {
+		// remove from ignored list if present
+		delete(ctx.IgnoredLowFeeTicketsMSA, tickethash)
+		// add to live list
+		ctx.LiveTicketsMSA[tickethash] = msa
+	}
+
+	// if something is being deleted from the db by this update then
+	// we need to put it back on the ignored list
+	for th, m := range ctx.AddedLowFeeTicketsMSA {
+		_, exists := newAddedLowFeeTicketsMSA[th]
+		if !exists {
+			ctx.IgnoredLowFeeTicketsMSA[th] = m
+		}
+	}
+
+	ctx.AddedLowFeeTicketsMSA = newAddedLowFeeTicketsMSA
+	addedLowFeeTicketsCount := len(ctx.AddedLowFeeTicketsMSA)
+	ignoredLowFeeTicketsCount := len(ctx.IgnoredLowFeeTicketsMSA)
+	liveTicketsCount := len(ctx.LiveTicketsMSA)
+	ctx.Unlock()
+	log.Debug("updateTicketData ctx.Unlock")
+	// Log ticket information outside of the handler.
+	go func() {
+		log.Infof("tickets loaded -- addedLowFee %v ignoredLowFee %v live %v "+
+			"total %v", addedLowFeeTicketsCount, ignoredLowFeeTicketsCount,
+			liveTicketsCount,
+			addedLowFeeTicketsCount+ignoredLowFeeTicketsCount+liveTicketsCount)
+
+	}()
+}
+
+func (ctx *AppContext) UpdateTicketDataFromMySQL() error {
+	start := time.Now()
+	newAddedLowFeeTicketsMSA, err := ctx.UserData.MySQLFetchAddedLowFeeTickets()
+	log.Infof("MySQLFetchAddedLowFeeTickets took %v", time.Since(start))
+	if err != nil {
+		return err
+	}
+	ctx.updateTicketData(newAddedLowFeeTicketsMSA)
+	return nil
+}
+
+func (ctx *AppContext) importScript(script []byte) int64 {
+	err := ctx.WalletConnection.ImportScript(script)
+	if err != nil {
+		log.Errorf("importScript: importScript rpc failed: %v", err)
+		return -1
+	}
+
+	_, block, err := ctx.WalletConnection.GetBestBlock()
+	if err != nil {
+		log.Errorf("importScript: getBetBlock rpc failed: %v", err)
+		return -1
+	}
+	return block
+}
+
+func (ctx *AppContext) updateUserData(newUserVotingConfig map[string]userdata.UserVotingConfig) {
+	log.Debug("updateUserData ctx.Lock")
+	ctx.Lock()
+	ctx.UserVotingConfig = newUserVotingConfig
+	ctx.Unlock()
+	log.Debug("updateUserData ctx.Unlock")
+}
+
+func (ctx *AppContext) UpdateUserDataFromMySQL() error {
+	start := time.Now()
+	newUserVotingConfig, err := ctx.UserData.MySQLFetchUserVotingConfig()
+	log.Infof("MySQLFetchUserVotingConfig took %v",
+		time.Since(start))
+	if err != nil {
+		return err
+	}
+	ctx.updateUserData(newUserVotingConfig)
+	return nil
+}
+
+// vote Generates a vote and send it off to the network.  This is a go routine!
+func (ctx *AppContext) vote(wg *sync.WaitGroup, blockHash *chainhash.Hash, blockHeight int64, w *ticketMetadata) {
+	start := time.Now()
+
+	defer func() {
+		w.duration = time.Since(start)
+		wg.Done()
+	}()
+
+	// Ask wallet to generate vote result.
+	var res *wallettypes.GenerateVoteResult
+	res, w.err = ctx.WalletConnection.GenerateVote(blockHash, blockHeight,
+		w.ticket, w.config.VoteBits, ctx.VotingConfig.VoteBitsExtended)
+	if w.err != nil || res.Hex == "" {
+		return
+	}
+	w.signDuration = time.Since(start)
+
+	// Create raw transaction.
+	var buf []byte
+	buf, w.err = hex.DecodeString(res.Hex)
+	if w.err != nil {
+		return
+	}
+	newTx := wire.NewMsgTx()
+	w.err = newTx.FromBytes(buf)
+	if w.err != nil {
+		return
+	}
+
+	// Ask node to transmit raw transaction.
+	startSend := time.Now()
+	tx, err := ctx.NodeConnection.SendRawTransaction(newTx, false)
+	if err != nil {
+		log.Infof("vote err %v", err)
+		w.err = err
+	} else {
+		w.txid = tx
+	}
+	w.sendDuration = time.Since(startSend)
+}
+
+func (ctx *AppContext) processNewTickets(nt NewTicketsForBlock) {
+	start := time.Now()
+
+	// We use pointer because it is the fastest accessor.
+	newtickets := make([]*ticketMetadata, 0, len(nt.NewTickets))
+
+	var wg sync.WaitGroup // wait group for go routine exits
+
+	ctx.RLock()
+	for _, tickethash := range nt.NewTickets {
+		n := &ticketMetadata{
+			blockHash:   nt.BlockHash,
+			blockHeight: nt.BlockHeight,
+			ticket:      tickethash,
+			ticketType:  ticketTypeNew,
+		}
+		newtickets = append(newtickets, n)
+
+		wg.Add(1)
+		go ctx.getticket(&wg, n)
+	}
+	ctx.RUnlock()
+
+	wg.Wait()
+
+	newIgnoredLowFeeTickets := make(map[chainhash.Hash]string)
+	newLiveTickets := make(map[chainhash.Hash]string)
+
+	for _, n := range newtickets {
+		if n.err != nil || n.msa == "" {
+			// most likely can't look up the transaction because it's
+			// not in our wallet because it doesn't belong to us
+			continue
+		}
+
+		msgTx, err := MsgTxFromHex(n.hex)
+		if err != nil {
+			log.Warnf("MsgTxFromHex failed for %v: %v", n.hex, err)
+			continue
+		}
+
+		ticketFeesValid, err := ctx.EvaluateStakePoolTicket(msgTx, int32(nt.BlockHeight))
+		if err != nil {
+			log.Warnf("ignoring ticket %v for msa %v ticketFeesValid %v err %v",
+				n.ticket, n.msa, ticketFeesValid, err)
+			newIgnoredLowFeeTickets[*n.ticket] = n.msa
+		}
+
+		newLiveTickets[*n.ticket] = n.msa
+	}
+
+	log.Debug("processNewTickets ctx.Lock")
+	ctx.Lock()
+	// update ignored low fee tickets
+	for ticket, msa := range newIgnoredLowFeeTickets {
+		ctx.IgnoredLowFeeTicketsMSA[ticket] = msa
+	}
+
+	// update live tickets
+	for ticket, msa := range newLiveTickets {
+		ctx.LiveTicketsMSA[ticket] = msa
+	}
+
+	// update counts
+	addedLowFeeTicketsCount := len(ctx.AddedLowFeeTicketsMSA)
+	ignoredLowFeeTicketsCount := len(ctx.IgnoredLowFeeTicketsMSA)
+	liveTicketsCount := len(ctx.LiveTicketsMSA)
+	ctx.Unlock()
+	log.Debug("processNewTickets ctx.Unlock")
+
+	// Log ticket information outside of the handler.
+	go func() {
+		for ticket, msa := range newLiveTickets {
+			log.Infof("added new live ticket %v msa %v", ticket, msa)
+		}
+
+		for ticket, msa := range newIgnoredLowFeeTickets {
+			log.Infof("added new ignored ticket %v msa %v", ticket, msa)
+		}
+
+		log.Infof("processNewTickets: height %v block %v duration %v "+
+			"ignored %v live %v notours %v", nt.BlockHeight,
+			nt.BlockHash, time.Since(start), len(newIgnoredLowFeeTickets),
+			len(newLiveTickets),
+			len(nt.NewTickets)-len(newIgnoredLowFeeTickets)-len(newLiveTickets))
+		log.Infof("tickets loaded -- addedLowFee %v ignoredLowFee %v live %v "+
+			"total %v", addedLowFeeTicketsCount, ignoredLowFeeTicketsCount,
+			liveTicketsCount,
+			addedLowFeeTicketsCount+ignoredLowFeeTicketsCount+liveTicketsCount)
+	}()
+}
+
+func (ctx *AppContext) processSpentMissedTickets(smt SpentMissedTicketsForBlock) {
+	start := time.Now()
+
+	// We use pointer because it is the fastest accessor.
+	smtickets := make([]*ticketMetadata, 0, len(smt.SmTickets))
+
+	var wg sync.WaitGroup // wait group for go routine exits
+
+	ctx.RLock()
+	for ticket, spent := range smt.SmTickets {
+		sm := &ticketMetadata{
+			blockHash:   smt.BlockHash,
+			blockHeight: smt.BlockHeight,
+			spent:       spent,
+			ticket:      ticket,
+			ticketType:  ticketTypeSpentMissed,
+		}
+		smtickets = append(smtickets, sm)
+
+		wg.Add(1)
+		go ctx.getticket(&wg, sm)
+	}
+	ctx.RUnlock()
+
+	wg.Wait()
+
+	var missedtickets []*chainhash.Hash
+	var spenttickets []*chainhash.Hash
+
+	for _, sm := range smtickets {
+		if sm.err != nil || sm.msa == "" {
+			// most likely can't look up the transaction because it's
+			// not in our wallet because it doesn't belong to us
+			continue
+		}
+
+		if !sm.spent {
+			missedtickets = append(missedtickets, sm.ticket)
+			continue
+		}
+
+		spenttickets = append(spenttickets, sm.ticket)
+	}
+
+	ticketCountNew := 0
+	ticketCountOld := 0
+
+	log.Debug("processSpentMissedTickets ctx.Lock")
+	ctx.Lock()
+	ticketCountOld = len(ctx.LiveTicketsMSA)
+	for _, ticket := range missedtickets {
+		delete(ctx.IgnoredLowFeeTicketsMSA, *ticket)
+		delete(ctx.LiveTicketsMSA, *ticket)
+	}
+	for _, ticket := range spenttickets {
+		delete(ctx.IgnoredLowFeeTicketsMSA, *ticket)
+		delete(ctx.LiveTicketsMSA, *ticket)
+	}
+	ticketCountNew = len(ctx.LiveTicketsMSA)
+	ctx.Unlock()
+	log.Debug("processSpentMissedTickets ctx.Unlock")
+
+	// Log ticket information outside of the handler.
+	go func() {
+		for _, ticket := range missedtickets {
+			log.Infof("removed missed ticket %v", ticket)
+		}
+		for _, ticket := range spenttickets {
+			log.Infof("removed spent ticket %v", ticket)
+		}
+
+		log.Infof("processSpentMissedTickets: height %v block %v "+
+			"duration %v spenttickets %v missedtickets %v ticketCountOld %v "+
+			"ticketCountNew %v", smt.BlockHeight, smt.BlockHash,
+			time.Since(start), len(spenttickets), len(missedtickets),
+			ticketCountOld, ticketCountNew)
+	}()
+}
+
+// processWinningTickets is called every time a new block comes in to handle
+// voting.  The function requires ASAP processing for each vote and therefore
+// it is not sequential and hard to read.  This is unfortunate but a reality of
+// speeding up code.
+func (ctx *AppContext) processWinningTickets(wt WinningTicketsForBlock) {
+	start := time.Now()
+
+	// We use pointer because it is the fastest accessor.
+	winners := make([]*ticketMetadata, 0, len(wt.WinningTickets))
+
+	var wg sync.WaitGroup // wait group for go routine exits
+
+	ctx.RLock()
+	for _, ticket := range wt.WinningTickets {
+		// Look up multi sig address.
+		msa, ok := ctx.LiveTicketsMSA[*ticket]
+		if !ok {
+			log.Debugf("unmanaged winning ticket: %v", ticket)
+			if ctx.Testing {
+				panic("boom")
+			}
+			continue
+		}
+
+		voteCfg, ok := ctx.UserVotingConfig[msa]
+		if !ok {
+			// Use defaults if not found.
+			log.Warnf("vote config not found for %v using defaults",
+				msa)
+			voteCfg = userdata.UserVotingConfig{
+				Userid:          0,
+				MultiSigAddress: msa,
+				VoteBits:        ctx.VotingConfig.VoteBits,
+				VoteBitsVersion: ctx.VotingConfig.VoteVersion,
+			}
+		} else if voteCfg.VoteBitsVersion != ctx.VotingConfig.VoteVersion {
+			// If the user's voting config has a vote version that
+			// is different from our global vote version that we
+			// plucked from dcrwallet walletinfo then just use the
+			// default votebits.
+			voteCfg.VoteBits = ctx.VotingConfig.VoteBits
+			log.Infof("userid %v multisigaddress %v vote "+
+				"version mismatch user %v stakepoold "+
+				"%v using votebits %d",
+				voteCfg.Userid, voteCfg.MultiSigAddress,
+				voteCfg.VoteBitsVersion,
+				ctx.VotingConfig.VoteVersion,
+				voteCfg.VoteBits)
+		}
+
+		w := &ticketMetadata{
+			msa:    msa,
+			ticket: ticket,
+			config: voteCfg,
+		}
+		winners = append(winners, w)
+
+		// When testing we don't send the tickets.
+		if ctx.Testing {
+			continue
+		}
+
+		wg.Add(1)
+		log.Debugf("calling GenerateVote with blockHash %v blockHeight %v "+
+			"ticket %v VoteBits %v VoteBitsExtended %v ",
+			wt.BlockHash, wt.BlockHeight, w.ticket, w.config.VoteBits,
+			ctx.VotingConfig.VoteBitsExtended)
+		go ctx.vote(&wg, wt.BlockHash, wt.BlockHeight, w)
+	}
+	ctx.RUnlock()
+
+	wg.Wait()
+
+	// Log ticket information outside of the handler.
+	go func() {
+		var dupeCount, errorCount, votedCount int
+
+		for _, w := range winners {
+			if w.err == nil {
+				votedCount++
+				w.err = errSuccess
+			} else {
+				// don't count duplicate votes as errors
+				if strings.HasPrefix(w.err.Error(), errDuplicateVote) {
+					// copy the txid into our metadata struct so it gets printed
+					// properly
+					voteErrParts := strings.Split(w.err.Error(), errDuplicateVote)
+					w.txid, _ = chainhash.NewHashFromStr(voteErrParts[1])
+					dupeCount++
+				} else {
+					errorCount++
+				}
+			}
+			log.Infof("voted ticket %v (hash: %v bits: %v) msa %v duration %v "+
+				"(%v + %v): %v", w.ticket, w.txid, w.config.VoteBits, w.msa,
+				w.duration, w.signDuration, w.sendDuration, w.err)
+		}
+		log.Infof("processWinningTickets: height %v block %v "+
+			"duration %v newvotes %v duplicatevotes %v errors %v",
+			wt.BlockHeight, wt.BlockHash, time.Since(start), votedCount,
+			dupeCount, errorCount)
+	}()
+}
+
+func (ctx *AppContext) GrpcCommandQueueHandler() {
+	defer ctx.Wg.Done()
+
+	for {
+		select {
+		case grpcCommand := <-ctx.GrpcCommandQueueChan:
+			switch grpcCommand.Command {
+			case GetAddedLowFeeTickets:
+				ctx.RLock()
+				ticketsMSA := ctx.AddedLowFeeTicketsMSA
+				ctx.RUnlock()
+				grpcCommand.ResponseTicketsMSAChan <- ticketsMSA
+			case GetIgnoredLowFeeTickets:
+				ctx.RLock()
+				ticketsMSA := ctx.IgnoredLowFeeTicketsMSA
+				grpcCommand.ResponseTicketsMSAChan <- ticketsMSA
+				ctx.RUnlock()
+			case GetLiveTickets:
+				ctx.RLock()
+				ticketsMSA := ctx.LiveTicketsMSA
+				ctx.RUnlock()
+				grpcCommand.ResponseTicketsMSAChan <- ticketsMSA
+			case SetAddedLowFeeTickets:
+				ctx.updateTicketData(grpcCommand.RequestTicketData)
+				grpcCommand.ResponseEmptyChan <- struct{}{}
+			case SetUserVotingPrefs:
+				ctx.updateUserData(grpcCommand.RequestUserData)
+				grpcCommand.ResponseEmptyChan <- struct{}{}
+			case ImportScript:
+				blockHeight := ctx.importScript(grpcCommand.RequestScript)
+				grpcCommand.ResponseBlockHeight <- blockHeight
+			default:
+				err := fmt.Errorf("grpcCommandQueueHandler: ignoring "+
+					"unregistered gRPC command '%v'",
+					grpcCommand.Command.String())
+				log.Warn(err)
+			}
+		case <-ctx.Quit:
+			return
+		}
+	}
+}
+
+func (ctx *AppContext) NewTicketHandler() {
+	defer ctx.Wg.Done()
+
+	for {
+		select {
+		case nt := <-ctx.NewTicketsChan:
+			go ctx.processNewTickets(nt)
+		case <-ctx.Quit:
+			return
+		}
+	}
+}
+
+func (ctx *AppContext) SpentmissedTicketHandler() {
+	defer ctx.Wg.Done()
+
+	for {
+		select {
+		case smt := <-ctx.SpentmissedTicketsChan:
+			go ctx.processSpentMissedTickets(smt)
+		case <-ctx.Quit:
+			return
+		}
+	}
+}
+
+func (ctx *AppContext) WinningTicketHandler() {
+	defer ctx.Wg.Done()
+
+	for {
+		select {
+		case wt := <-ctx.WinningTicketsChan:
+			go ctx.processWinningTickets(wt)
+		case <-ctx.Quit:
+			return
+		}
+	}
+}

--- a/backend/stakepoold/server.go
+++ b/backend/stakepoold/server.go
@@ -5,9 +5,7 @@
 package main
 
 import (
-	"bytes"
 	"encoding/gob"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -16,76 +14,19 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
-	"sync"
 	"time"
 
-	"github.com/decred/dcrd/blockchain/stake"
 	"github.com/decred/dcrd/chaincfg"
-	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrd/hdkeychain"
 	"github.com/decred/dcrd/rpcclient/v2"
-	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrstakepool/backend/stakepoold/rpc/rpcserver"
 	"github.com/decred/dcrstakepool/backend/stakepoold/userdata"
-	wallettypes "github.com/decred/dcrwallet/rpc/jsonrpc/types"
 	"github.com/decred/dcrwallet/wallet/v2/txrules"
 	"github.com/decred/dcrwallet/wallet/v2/udb"
 
 	_ "github.com/go-sql-driver/mysql"
 )
-
-type appContext struct {
-	sync.RWMutex
-
-	// locking required
-	addedLowFeeTicketsMSA   map[chainhash.Hash]string            // [ticket]multisigaddr
-	ignoredLowFeeTicketsMSA map[chainhash.Hash]string            // [ticket]multisigaddr
-	liveTicketsMSA          map[chainhash.Hash]string            // [ticket]multisigaddr
-	userVotingConfig        map[string]userdata.UserVotingConfig // [multisigaddr]
-
-	// no locking required
-	dataPath               string
-	feeAddrs               map[string]struct{}
-	poolFees               float64
-	grpcCommandQueueChan   chan *rpcserver.GRPCCommandQueue
-	newTicketsChan         chan NewTicketsForBlock
-	nodeConnection         *rpcclient.Client
-	params                 *chaincfg.Params
-	wg                     sync.WaitGroup // wait group for go routine exits
-	quit                   chan struct{}
-	spentmissedTicketsChan chan SpentMissedTicketsForBlock
-	userData               *userdata.UserData
-	votingConfig           *VotingConfig
-	walletConnection       *rpcclient.Client
-	winningTicketsChan     chan WinningTicketsForBlock
-	testing                bool // enabled only for testing
-}
-
-type NewTicketsForBlock struct {
-	blockHash   *chainhash.Hash
-	blockHeight int64
-	newTickets  []*chainhash.Hash
-}
-
-type SpentMissedTicketsForBlock struct {
-	blockHash   *chainhash.Hash
-	blockHeight int64
-	smTickets   map[*chainhash.Hash]bool
-}
-
-// VotingConfig contains global voting defaults.
-type VotingConfig struct {
-	VoteBits         uint16
-	VoteVersion      uint32
-	VoteBitsExtended string
-}
-
-type WinningTicketsForBlock struct {
-	blockHash      *chainhash.Hash
-	blockHeight    int64
-	winningTickets []*chainhash.Hash
-}
 
 const (
 	// TODO: sync with controllers/main.go MaxUsers
@@ -93,10 +34,7 @@ const (
 )
 
 var (
-	cfg              *config
-	errDuplicateVote = "-32603: already have transaction "
-	errNoTxInfo      = "-5: no information for transaction"
-	errSuccess       = errors.New("success")
+	cfg *config
 
 	dataFilenameTemplate = "KIND-DATE-VERSION.gob"
 	// save individual versions of fields in case they're changed in the future
@@ -117,8 +55,6 @@ var (
 		UserVotingConfig:   dataVersionUserVotingConfig,
 		Version:            dataVersionCommon,
 	}
-	ticketTypeNew         = "New"
-	ticketTypeSpentMissed = "SpentMissed"
 )
 
 // calculateFeeAddresses decodes the string of voting service payment addresses
@@ -181,92 +117,6 @@ func deriveChildAddresses(key *hdkeychain.ExtendedKey, startIndex, count uint32,
 	return addresses, nil
 }
 
-// evaluateStakePoolTicket evaluates a voting service ticket to see if it's
-// acceptable to the voting service. The ticket must pay out to the voting
-// service cold wallet, and must have a sufficient fee.
-func evaluateStakePoolTicket(ctx *appContext, tx *wire.MsgTx, blockHeight int32) (bool, error) {
-	// Check the first commitment output (txOuts[1])
-	// and ensure that the address found there exists
-	// in the list of approved addresses. Also ensure
-	// that the fee exists and is of the amount
-	// requested by the pool.
-	commitmentOut := tx.TxOut[1]
-	commitAddr, err := stake.AddrFromSStxPkScrCommitment(
-		commitmentOut.PkScript, ctx.params)
-	if err != nil {
-		return false, fmt.Errorf("Failed to parse commit out addr: %s",
-			err.Error())
-	}
-
-	// Extract the fee from the ticket.
-	in := dcrutil.Amount(0)
-	for i := range tx.TxOut {
-		if i%2 != 0 {
-			commitAmt, err := stake.AmountFromSStxPkScrCommitment(
-				tx.TxOut[i].PkScript)
-			if err != nil {
-				return false, fmt.Errorf("Failed to parse commit "+
-					"out amt for commit in vout %v: %s", i, err.Error())
-			}
-			in += commitAmt
-		}
-	}
-	out := dcrutil.Amount(0)
-	for i := range tx.TxOut {
-		out += dcrutil.Amount(tx.TxOut[i].Value)
-	}
-	fees := in - out
-
-	_, exists := ctx.feeAddrs[commitAddr.EncodeAddress()]
-	if exists {
-		commitAmt, err := stake.AmountFromSStxPkScrCommitment(
-			commitmentOut.PkScript)
-		if err != nil {
-			return false, fmt.Errorf("failed to parse commit "+
-				"out amt: %s", err.Error())
-		}
-
-		// Calculate the fee required based on the current
-		// height and the required amount from the pool.
-		feeNeeded := txrules.StakePoolTicketFee(dcrutil.Amount(
-			tx.TxOut[0].Value), fees, blockHeight, ctx.poolFees,
-			ctx.params)
-		if commitAmt < feeNeeded {
-			log.Warnf("User %s submitted ticket %v which "+
-				"has less fees than are required to use this "+
-				"Voting service and is being skipped (required: %v"+
-				", found %v)", commitAddr.EncodeAddress(),
-				tx.TxHash(), feeNeeded, commitAmt)
-
-			// Reject the entire transaction if it didn't
-			// pay the pool server fees.
-			return false, nil
-		}
-	} else {
-		log.Warnf("Unknown pool commitment address %s for ticket %v",
-			commitAddr.EncodeAddress(), tx.TxHash())
-		return false, nil
-	}
-
-	log.Debugf("Accepted valid voting service ticket %v committing %v in fees",
-		tx.TxHash(), tx.TxOut[0].Value)
-
-	return true, nil
-}
-
-// MsgTxFromHex returns a wire.MsgTx struct built from the transaction hex string
-func MsgTxFromHex(txhex string) (*wire.MsgTx, error) {
-	txBytes, err := hex.DecodeString(txhex)
-	if err != nil {
-		return nil, err
-	}
-	msgTx := wire.NewMsgTx()
-	if err = msgTx.Deserialize(bytes.NewReader(txBytes)); err != nil {
-		return nil, err
-	}
-	return msgTx, nil
-}
-
 func runMain() error {
 	// Load configuration and parse command line.  This function also
 	// initializes logging and configures it accordingly.
@@ -318,7 +168,7 @@ func runMain() error {
 		return err
 	}
 
-	votingConfig := VotingConfig{
+	votingConfig := rpcserver.VotingConfig{
 		VoteBits:         walletInfoRes.VoteBits,
 		VoteBitsExtended: walletInfoRes.VoteBitsExtended,
 		VoteVersion:      walletInfoRes.VoteVersion,
@@ -349,22 +199,22 @@ func runMain() error {
 		return err
 	}
 
-	ctx := &appContext{
-		addedLowFeeTicketsMSA:  addedLowFeeTicketsMSA,
-		dataPath:               cfg.DataDir,
-		feeAddrs:               feeAddrs,
-		poolFees:               cfg.PoolFees,
-		grpcCommandQueueChan:   make(chan *rpcserver.GRPCCommandQueue),
-		newTicketsChan:         make(chan NewTicketsForBlock),
-		params:                 activeNetParams.Params,
-		quit:                   make(chan struct{}),
-		spentmissedTicketsChan: make(chan SpentMissedTicketsForBlock),
-		userData:               userData,
-		userVotingConfig:       userVotingConfig,
-		votingConfig:           &votingConfig,
-		walletConnection:       walletConn,
-		winningTicketsChan:     make(chan WinningTicketsForBlock),
-		testing:                false,
+	ctx := &rpcserver.AppContext{
+		AddedLowFeeTicketsMSA:  addedLowFeeTicketsMSA,
+		DataPath:               cfg.DataDir,
+		FeeAddrs:               feeAddrs,
+		PoolFees:               cfg.PoolFees,
+		GrpcCommandQueueChan:   make(chan *rpcserver.GRPCCommandQueue),
+		NewTicketsChan:         make(chan rpcserver.NewTicketsForBlock),
+		Params:                 activeNetParams.Params,
+		Quit:                   make(chan struct{}),
+		SpentmissedTicketsChan: make(chan rpcserver.SpentMissedTicketsForBlock),
+		UserData:               userData,
+		UserVotingConfig:       userVotingConfig,
+		VotingConfig:           &votingConfig,
+		WalletConnection:       walletConn,
+		WinningTicketsChan:     make(chan rpcserver.WinningTicketsForBlock),
+		Testing:                false,
 	}
 
 	// Daemon client connection
@@ -373,7 +223,7 @@ func runMain() error {
 		log.Infof("Connection to dcrd failed: %v", err)
 		return err
 	}
-	ctx.nodeConnection = nodeConn
+	ctx.NodeConnection = nodeConn
 
 	// Display connected network
 	curnet, err := nodeConn.GetCurrentNet()
@@ -391,7 +241,7 @@ func runMain() error {
 	}
 
 	// load AddedLowFeeTicketsMSA from disk cache if necessary
-	if len(ctx.addedLowFeeTicketsMSA) == 0 && errMySQLFetchAddedLowFeeTickets != nil {
+	if len(ctx.AddedLowFeeTicketsMSA) == 0 && errMySQLFetchAddedLowFeeTickets != nil {
 		err = loadData(ctx, "AddedLowFeeTickets")
 		if err != nil {
 			// might not have any so continue
@@ -399,12 +249,12 @@ func runMain() error {
 				"cache: %v", err)
 		} else {
 			log.Infof("Loaded %v AddedLowFeeTickets from disk cache",
-				len(ctx.addedLowFeeTicketsMSA))
+				len(ctx.AddedLowFeeTicketsMSA))
 		}
 	}
 
 	// load userVotingConfig from disk cache if necessary
-	if len(ctx.userVotingConfig) == 0 && errMySQLFetchUserVotingConfig != nil {
+	if len(ctx.UserVotingConfig) == 0 && errMySQLFetchUserVotingConfig != nil {
 		err = loadData(ctx, "UserVotingConfig")
 		if err != nil {
 			// we could possibly die out here but it's probably better
@@ -414,11 +264,11 @@ func runMain() error {
 				"cache: %v", err)
 		} else {
 			log.Infof("Loaded UserVotingConfig for %d users from disk cache",
-				len(ctx.userVotingConfig))
+				len(ctx.UserVotingConfig))
 		}
 	}
 
-	if len(ctx.userVotingConfig) == 0 {
+	if len(ctx.UserVotingConfig) == 0 {
 		log.Warn("0 active users")
 	}
 
@@ -432,7 +282,7 @@ func runMain() error {
 		}
 		log.Infof("current block height %v hash %v", curHeight, curHash)
 
-		ctx.ignoredLowFeeTicketsMSA, ctx.liveTicketsMSA, err = walletGetTickets(ctx)
+		ctx.IgnoredLowFeeTicketsMSA, ctx.LiveTicketsMSA, err = walletGetTickets(ctx)
 		if err != nil {
 			log.Errorf("unable to get tickets: %v", err)
 			return err
@@ -476,7 +326,7 @@ func runMain() error {
 	log.Info("subscribed to notifications from dcrd")
 
 	if !cfg.NoRPCListen {
-		if _, err = startGRPCServers(ctx.grpcCommandQueueChan); err != nil {
+		if _, err = startGRPCServers(ctx.GrpcCommandQueueChan); err != nil {
 			fmt.Printf("Failed to start GRPCServers: %s\n", err.Error())
 			return err
 		}
@@ -493,34 +343,34 @@ func runMain() error {
 		// Close the channel so multiple goroutines can get the message
 		log.Info("CTRL+C hit.  Closing goroutines.")
 		saveData(ctx)
-		close(ctx.quit)
+		close(ctx.Quit)
 	}()
 
-	ctx.wg.Add(4)
-	go ctx.grpcCommandQueueHandler()
-	go ctx.newTicketHandler()
-	go ctx.spentmissedTicketHandler()
-	go ctx.winningTicketHandler()
+	ctx.Wg.Add(4)
+	go ctx.GrpcCommandQueueHandler()
+	go ctx.NewTicketHandler()
+	go ctx.SpentmissedTicketHandler()
+	go ctx.WinningTicketHandler()
 
 	if cfg.NoRPCListen {
 		// Start reloading when a ticker fires
 		configTicker := time.NewTicker(time.Second * 240)
 		go func() {
 			for range configTicker.C {
-				err := ctx.updateTicketDataFromMySQL()
+				err := ctx.UpdateTicketDataFromMySQL()
 				if err != nil {
-					log.Warnf("updateTicketDataFromMySQL failed %v:", err)
+					log.Warnf("UpdateTicketDataFromMySQL failed %v:", err)
 				}
-				err = ctx.updateUserDataFromMySQL()
+				err = ctx.UpdateUserDataFromMySQL()
 				if err != nil {
-					log.Warnf("updateUserDataFromMySQL failed %v:", err)
+					log.Warnf("UpdateUserDataFromMySQL failed %v:", err)
 				}
 			}
 		}()
 	}
 
 	// Wait for CTRL+C to signal goroutines to terminate via quit channel.
-	ctx.wg.Wait()
+	ctx.Wg.Wait()
 
 	return nil
 }
@@ -549,17 +399,17 @@ func getDataNames() map[string]string {
 }
 
 // pruneData prunes any extra save files.
-func pruneData(ctx *appContext) error {
+func pruneData(ctx *rpcserver.AppContext) error {
 	saveFiles := getDataNames()
 
-	if !fileExists(ctx.dataPath) {
-		return fmt.Errorf("datapath %v doesn't exist", ctx.dataPath)
+	if !fileExists(ctx.DataPath) {
+		return fmt.Errorf("datapath %v doesn't exist", ctx.DataPath)
 	}
 
 	for dataKind, dataVersion := range saveFiles {
 		var filesToPrune []string
 
-		files, err := ioutil.ReadDir(ctx.dataPath)
+		files, err := ioutil.ReadDir(ctx.DataPath)
 		if err != nil {
 			return err
 		}
@@ -569,7 +419,7 @@ func pruneData(ctx *appContext) error {
 			if strings.HasPrefix(file.Name(), strings.ToLower(dataKind)) &&
 				strings.Contains(file.Name(), dataVersion) &&
 				strings.HasSuffix(file.Name(), ".gob") {
-				filesToPrune = append(filesToPrune, filepath.Join(ctx.dataPath, file.Name()))
+				filesToPrune = append(filesToPrune, filepath.Join(ctx.DataPath, file.Name()))
 			}
 		}
 
@@ -596,7 +446,7 @@ func pruneData(ctx *appContext) error {
 
 // loadData looks for and attempts to load into memory the most recent save
 // file for a passed data kind.
-func loadData(ctx *appContext, dataKind string) error {
+func loadData(ctx *rpcserver.AppContext, dataKind string) error {
 	dataVersion := ""
 	found := false
 	saveFiles := getDataNames()
@@ -612,8 +462,8 @@ func loadData(ctx *appContext, dataKind string) error {
 		return errors.New("unhandled data kind of " + dataKind)
 	}
 
-	if fileExists(ctx.dataPath) {
-		files, err := ioutil.ReadDir(ctx.dataPath)
+	if fileExists(ctx.DataPath) {
+		files, err := ioutil.ReadDir(ctx.DataPath)
 		if err != nil {
 			return err
 		}
@@ -636,7 +486,7 @@ func loadData(ctx *appContext, dataKind string) error {
 			return nil
 		}
 
-		fullPath := filepath.Join(ctx.dataPath, lastseen)
+		fullPath := filepath.Join(ctx.DataPath, lastseen)
 
 		r, err := os.Open(fullPath)
 		if err != nil {
@@ -645,17 +495,17 @@ func loadData(ctx *appContext, dataKind string) error {
 		dec := gob.NewDecoder(r)
 		switch dataKind {
 		case "AddedLowFeeTickets":
-			err = dec.Decode(&ctx.addedLowFeeTicketsMSA)
+			err = dec.Decode(&ctx.AddedLowFeeTicketsMSA)
 			if err != nil {
 				return err
 			}
 		case "LiveTickets":
-			err = dec.Decode(&ctx.liveTicketsMSA)
+			err = dec.Decode(&ctx.LiveTicketsMSA)
 			if err != nil {
 				return err
 			}
 		case "UserVotingConfig":
-			err = dec.Decode(&ctx.userVotingConfig)
+			err = dec.Decode(&ctx.UserVotingConfig)
 			if err != nil {
 				return err
 			}
@@ -665,12 +515,12 @@ func loadData(ctx *appContext, dataKind string) error {
 	}
 
 	// shouldn't get here -- data dir is created on startup
-	return errors.New("loadData - path " + ctx.dataPath + " does not exist")
+	return errors.New("loadData - path " + ctx.DataPath + " does not exist")
 }
 
 // saveData saves some appContext fields to a file so they can be loaded back
 // into memory at next run.
-func saveData(ctx *appContext) {
+func saveData(ctx *rpcserver.AppContext) {
 	ctx.Lock()
 	defer ctx.Unlock()
 
@@ -681,22 +531,22 @@ func saveData(ctx *appContext) {
 		destFilename := strings.Replace(dataFilenameTemplate, "KIND", filenameprefix, -1)
 		destFilename = strings.Replace(destFilename, "DATE", t.Format("2006_01_02_15_04_05"), -1)
 		destFilename = strings.Replace(destFilename, "VERSION", dataversion, -1)
-		destPath := strings.ToLower(filepath.Join(ctx.dataPath, destFilename))
+		destPath := strings.ToLower(filepath.Join(ctx.DataPath, destFilename))
 
 		// Pre-validate whether we'll be saving or not.
 		switch filenameprefix {
 		case "AddedLowFeeTickets":
-			if len(ctx.addedLowFeeTicketsMSA) == 0 {
+			if len(ctx.AddedLowFeeTicketsMSA) == 0 {
 				log.Warn("saveData: addedLowFeeTicketsMSA is empty; skipping save")
 				continue
 			}
 		case "LiveTickets":
-			if len(ctx.liveTicketsMSA) == 0 {
+			if len(ctx.LiveTicketsMSA) == 0 {
 				log.Warn("saveData: liveTicketsMSA is empty; skipping save")
 				continue
 			}
 		case "UserVotingConfig":
-			if len(ctx.userVotingConfig) == 0 {
+			if len(ctx.UserVotingConfig) == 0 {
 				log.Warn("saveData: UserVotingConfig is empty; skipping save")
 				continue
 			}
@@ -707,7 +557,7 @@ func saveData(ctx *appContext) {
 
 		w, err := os.Create(destPath)
 		if err != nil {
-			log.Errorf("Error opening file %s: %v", ctx.dataPath, err)
+			log.Errorf("Error opening file %s: %v", ctx.DataPath, err)
 			continue
 		}
 		defer w.Close()
@@ -715,570 +565,25 @@ func saveData(ctx *appContext) {
 		switch filenameprefix {
 		case "AddedLowFeeTickets":
 			enc := gob.NewEncoder(w)
-			if err := enc.Encode(&ctx.addedLowFeeTicketsMSA); err != nil {
-				log.Errorf("Failed to encode file %s: %v", ctx.dataPath, err)
+			if err := enc.Encode(&ctx.AddedLowFeeTicketsMSA); err != nil {
+				log.Errorf("Failed to encode file %s: %v", ctx.DataPath, err)
 				continue
 			}
 		case "LiveTickets":
 			enc := gob.NewEncoder(w)
-			if err := enc.Encode(&ctx.liveTicketsMSA); err != nil {
-				log.Errorf("Failed to encode file %s: %v", ctx.dataPath, err)
+			if err := enc.Encode(&ctx.LiveTicketsMSA); err != nil {
+				log.Errorf("Failed to encode file %s: %v", ctx.DataPath, err)
 				continue
 			}
 		case "UserVotingConfig":
 			enc := gob.NewEncoder(w)
-			if err := enc.Encode(&ctx.userVotingConfig); err != nil {
-				log.Errorf("Failed to encode file %s: %v", ctx.dataPath, err)
+			if err := enc.Encode(&ctx.UserVotingConfig); err != nil {
+				log.Errorf("Failed to encode file %s: %v", ctx.DataPath, err)
 				continue
 			}
 		}
 
 		log.Infof("saveData: successfully saved %v data to %s",
 			filenameprefix, destPath)
-	}
-}
-
-// ticketMetadata contains all the bits and pieces required to vote new tickets,
-// to look up new/missed/spent tickets, and to print statistics after usage.
-type ticketMetadata struct {
-	blockHash    *chainhash.Hash
-	blockHeight  int64
-	msa          string                    // multisig
-	ticket       *chainhash.Hash           // ticket
-	spent        bool                      // spent (true) or missed (false)
-	config       userdata.UserVotingConfig // voting config
-	duration     time.Duration             // overall vote duration
-	getDuration  time.Duration             // time to gettransaction
-	hex          string                    // hex encoded tx data
-	txid         *chainhash.Hash           // transaction id
-	ticketType   string                    // new or spentmissed
-	signDuration time.Duration             // time to generatevote
-	sendDuration time.Duration             // time to sendrawtransaction
-	err          error                     // log errors along the way
-}
-
-// getticket pulls the transaction information for a ticket from dcrwallet. This is a go routine!
-func (ctx *appContext) getticket(wg *sync.WaitGroup, nt *ticketMetadata) {
-	start := time.Now()
-
-	defer func() {
-		nt.duration = time.Since(start)
-		wg.Done()
-	}()
-
-	// Ask wallet to look up vote transaction to see if it belongs to us
-	log.Debugf("calling GetTransaction for %v ticket %v",
-		strings.ToLower(nt.ticketType), nt.ticket)
-	res, err := ctx.walletConnection.GetTransaction(nt.ticket)
-	nt.getDuration = time.Since(start)
-	if err != nil {
-		// suppress "No information for transaction ..." errors
-		if !strings.HasPrefix(err.Error(), errNoTxInfo) {
-			log.Warnf("unexpected GetTransaction error: '%v' for %v",
-				err, nt.ticket)
-		}
-		return
-	}
-	for i := range res.Details {
-		_, ok := ctx.userVotingConfig[res.Details[i].Address]
-		if ok {
-			// multisigaddress will match if it belongs a pool user
-			nt.msa = res.Details[i].Address
-
-			if nt.ticketType == ticketTypeNew {
-				// TODO(maybe): we could check if the ticket was added to the
-				// low fee list here but since it was just mined, it should be
-				// extremely unlikely to have been added before it was mined.
-
-				// save for fee checking
-				nt.hex = res.Hex
-
-			}
-			break
-		}
-	}
-	log.Debugf("getticket finished for %v ticket %v",
-		strings.ToLower(nt.ticketType), nt.ticket)
-}
-
-func (ctx *appContext) updateTicketData(newAddedLowFeeTicketsMSA map[chainhash.Hash]string) {
-	log.Debug("updateTicketData ctx.Lock")
-	ctx.Lock()
-
-	// apply unconditional updates
-	for tickethash, msa := range newAddedLowFeeTicketsMSA {
-		// remove from ignored list if present
-		delete(ctx.ignoredLowFeeTicketsMSA, tickethash)
-		// add to live list
-		ctx.liveTicketsMSA[tickethash] = msa
-	}
-
-	// if something is being deleted from the db by this update then
-	// we need to put it back on the ignored list
-	for th, m := range ctx.addedLowFeeTicketsMSA {
-		_, exists := newAddedLowFeeTicketsMSA[th]
-		if !exists {
-			ctx.ignoredLowFeeTicketsMSA[th] = m
-		}
-	}
-
-	ctx.addedLowFeeTicketsMSA = newAddedLowFeeTicketsMSA
-	addedLowFeeTicketsCount := len(ctx.addedLowFeeTicketsMSA)
-	ignoredLowFeeTicketsCount := len(ctx.ignoredLowFeeTicketsMSA)
-	liveTicketsCount := len(ctx.liveTicketsMSA)
-	ctx.Unlock()
-	log.Debug("updateTicketData ctx.Unlock")
-	// Log ticket information outside of the handler.
-	go func() {
-		log.Infof("tickets loaded -- addedLowFee %v ignoredLowFee %v live %v "+
-			"total %v", addedLowFeeTicketsCount, ignoredLowFeeTicketsCount,
-			liveTicketsCount,
-			addedLowFeeTicketsCount+ignoredLowFeeTicketsCount+liveTicketsCount)
-
-	}()
-}
-
-func (ctx *appContext) updateTicketDataFromMySQL() error {
-	start := time.Now()
-	newAddedLowFeeTicketsMSA, err := ctx.userData.MySQLFetchAddedLowFeeTickets()
-	log.Infof("MySQLFetchAddedLowFeeTickets took %v", time.Since(start))
-	if err != nil {
-		return err
-	}
-	ctx.updateTicketData(newAddedLowFeeTicketsMSA)
-	return nil
-}
-
-func (ctx *appContext) importScript(script []byte) int64 {
-	err := ctx.walletConnection.ImportScript(script)
-	if err != nil {
-		log.Errorf("importScript: importScript rpc failed: %v", err)
-		return -1
-	}
-
-	_, block, err := ctx.walletConnection.GetBestBlock()
-	if err != nil {
-		log.Errorf("importScript: getBetBlock rpc failed: %v", err)
-		return -1
-	}
-	return block
-}
-
-func (ctx *appContext) updateUserData(newUserVotingConfig map[string]userdata.UserVotingConfig) {
-	log.Debug("updateUserData ctx.Lock")
-	ctx.Lock()
-	ctx.userVotingConfig = newUserVotingConfig
-	ctx.Unlock()
-	log.Debug("updateUserData ctx.Unlock")
-}
-
-func (ctx *appContext) updateUserDataFromMySQL() error {
-	start := time.Now()
-	newUserVotingConfig, err := ctx.userData.MySQLFetchUserVotingConfig()
-	log.Infof("MySQLFetchUserVotingConfig took %v",
-		time.Since(start))
-	if err != nil {
-		return err
-	}
-	ctx.updateUserData(newUserVotingConfig)
-	return nil
-}
-
-// vote Generates a vote and send it off to the network.  This is a go routine!
-func (ctx *appContext) vote(wg *sync.WaitGroup, blockHash *chainhash.Hash, blockHeight int64, w *ticketMetadata) {
-	start := time.Now()
-
-	defer func() {
-		w.duration = time.Since(start)
-		wg.Done()
-	}()
-
-	// Ask wallet to generate vote result.
-	var res *wallettypes.GenerateVoteResult
-	res, w.err = ctx.walletConnection.GenerateVote(blockHash, blockHeight,
-		w.ticket, w.config.VoteBits, ctx.votingConfig.VoteBitsExtended)
-	if w.err != nil || res.Hex == "" {
-		return
-	}
-	w.signDuration = time.Since(start)
-
-	// Create raw transaction.
-	var buf []byte
-	buf, w.err = hex.DecodeString(res.Hex)
-	if w.err != nil {
-		return
-	}
-	newTx := wire.NewMsgTx()
-	w.err = newTx.FromBytes(buf)
-	if w.err != nil {
-		return
-	}
-
-	// Ask node to transmit raw transaction.
-	startSend := time.Now()
-	tx, err := ctx.nodeConnection.SendRawTransaction(newTx, false)
-	if err != nil {
-		log.Infof("vote err %v", err)
-		w.err = err
-	} else {
-		w.txid = tx
-	}
-	w.sendDuration = time.Since(startSend)
-}
-
-func (ctx *appContext) processNewTickets(nt NewTicketsForBlock) {
-	start := time.Now()
-
-	// We use pointer because it is the fastest accessor.
-	newtickets := make([]*ticketMetadata, 0, len(nt.newTickets))
-
-	var wg sync.WaitGroup // wait group for go routine exits
-
-	ctx.RLock()
-	for _, tickethash := range nt.newTickets {
-		n := &ticketMetadata{
-			blockHash:   nt.blockHash,
-			blockHeight: nt.blockHeight,
-			ticket:      tickethash,
-			ticketType:  ticketTypeNew,
-		}
-		newtickets = append(newtickets, n)
-
-		wg.Add(1)
-		go ctx.getticket(&wg, n)
-	}
-	ctx.RUnlock()
-
-	wg.Wait()
-
-	newIgnoredLowFeeTickets := make(map[chainhash.Hash]string)
-	newLiveTickets := make(map[chainhash.Hash]string)
-
-	for _, n := range newtickets {
-		if n.err != nil || n.msa == "" {
-			// most likely can't look up the transaction because it's
-			// not in our wallet because it doesn't belong to us
-			continue
-		}
-
-		msgTx, err := MsgTxFromHex(n.hex)
-		if err != nil {
-			log.Warnf("MsgTxFromHex failed for %v: %v", n.hex, err)
-			continue
-		}
-
-		ticketFeesValid, err := evaluateStakePoolTicket(ctx, msgTx, int32(nt.blockHeight))
-		if err != nil {
-			log.Warnf("ignoring ticket %v for msa %v ticketFeesValid %v err %v",
-				n.ticket, n.msa, ticketFeesValid, err)
-			newIgnoredLowFeeTickets[*n.ticket] = n.msa
-		}
-
-		newLiveTickets[*n.ticket] = n.msa
-	}
-
-	log.Debug("processNewTickets ctx.Lock")
-	ctx.Lock()
-	// update ignored low fee tickets
-	for ticket, msa := range newIgnoredLowFeeTickets {
-		ctx.ignoredLowFeeTicketsMSA[ticket] = msa
-	}
-
-	// update live tickets
-	for ticket, msa := range newLiveTickets {
-		ctx.liveTicketsMSA[ticket] = msa
-	}
-
-	// update counts
-	addedLowFeeTicketsCount := len(ctx.addedLowFeeTicketsMSA)
-	ignoredLowFeeTicketsCount := len(ctx.ignoredLowFeeTicketsMSA)
-	liveTicketsCount := len(ctx.liveTicketsMSA)
-	ctx.Unlock()
-	log.Debug("processNewTickets ctx.Unlock")
-
-	// Log ticket information outside of the handler.
-	go func() {
-		for ticket, msa := range newLiveTickets {
-			log.Infof("added new live ticket %v msa %v", ticket, msa)
-		}
-
-		for ticket, msa := range newIgnoredLowFeeTickets {
-			log.Infof("added new ignored ticket %v msa %v", ticket, msa)
-		}
-
-		log.Infof("processNewTickets: height %v block %v duration %v "+
-			"ignored %v live %v notours %v", nt.blockHeight,
-			nt.blockHash, time.Since(start), len(newIgnoredLowFeeTickets),
-			len(newLiveTickets),
-			len(nt.newTickets)-len(newIgnoredLowFeeTickets)-len(newLiveTickets))
-		log.Infof("tickets loaded -- addedLowFee %v ignoredLowFee %v live %v "+
-			"total %v", addedLowFeeTicketsCount, ignoredLowFeeTicketsCount,
-			liveTicketsCount,
-			addedLowFeeTicketsCount+ignoredLowFeeTicketsCount+liveTicketsCount)
-	}()
-}
-
-func (ctx *appContext) processSpentMissedTickets(smt SpentMissedTicketsForBlock) {
-	start := time.Now()
-
-	// We use pointer because it is the fastest accessor.
-	smtickets := make([]*ticketMetadata, 0, len(smt.smTickets))
-
-	var wg sync.WaitGroup // wait group for go routine exits
-
-	ctx.RLock()
-	for ticket, spent := range smt.smTickets {
-		sm := &ticketMetadata{
-			blockHash:   smt.blockHash,
-			blockHeight: smt.blockHeight,
-			spent:       spent,
-			ticket:      ticket,
-			ticketType:  ticketTypeSpentMissed,
-		}
-		smtickets = append(smtickets, sm)
-
-		wg.Add(1)
-		go ctx.getticket(&wg, sm)
-	}
-	ctx.RUnlock()
-
-	wg.Wait()
-
-	var missedtickets []*chainhash.Hash
-	var spenttickets []*chainhash.Hash
-
-	for _, sm := range smtickets {
-		if sm.err != nil || sm.msa == "" {
-			// most likely can't look up the transaction because it's
-			// not in our wallet because it doesn't belong to us
-			continue
-		}
-
-		if !sm.spent {
-			missedtickets = append(missedtickets, sm.ticket)
-			continue
-		}
-
-		spenttickets = append(spenttickets, sm.ticket)
-	}
-
-	ticketCountNew := 0
-	ticketCountOld := 0
-
-	log.Debug("processSpentMissedTickets ctx.Lock")
-	ctx.Lock()
-	ticketCountOld = len(ctx.liveTicketsMSA)
-	for _, ticket := range missedtickets {
-		delete(ctx.ignoredLowFeeTicketsMSA, *ticket)
-		delete(ctx.liveTicketsMSA, *ticket)
-	}
-	for _, ticket := range spenttickets {
-		delete(ctx.ignoredLowFeeTicketsMSA, *ticket)
-		delete(ctx.liveTicketsMSA, *ticket)
-	}
-	ticketCountNew = len(ctx.liveTicketsMSA)
-	ctx.Unlock()
-	log.Debug("processSpentMissedTickets ctx.Unlock")
-
-	// Log ticket information outside of the handler.
-	go func() {
-		for _, ticket := range missedtickets {
-			log.Infof("removed missed ticket %v", ticket)
-		}
-		for _, ticket := range spenttickets {
-			log.Infof("removed spent ticket %v", ticket)
-		}
-
-		log.Infof("processSpentMissedTickets: height %v block %v "+
-			"duration %v spenttickets %v missedtickets %v ticketCountOld %v "+
-			"ticketCountNew %v", smt.blockHeight, smt.blockHash,
-			time.Since(start), len(spenttickets), len(missedtickets),
-			ticketCountOld, ticketCountNew)
-	}()
-}
-
-// processWinningTickets is called every time a new block comes in to handle
-// voting.  The function requires ASAP processing for each vote and therefore
-// it is not sequential and hard to read.  This is unfortunate but a reality of
-// speeding up code.
-func (ctx *appContext) processWinningTickets(wt WinningTicketsForBlock) {
-	start := time.Now()
-
-	// We use pointer because it is the fastest accessor.
-	winners := make([]*ticketMetadata, 0, len(wt.winningTickets))
-
-	var wg sync.WaitGroup // wait group for go routine exits
-
-	ctx.RLock()
-	for _, ticket := range wt.winningTickets {
-		// Look up multi sig address.
-		msa, ok := ctx.liveTicketsMSA[*ticket]
-		if !ok {
-			log.Debugf("unmanaged winning ticket: %v", ticket)
-			if ctx.testing {
-				panic("boom")
-			}
-			continue
-		}
-
-		voteCfg, ok := ctx.userVotingConfig[msa]
-		if !ok {
-			// Use defaults if not found.
-			log.Warnf("vote config not found for %v using defaults",
-				msa)
-			voteCfg = userdata.UserVotingConfig{
-				Userid:          0,
-				MultiSigAddress: msa,
-				VoteBits:        ctx.votingConfig.VoteBits,
-				VoteBitsVersion: ctx.votingConfig.VoteVersion,
-			}
-		} else if voteCfg.VoteBitsVersion != ctx.votingConfig.VoteVersion {
-			// If the user's voting config has a vote version that
-			// is different from our global vote version that we
-			// plucked from dcrwallet walletinfo then just use the
-			// default votebits.
-			voteCfg.VoteBits = ctx.votingConfig.VoteBits
-			log.Infof("userid %v multisigaddress %v vote "+
-				"version mismatch user %v stakepoold "+
-				"%v using votebits %d",
-				voteCfg.Userid, voteCfg.MultiSigAddress,
-				voteCfg.VoteBitsVersion,
-				ctx.votingConfig.VoteVersion,
-				voteCfg.VoteBits)
-		}
-
-		w := &ticketMetadata{
-			msa:    msa,
-			ticket: ticket,
-			config: voteCfg,
-		}
-		winners = append(winners, w)
-
-		// When testing we don't send the tickets.
-		if ctx.testing {
-			continue
-		}
-
-		wg.Add(1)
-		log.Debugf("calling GenerateVote with blockHash %v blockHeight %v "+
-			"ticket %v VoteBits %v VoteBitsExtended %v ",
-			wt.blockHash, wt.blockHeight, w.ticket, w.config.VoteBits,
-			ctx.votingConfig.VoteBitsExtended)
-		go ctx.vote(&wg, wt.blockHash, wt.blockHeight, w)
-	}
-	ctx.RUnlock()
-
-	wg.Wait()
-
-	// Log ticket information outside of the handler.
-	go func() {
-		var dupeCount, errorCount, votedCount int
-
-		for _, w := range winners {
-			if w.err == nil {
-				votedCount++
-				w.err = errSuccess
-			} else {
-				// don't count duplicate votes as errors
-				if strings.HasPrefix(w.err.Error(), errDuplicateVote) {
-					// copy the txid into our metadata struct so it gets printed
-					// properly
-					voteErrParts := strings.Split(w.err.Error(), errDuplicateVote)
-					w.txid, _ = chainhash.NewHashFromStr(voteErrParts[1])
-					dupeCount++
-				} else {
-					errorCount++
-				}
-			}
-			log.Infof("voted ticket %v (hash: %v bits: %v) msa %v duration %v "+
-				"(%v + %v): %v", w.ticket, w.txid, w.config.VoteBits, w.msa,
-				w.duration, w.signDuration, w.sendDuration, w.err)
-		}
-		log.Infof("processWinningTickets: height %v block %v "+
-			"duration %v newvotes %v duplicatevotes %v errors %v",
-			wt.blockHeight, wt.blockHash, time.Since(start), votedCount,
-			dupeCount, errorCount)
-	}()
-}
-
-func (ctx *appContext) grpcCommandQueueHandler() {
-	defer ctx.wg.Done()
-
-	for {
-		select {
-		case grpcCommand := <-ctx.grpcCommandQueueChan:
-			switch grpcCommand.Command {
-			case rpcserver.GetAddedLowFeeTickets:
-				ctx.RLock()
-				ticketsMSA := ctx.addedLowFeeTicketsMSA
-				ctx.RUnlock()
-				grpcCommand.ResponseTicketsMSAChan <- ticketsMSA
-			case rpcserver.GetIgnoredLowFeeTickets:
-				ctx.RLock()
-				ticketsMSA := ctx.ignoredLowFeeTicketsMSA
-				grpcCommand.ResponseTicketsMSAChan <- ticketsMSA
-				ctx.RUnlock()
-			case rpcserver.GetLiveTickets:
-				ctx.RLock()
-				ticketsMSA := ctx.liveTicketsMSA
-				ctx.RUnlock()
-				grpcCommand.ResponseTicketsMSAChan <- ticketsMSA
-			case rpcserver.SetAddedLowFeeTickets:
-				ctx.updateTicketData(grpcCommand.RequestTicketData)
-				grpcCommand.ResponseEmptyChan <- struct{}{}
-			case rpcserver.SetUserVotingPrefs:
-				ctx.updateUserData(grpcCommand.RequestUserData)
-				grpcCommand.ResponseEmptyChan <- struct{}{}
-			case rpcserver.ImportScript:
-				blockHeight := ctx.importScript(grpcCommand.RequestScript)
-				grpcCommand.ResponseBlockHeight <- blockHeight
-			default:
-				err := fmt.Errorf("grpcCommandQueueHandler: ignoring "+
-					"unregistered gRPC command '%v'",
-					grpcCommand.Command.String())
-				log.Warn(err)
-			}
-		case <-ctx.quit:
-			return
-		}
-	}
-}
-
-func (ctx *appContext) newTicketHandler() {
-	defer ctx.wg.Done()
-
-	for {
-		select {
-		case nt := <-ctx.newTicketsChan:
-			go ctx.processNewTickets(nt)
-		case <-ctx.quit:
-			return
-		}
-	}
-}
-
-func (ctx *appContext) spentmissedTicketHandler() {
-	defer ctx.wg.Done()
-
-	for {
-		select {
-		case smt := <-ctx.spentmissedTicketsChan:
-			go ctx.processSpentMissedTickets(smt)
-		case <-ctx.quit:
-			return
-		}
-	}
-}
-
-func (ctx *appContext) winningTicketHandler() {
-	defer ctx.wg.Done()
-
-	for {
-		select {
-		case wt := <-ctx.winningTicketsChan:
-			go ctx.processWinningTickets(wt)
-		case <-ctx.quit:
-			return
-		}
 	}
 }

--- a/backend/stakepoold/server.go
+++ b/backend/stakepoold/server.go
@@ -204,7 +204,6 @@ func runMain() error {
 		DataPath:               cfg.DataDir,
 		FeeAddrs:               feeAddrs,
 		PoolFees:               cfg.PoolFees,
-		GrpcCommandQueueChan:   make(chan *rpcserver.GRPCCommandQueue),
 		NewTicketsChan:         make(chan rpcserver.NewTicketsForBlock),
 		Params:                 activeNetParams.Params,
 		Quit:                   make(chan struct{}),
@@ -326,7 +325,7 @@ func runMain() error {
 	log.Info("subscribed to notifications from dcrd")
 
 	if !cfg.NoRPCListen {
-		if _, err = startGRPCServers(ctx.GrpcCommandQueueChan); err != nil {
+		if _, err = startGRPCServers(ctx); err != nil {
 			fmt.Printf("Failed to start GRPCServers: %s\n", err.Error())
 			return err
 		}
@@ -346,8 +345,7 @@ func runMain() error {
 		close(ctx.Quit)
 	}()
 
-	ctx.Wg.Add(4)
-	go ctx.GrpcCommandQueueHandler()
+	ctx.Wg.Add(3)
 	go ctx.NewTicketHandler()
 	go ctx.SpentmissedTicketHandler()
 	go ctx.WinningTicketHandler()

--- a/backend/stakepoold/server_test.go
+++ b/backend/stakepoold/server_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrstakepool/backend/stakepoold/rpc/rpcserver"
 	"github.com/decred/dcrstakepool/backend/stakepoold/userdata"
 )
 
@@ -85,21 +86,21 @@ func randString(n int) string {
 }
 
 var (
-	c  *appContext
-	wt WinningTicketsForBlock
+	c  *rpcserver.AppContext
+	wt rpcserver.WinningTicketsForBlock
 )
 
 func init() {
 
-	c = &appContext{
-		liveTicketsMSA: make(map[chainhash.Hash]string),
-		votingConfig: &VotingConfig{
+	c = &rpcserver.AppContext{
+		LiveTicketsMSA: make(map[chainhash.Hash]string),
+		VotingConfig: &rpcserver.VotingConfig{
 			VoteBits:         1,
 			VoteBitsExtended: "05000000",
 			VoteVersion:      5,
 		},
-		userVotingConfig: make(map[string]userdata.UserVotingConfig),
-		testing:          true,
+		UserVotingConfig: make(map[string]userdata.UserVotingConfig),
+		Testing:          true,
 	}
 
 	// Create users
@@ -107,11 +108,11 @@ func init() {
 	// leave out last 5, as they will be inserted when tickets are generated
 	for i := 0; i < userCount-5; i++ {
 		msa := "Tc" + randString(33)
-		c.userVotingConfig[msa] = userdata.UserVotingConfig{
+		c.UserVotingConfig[msa] = userdata.UserVotingConfig{
 			Userid:          int64(i),
 			MultiSigAddress: msa,
-			VoteBits:        c.votingConfig.VoteBits,
-			VoteBitsVersion: c.votingConfig.VoteVersion,
+			VoteBits:        c.VotingConfig.VoteBits,
+			VoteBitsVersion: c.VotingConfig.VoteVersion,
 		}
 	}
 
@@ -124,18 +125,18 @@ func init() {
 		ticket := &chainhash.Hash{b[0], b[1], b[2], b[3]}
 
 		// use ticket as the key
-		c.liveTicketsMSA[*ticket] = msa
+		c.LiveTicketsMSA[*ticket] = msa
 
 		// last 5 tickets win
 		if i > ticketCount-6 {
-			wt.winningTickets = append(wt.winningTickets, ticket)
-			c.userVotingConfig[msa] = userdata.UserVotingConfig{}
+			wt.WinningTickets = append(wt.WinningTickets, ticket)
+			c.UserVotingConfig[msa] = userdata.UserVotingConfig{}
 		}
 	}
 }
 
 func BenchmarkProcessWinningTickets(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		c.processWinningTickets(wt)
+		c.ProcessWinningTickets(wt)
 	}
 }


### PR DESCRIPTION
In order to add a new RPC call to stakepoold in #342, it was necessary to add a lot of nasty code to `stakepoold/rpc/rpcserver/server.go`, and this really should not be needed. This PR removes that nasty code, and thus makes it easier to add/change stakepoold RPC calls in future (eg whilst implementing #227).

The changeset is quite big, so I have broken it into two commits:

1. The first commit simply moves/renames existing code without making any significant changes. It splits the `appContext` code out of `stakepoold/server.go` and into its own, reusable, file `stakepoold/rpc/rpcserver/context.go`
2. The second commit passes the AppContext instance into `stakepoold/rpc/rpcserver/server.go` which allows the nasty code to be removed from that file.

The stakepoold code after this PR is still a bit messy and could use further improvement, but splitting reusable component out of a huge file and removing some of the nasty code are definitely steps in the right direction.