### PR TITLE
introduce stakepoold connection manager

### DIFF
--- a/stakepooldclient/stakepooldclient.go
+++ b/stakepooldclient/stakepooldclient.go
@@ -1,9 +1,11 @@
 package stakepooldclient
 
 import (
+	"errors"
 	"fmt"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
@@ -14,111 +16,134 @@ import (
 
 var requiredStakepooldAPI = semver{major: 4, minor: 0, patch: 0}
 
-func ConnectStakepooldGRPC(stakepooldHosts []string, stakepooldCerts []string, serverID int) (*grpc.ClientConn, error) {
-	log.Infof("Attempting to connect to stakepoold gRPC %s using "+
-		"certificate located in %s", stakepooldHosts[serverID],
-		stakepooldCerts[serverID])
-	creds, err := credentials.NewClientTLSFromFile(stakepooldCerts[serverID], "localhost")
-	if err != nil {
-		return nil, err
-	}
-	conn, err := grpc.Dial(stakepooldHosts[serverID], grpc.WithTransportCredentials(creds))
-	if err != nil {
-		return nil, err
-	}
-	c := pb.NewVersionServiceClient(conn)
-
-	versionRequest := &pb.VersionRequest{}
-	versionResponse, err := c.Version(context.Background(), versionRequest)
-	if err != nil {
-		return nil, err
-	}
-
-	var semverResponse = semver{
-		major: versionResponse.Major,
-		minor: versionResponse.Minor,
-		patch: versionResponse.Patch,
-	}
-
-	if !semverCompatible(requiredStakepooldAPI, semverResponse) {
-		return nil, fmt.Errorf("Stakepoold gRPC server does not have "+
-			"a compatible API version. Advertises %v but require %v",
-			versionResponse, requiredStakepooldAPI)
-	}
-
-	log.Infof("Established connection to gRPC server %s",
-		stakepooldHosts[serverID])
-
-	return conn, nil
+type StakepooldManager struct {
+	grpcConnections []*grpc.ClientConn
 }
 
-func StakepooldGetAddedLowFeeTickets(conn *grpc.ClientConn) (map[chainhash.Hash]string, error) {
-	addedLowFeeTickets := make(map[chainhash.Hash]string)
+func ConnectStakepooldGRPC(stakepooldHosts []string, stakepooldCerts []string) (*StakepooldManager, error) {
 
-	client := pb.NewStakepooldServiceClient(conn)
-	resp, err := client.GetAddedLowFeeTickets(context.Background(), &pb.GetAddedLowFeeTicketsRequest{})
-	// return early if the list is empty
-	if resp == nil || err != nil {
+	conns := make([]*grpc.ClientConn, len(stakepooldHosts))
+
+	for serverID := range stakepooldHosts {
+		log.Infof("Attempting to connect to stakepoold gRPC %s using "+
+			"certificate located in %s", stakepooldHosts[serverID],
+			stakepooldCerts[serverID])
+		creds, err := credentials.NewClientTLSFromFile(stakepooldCerts[serverID], "localhost")
+		if err != nil {
+			return nil, err
+		}
+		conn, err := grpc.Dial(stakepooldHosts[serverID], grpc.WithTransportCredentials(creds))
+		if err != nil {
+			return nil, err
+		}
+		c := pb.NewVersionServiceClient(conn)
+
+		versionRequest := &pb.VersionRequest{}
+		versionResponse, err := c.Version(context.Background(), versionRequest)
+		if err != nil {
+			return nil, err
+		}
+
+		var semverResponse = semver{
+			major: versionResponse.Major,
+			minor: versionResponse.Minor,
+			patch: versionResponse.Patch,
+		}
+
+		if !semverCompatible(requiredStakepooldAPI, semverResponse) {
+			return nil, fmt.Errorf("Stakepoold gRPC server does not have "+
+				"a compatible API version. Advertises %v but require %v",
+				versionResponse, requiredStakepooldAPI)
+		}
+
+		log.Infof("Established connection to gRPC server %s",
+			stakepooldHosts[serverID])
+		conns[serverID] = conn
+	}
+
+	return &StakepooldManager{conns}, nil
+}
+
+// GetAddedLowFeeTickets performs gRPC GetAddedLowFeeTickets
+// requests against all stakepoold instances and returns the first result fetched
+// without errors. Returns an error if all RPC requests fail.
+func (s *StakepooldManager) GetAddedLowFeeTickets() (map[chainhash.Hash]string, error) {
+	for i, conn := range s.grpcConnections {
+		client := pb.NewStakepooldServiceClient(conn)
+		resp, err := client.GetAddedLowFeeTickets(context.Background(), &pb.GetAddedLowFeeTicketsRequest{})
+		if err != nil {
+			log.Warnf("GetAddedLowFeeTickets RPC failed on stakepoold instance %d: %v", i, err)
+			continue
+		}
+
+		addedLowFeeTickets := processTicketsResponse(resp.Tickets)
+		log.Infof("stakepoold %d reports %d AddedLowFee tickets", i, len(addedLowFeeTickets))
 		return addedLowFeeTickets, err
 	}
 
-	for _, ticket := range resp.Tickets {
+	// All RPC requests failed
+	return nil, errors.New("GetAddedLowFeeTickets RPC failed on all stakepoold instances")
+}
+
+// GetIgnoredLowFeeTickets performs gRPC GetIgnoredLowFeeTickets
+// requests against all stakepoold instances and returns the first result fetched
+// without errors. Returns an error if all RPC requests fail.
+func (s *StakepooldManager) GetIgnoredLowFeeTickets() (map[chainhash.Hash]string, error) {
+	for i, conn := range s.grpcConnections {
+		client := pb.NewStakepooldServiceClient(conn)
+		resp, err := client.GetIgnoredLowFeeTickets(context.Background(), &pb.GetIgnoredLowFeeTicketsRequest{})
+		if err != nil {
+			log.Warnf("GetIgnoredLowFeeTickets RPC failed on stakepoold instance %d: %v", i, err)
+			continue
+		}
+
+		ignoredLowFeeTickets := processTicketsResponse(resp.Tickets)
+		log.Infof("stakepoold %d reports %d IgnoredLowFee tickets", i, len(ignoredLowFeeTickets))
+		return ignoredLowFeeTickets, nil
+	}
+
+	// All RPC requests failed
+	return nil, errors.New("GetIgnoredLowFeeTickets RPC failed on all stakepoold instances")
+}
+
+// GetLiveTickets performs gRPC GetLiveTickets
+// requests against all stakepoold instances and returns the first result fetched
+// without errors. Returns an error if all RPC requests fail.
+func (s *StakepooldManager) GetLiveTickets() (map[chainhash.Hash]string, error) {
+	for i, conn := range s.grpcConnections {
+		client := pb.NewStakepooldServiceClient(conn)
+		resp, err := client.GetLiveTickets(context.Background(), &pb.GetLiveTicketsRequest{})
+		if err != nil {
+			log.Warnf("GetLiveTickets RPC failed on stakepoold instance %d: %v", i, err)
+			continue
+		}
+
+		liveTickets := processTicketsResponse(resp.Tickets)
+		log.Infof("stakepoold %d reports %d Live Tickets", i, len(liveTickets))
+		return liveTickets, nil
+	}
+
+	// All RPC requests failed
+	return nil, errors.New("GetLiveTickets RPC failed on all stakepoold instances")
+}
+
+func processTicketsResponse(tickets []*pb.Ticket) map[chainhash.Hash]string {
+	processedTickets := make(map[chainhash.Hash]string)
+	for _, ticket := range tickets {
 		hash, err := chainhash.NewHash(ticket.Hash)
 		if err != nil {
 			log.Warnf("NewHash failed for %v: %v", ticket.Hash, err)
 			continue
 		}
-		addedLowFeeTickets[*hash] = ticket.Address
+		processedTickets[*hash] = ticket.Address
 	}
 
-	return addedLowFeeTickets, err
+	return processedTickets
 }
 
-func StakepooldGetIgnoredLowFeeTickets(conn *grpc.ClientConn) (map[chainhash.Hash]string, error) {
-	ignoredLowFeeTickets := make(map[chainhash.Hash]string)
-
-	client := pb.NewStakepooldServiceClient(conn)
-	resp, err := client.GetIgnoredLowFeeTickets(context.Background(), &pb.GetIgnoredLowFeeTicketsRequest{})
-	// return early if the list is empty
-	if resp == nil || err != nil {
-		return ignoredLowFeeTickets, err
-	}
-
-	for _, ticket := range resp.Tickets {
-		hash, err := chainhash.NewHash(ticket.Hash)
-		if err != nil {
-			log.Warnf("NewHash failed for %v: %v", ticket.Hash, err)
-			continue
-		}
-		ignoredLowFeeTickets[*hash] = ticket.Address
-	}
-
-	return ignoredLowFeeTickets, err
-}
-
-func StakepooldGetLiveTickets(conn *grpc.ClientConn) (map[chainhash.Hash]string, error) {
-	liveTickets := make(map[chainhash.Hash]string)
-
-	client := pb.NewStakepooldServiceClient(conn)
-	resp, err := client.GetLiveTickets(context.Background(), &pb.GetLiveTicketsRequest{})
-	// return early if the list is empty
-	if resp == nil || err != nil {
-		return liveTickets, err
-	}
-
-	for _, ticket := range resp.Tickets {
-		hash, err := chainhash.NewHash(ticket.Hash)
-		if err != nil {
-			log.Warnf("NewHash failed for %v: %v", ticket.Hash, err)
-			continue
-		}
-		liveTickets[*hash] = ticket.Address
-	}
-
-	return liveTickets, err
-}
-
-func StakepooldSetAddedLowFeeTickets(conn *grpc.ClientConn, dbTickets []models.LowFeeTicket) error {
+// SetAddedLowFeeTickets performs gRPC SetAddedLowFeeTickets. It stops
+// executing and returns an error if any RPC call fails
+func (s *StakepooldManager) SetAddedLowFeeTickets(dbTickets []models.LowFeeTicket) error {
 	var tickets []*pb.Ticket
 	for _, ticket := range dbTickets {
 		hash, err := chainhash.NewHashFromStr(ticket.TicketHash)
@@ -132,17 +157,26 @@ func StakepooldSetAddedLowFeeTickets(conn *grpc.ClientConn, dbTickets []models.L
 		})
 	}
 
-	client := pb.NewStakepooldServiceClient(conn)
-	setAddedTicketsReq := &pb.SetAddedLowFeeTicketsRequest{
-		Tickets: tickets,
+	for i, conn := range s.grpcConnections {
+		client := pb.NewStakepooldServiceClient(conn)
+		setAddedTicketsReq := &pb.SetAddedLowFeeTicketsRequest{
+			Tickets: tickets,
+		}
+		_, err := client.SetAddedLowFeeTickets(context.Background(),
+			setAddedTicketsReq)
+		if err != nil {
+			log.Errorf("SetAddedLowFeeTickets RPC failed on stakepoold instance %d: %v", i, err)
+			return err
+		}
 	}
-	_, err := client.SetAddedLowFeeTickets(context.Background(),
-		setAddedTicketsReq)
 
-	return err
+	log.Info("SetAddedLowFeeTickets successful on all stakepoold instances")
+	return nil
 }
 
-func StakepooldSetUserVotingPrefs(conn *grpc.ClientConn, dbUsers map[int64]*models.User) error {
+// SetUserVotingPrefs performs gRPC SetUserVotingPrefs. It stops
+// executing and returns an error if any RPC call fails
+func (s *StakepooldManager) SetUserVotingPrefs(dbUsers map[int64]*models.User) error {
 	var users []*pb.UserVotingConfigEntry
 	for userid, data := range dbUsers {
 		users = append(users, &pb.UserVotingConfigEntry{
@@ -153,24 +187,64 @@ func StakepooldSetUserVotingPrefs(conn *grpc.ClientConn, dbUsers map[int64]*mode
 		})
 	}
 
-	client := pb.NewStakepooldServiceClient(conn)
-	setVotingConfigReq := &pb.SetUserVotingPrefsRequest{
-		UserVotingConfig: users,
+	for i, conn := range s.grpcConnections {
+		client := pb.NewStakepooldServiceClient(conn)
+		setVotingConfigReq := &pb.SetUserVotingPrefsRequest{
+			UserVotingConfig: users,
+		}
+		_, err := client.SetUserVotingPrefs(context.Background(),
+			setVotingConfigReq)
+		if err != nil {
+			log.Errorf("SetUserVotingPrefs RPC failed on stakepoold instance %d: %v", i, err)
+			return err
+		}
 	}
-	_, err := client.SetUserVotingPrefs(context.Background(),
-		setVotingConfigReq)
 
-	return err
+	log.Info("SetUserVotingPrefs successful on all stakepoold instances")
+	return nil
 }
 
-func StakepooldImportScript(conn *grpc.ClientConn, script []byte) (heightImported int64, err error) {
-	client := pb.NewStakepooldServiceClient(conn)
-	importScriptReq := &pb.ImportScriptRequest{
-		Script: script,
+// ImportScript calls ImportScript RPC on all stakepoold instances. It stops
+// executing and returns an error if any RPC call fails
+func (s *StakepooldManager) ImportScript(script []byte) (heightImported int64, err error) {
+	for i, conn := range s.grpcConnections {
+		client := pb.NewStakepooldServiceClient(conn)
+		req := &pb.ImportScriptRequest{
+			Script: script,
+		}
+		resp, err := client.ImportScript(context.Background(), req)
+		if err != nil {
+			log.Errorf("ImportScript RPC failed on stakepoold instance %d: %v", i, err)
+			return -1, err
+		}
+		heightImported = resp.HeightImported
 	}
-	importScriptResp, err := client.ImportScript(context.Background(), importScriptReq)
-	if err != nil {
-		return -1, err
+
+	log.Info("ImportScript successful on all stakepoold instances")
+	return heightImported, err
+}
+
+func (s *StakepooldManager) RPCStatus() []string {
+	stakepooldPageInfo := make([]string, len(s.grpcConnections))
+
+	for i, conn := range s.grpcConnections {
+		grpcStatus := "Unknown"
+		state := conn.GetState()
+		switch state {
+		case connectivity.Idle:
+			grpcStatus = "Idle"
+		case connectivity.Shutdown:
+			grpcStatus = "Shutdown"
+		case connectivity.Ready:
+			grpcStatus = "Ready"
+		case connectivity.Connecting:
+			grpcStatus = "Connecting"
+		case connectivity.TransientFailure:
+			grpcStatus = "TransientFailure"
+		}
+
+		stakepooldPageInfo[i] = grpcStatus
 	}
-	return importScriptResp.HeightImported, err
+
+	return stakepooldPageInfo
 }

--- a/views/admin/status.html
+++ b/views/admin/status.html
@@ -25,14 +25,14 @@
 								<thead class="thead-light">
 									<tr>
 										<th scope="col" class="text-center">Stakepoold Number</th>
-										<th scope="col" class="text-center">GRPC Connection Number</th>
+										<th scope="col" class="text-center">RPC Status</th>
 									</tr>
 								</thead>
 								<tbody>
 									{{ range $i, $data := .StakepooldInfo }}
 									<tr class="table-light">
 										<td class="text-center">{{$i}}</td>
-										<td class="text-center">{{ $data.Status }}</td>
+										<td class="text-center">{{ $data.RPCStatus }}</td>
 									</tr>
 									{{end}}
 								</tbody>


### PR DESCRIPTION
`dcrstakepool` connects to multiple instances of `stakepoold` and `dcrwallet` over gRPC. The code managing the `dcrwallet` gRPC connections is significantly more robust than the `stakepoold` counterpart.
`dcrwallet` connections are managed in a single place - namely [dcrclient.go](https://github.com/decred/dcrstakepool/blob/master/controllers/dcrclient.go). This file is responsible for comms to the multiple `dcrwallet` connections, error handling, retrying etc. Management of `stakepoold` connections is scattered throughout the code.

This PR introduces a connection manager for the stakepoold connections, similar to what exists for dcrwallet. Making stakepoold connection management more robust will become important in the future as we take further steps towards #227 and the `dcrwallet` connections are removed. The PR only refactors existing code and does not add any new functionality.

**_Marking the PR as a draft because I would like to properly validate the work on testnet before it is merged. Not possible right now because testnet blocks are not being mined_**