### PR TITLE
simplify overly complex method

### DIFF
--- a/server.go
+++ b/server.go
@@ -133,9 +133,14 @@ func runMain() int {
 	}
 
 	if cfg.EnableStakepoold {
-		err = controller.StakepooldUpdateAll(application.DbMap, controllers.StakepooldUpdateKindAll)
+		err = controller.StakepooldUpdateUsers(application.DbMap)
 		if err != nil {
-			log.Errorf("TriggerStakepooldUpdates failed: %v", err)
+			log.Errorf("StakepooldUpdateUsers failed: %v", err)
+			return 9
+		}
+		err = controller.StakepooldUpdateTickets(application.DbMap)
+		if err != nil {
+			log.Errorf("StakepooldUpdateTickets failed: %v", err)
 			return 9
 		}
 		for i := range grpcConnections {

--- a/stakepooldclient/stakepooldclient.go
+++ b/stakepooldclient/stakepooldclient.go
@@ -118,7 +118,7 @@ func StakepooldGetLiveTickets(conn *grpc.ClientConn) (map[chainhash.Hash]string,
 	return liveTickets, err
 }
 
-func StakepooldSetAddedLowFeeTickets(conn *grpc.ClientConn, dbTickets []models.LowFeeTicket) (processed bool, err error) {
+func StakepooldSetAddedLowFeeTickets(conn *grpc.ClientConn, dbTickets []models.LowFeeTicket) error {
 	var tickets []*pb.TicketEntry
 	for _, ticket := range dbTickets {
 		hash, err := chainhash.NewHashFromStr(ticket.TicketHash)
@@ -136,15 +136,13 @@ func StakepooldSetAddedLowFeeTickets(conn *grpc.ClientConn, dbTickets []models.L
 	setAddedTicketsReq := &pb.SetAddedLowFeeTicketsRequest{
 		Tickets: tickets,
 	}
-	_, err = client.SetAddedLowFeeTickets(context.Background(),
+	_, err := client.SetAddedLowFeeTickets(context.Background(),
 		setAddedTicketsReq)
-	if err != nil {
-		return false, err
-	}
-	return true, err
+
+	return err
 }
 
-func StakepooldSetUserVotingPrefs(conn *grpc.ClientConn, dbUsers map[int64]*models.User) (processed bool, err error) {
+func StakepooldSetUserVotingPrefs(conn *grpc.ClientConn, dbUsers map[int64]*models.User) error {
 	var users []*pb.UserVotingConfigEntry
 	for userid, data := range dbUsers {
 		users = append(users, &pb.UserVotingConfigEntry{
@@ -159,12 +157,10 @@ func StakepooldSetUserVotingPrefs(conn *grpc.ClientConn, dbUsers map[int64]*mode
 	setVotingConfigReq := &pb.SetUserVotingPrefsRequest{
 		UserVotingConfig: users,
 	}
-	_, err = client.SetUserVotingPrefs(context.Background(),
+	_, err := client.SetUserVotingPrefs(context.Background(),
 		setVotingConfigReq)
-	if err != nil {
-		return false, err
-	}
-	return true, err
+
+	return err
 }
 
 func StakepooldImportScript(conn *grpc.ClientConn, script []byte) (heightImported int64, err error) {


### PR DESCRIPTION
The method `StakepooldUpdateAll` could either update users, tickets, or both. The behaviour was controlled by a flag parameter, and this resulted in overly complex code which is difficult to modify. This PR splits the single complex method into two simple ones: `StakepooldUpdateTickets` and `StakepooldUpdateUsers`.