### PR TITLE
Clean Up: move pubkey parsing to config

### DIFF
--- a/config.go
+++ b/config.go
@@ -285,14 +285,6 @@ func (c *config) parsePubKeys(params *chaincfg.Params) error {
 	return nil
 }
 
-func (c *config) GetFeeKey() *hdkeychain.ExtendedKey {
-	return coldWalletFeeKey
-}
-
-func (c *config) GetVoteKey() *hdkeychain.ExtendedKey {
-	return votingWalletVoteKey
-}
-
 // newConfigParser returns a new command line flags parser.
 func newConfigParser(cfg *config, so *serviceOptions, options flags.Options) *flags.Parser {
 	parser := flags.NewParser(cfg, options)

--- a/config.go
+++ b/config.go
@@ -263,24 +263,24 @@ func fileExists(name string) bool {
 	return true
 }
 
-// validate pub vote and key keys as belonging to the network
+// validate pub vote and fee keys as belonging to the network
 func (c *config) parsePubKeys(params *chaincfg.Params) error {
 	// Parse the extended public key and the pool fees.
 	var err error
 	coldWalletFeeKey, err = hdkeychain.NewKeyFromString(c.ColdWalletExtPub)
 	if err != nil {
-		return err
+		return fmt.Errorf("cold wallet extended public key: %v", err)
 	}
 	if !coldWalletFeeKey.IsForNet(params) {
-		return fmt.Errorf("fee extended public key is for wrong network")
+		return fmt.Errorf("cold wallet extended public key is for wrong network")
 	}
 	// Parse the extended public key for the voting addresses.
 	votingWalletVoteKey, err = hdkeychain.NewKeyFromString(c.VotingWalletExtPub)
 	if err != nil {
-		return err
+		return fmt.Errorf("voting wallet extended public key: %v", err)
 	}
 	if !votingWalletVoteKey.IsForNet(params) {
-		return fmt.Errorf("voting extended public key is for wrong network")
+		return fmt.Errorf("voting wallet extended public key is for wrong network")
 	}
 	return nil
 }
@@ -495,13 +495,6 @@ func loadConfig() (*config, []string, error) {
 		}
 	}
 
-	if err := cfg.parsePubKeys(activeNetParams.Params); err != nil {
-		str := "%s: Failed to parse Pubkeys"
-		err := fmt.Errorf(str+": %v", funcName, err)
-		fmt.Fprintln(os.Stderr, err)
-		return nil, nil, err
-	}
-
 	if cfg.APISecret == "" {
 		str := "%s: APIsecret is not set in config"
 		err := fmt.Errorf(str, funcName)
@@ -547,6 +540,12 @@ func loadConfig() (*config, []string, error) {
 	if len(cfg.VotingWalletExtPub) == 0 {
 		str := "%s: votingwalletextpub is not set in config"
 		err := fmt.Errorf(str, funcName)
+		fmt.Fprintln(os.Stderr, err)
+		return nil, nil, err
+	}
+
+	if err := cfg.parsePubKeys(activeNetParams.Params); err != nil {
+		err := fmt.Errorf("%s: failed to parse extended public keys: %v", funcName, err)
 		fmt.Fprintln(os.Stderr, err)
 		return nil, nil, err
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2015-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"github.com/decred/dcrd/chaincfg"
+	"github.com/decred/dcrd/hdkeychain"
+	"testing"
+)
+
+const (
+	//real pubkeys
+	testnetXPub1 = "tpubVpFtCRJV1U7fJQYLiDtKTZFnwwaHp6uhcavTjvXBusiY1pDQw5YqT1HGDcQT2wjLQZnL7N66o7atgscq6tMP6fr5ejyqDHD3eQ9C3KQURzu"
+	testnetXPub2 = "tpubVpFtCRJV1U7fMienqUufobnNxxYACoLDTaAFmpspHy2iguBzoGRbi4btArDijbsNVvMVnciEC7ZHMCr8T19Ln7ECBuAT5UqYW21cKcNxMN6"
+	mainnetXPub1 = "dpubZGWjhGoJRkwao4W8Jsk56RPJNSAHmEtuERoeuugKmGxFhU1zhZJ2MfScJjzccGcs3xLHYZN2V7FjAHfBoiHdcpXtVyUnJQMxZxRENNgTEsM"
+	mainnetXPub2 = "dpubZGWjhGoJRkwaqnFhB6a85gjvSSbLuDxAj7ixmFqcu7RZPW7cthZU4jK7u7LZSrr7ooHGHFc1LEn1n9cypSvzKknqZYugKda6PYc5Ze7NhTL"
+	simnetXPub1  = "spubVVBn1KgTWoDRajAZrymsoTRjP1qQdKTbuUMBBKw2q6vNVrbHXYGPTxDFgcaYYzrTRQ38mvkKt8dbk9pUHppT6WLZ23DroW8V3i3kptjfndx"
+	simnetXPub2  = "spubVVBn1KgTWoDRefX2cjSRjhBYFahdbTvhMzB1Lia3hCseDjB4tdxFJ3FDPG3NGkBpA6XEjRxw1r9LnU5nRpkvKGkfxfAqqFtc72kaU5Fmn6r"
+)
+
+type keysIn struct {
+	coldFeeWallet string
+	voteWallet    string
+}
+
+type keysOut struct {
+	coldFeeWallet *hdkeychain.ExtendedKey
+	voteWallet    *hdkeychain.ExtendedKey
+}
+
+type keyParse struct {
+	params  *chaincfg.Params
+	keysIn  keysIn
+	keysOut keysOut
+	isError bool
+}
+
+//in keys, expected out keys, and error value
+var keyTestValues = []keyParse{
+	//testnet
+	keyParse{testNet3Params.Params, keysIn{testnetXPub1, testnetXPub2}, keysOut{hd(testnetXPub1), hd(testnetXPub2)}, false},
+	keyParse{testNet3Params.Params, keysIn{testnetXPub1, mainnetXPub2}, keysOut{hd(testnetXPub1), hd(mainnetXPub2)}, true},
+	keyParse{testNet3Params.Params, keysIn{"", mainnetXPub2}, keysOut{hd(""), hd(mainnetXPub2)}, true},
+	//mainnet
+	keyParse{mainNetParams.Params, keysIn{mainnetXPub1, mainnetXPub2}, keysOut{hd(mainnetXPub1), hd(mainnetXPub2)}, false},
+	keyParse{mainNetParams.Params, keysIn{simnetXPub1, mainnetXPub2}, keysOut{hd(simnetXPub1), hd(mainnetXPub2)}, true},
+	keyParse{mainNetParams.Params, keysIn{mainnetXPub1, mainnetXPub2 + "a"}, keysOut{hd(mainnetXPub1), hd(mainnetXPub2 + "a")}, true},
+	//simnnet
+	keyParse{simNetParams.Params, keysIn{simnetXPub1, simnetXPub2}, keysOut{hd(simnetXPub1), hd(simnetXPub2)}, false},
+	keyParse{simNetParams.Params, keysIn{testnetXPub1, simnetXPub2}, keysOut{hd(testnetXPub1), hd(simnetXPub2)}, true},
+	keyParse{simNetParams.Params, keysIn{simnetXPub1[:len(simnetXPub1)-1], simnetXPub2}, keysOut{hd(simnetXPub1[:len(simnetXPub1)-1]), hd(simnetXPub2)}, true},
+}
+
+//helper func string to extended key
+func hd(s string) *hdkeychain.ExtendedKey {
+	hd, _ := hdkeychain.NewKeyFromString(s)
+	return hd
+}
+
+//an error will produce a nil key struct so use nil string value
+func strFromHd(hd *hdkeychain.ExtendedKey) string {
+	if hd == nil {
+		return ""
+	}
+	return hd.String()
+}
+
+func TestParsePubKeys(t *testing.T) {
+	//dummy config
+	var cfg config
+	for _, test := range keyTestValues {
+		//parsePubKeys uses these fields
+		cfg.ColdWalletExtPub = test.keysIn.coldFeeWallet
+		cfg.VotingWalletExtPub = test.keysIn.voteWallet
+		//testing func
+		err := cfg.parsePubKeys(test.params)
+		//err if expected output key strings and real output key strings don't match or expected error status is different
+		if strFromHd(test.keysOut.coldFeeWallet) != strFromHd(coldWalletFeeKey) || strFromHd(test.keysOut.voteWallet) != strFromHd(votingWalletVoteKey) || (err != nil) != test.isError {
+			t.Error("for", test.keysIn, "expected", strFromHd(test.keysOut.coldFeeWallet), strFromHd(test.keysOut.voteWallet), "and is error=", test.isError, "got", strFromHd(coldWalletFeeKey), strFromHd(votingWalletVoteKey), "and is error=", err != nil)
+		}
+	}
+
+}

--- a/config_test.go
+++ b/config_test.go
@@ -40,17 +40,17 @@ type keyParse struct {
 //in keys, expected out keys, and error value
 var keyTestValues = []keyParse{
 	//testnet
-	keyParse{testNet3Params.Params, keysIn{testnetXPub1, testnetXPub2}, keysOut{hd(testnetXPub1), hd(testnetXPub2)}, false},
-	keyParse{testNet3Params.Params, keysIn{testnetXPub1, mainnetXPub2}, keysOut{hd(testnetXPub1), hd(mainnetXPub2)}, true},
-	keyParse{testNet3Params.Params, keysIn{"", mainnetXPub2}, keysOut{hd(""), hd(mainnetXPub2)}, true},
+	{testNet3Params.Params, keysIn{testnetXPub1, testnetXPub2}, keysOut{hd(testnetXPub1), hd(testnetXPub2)}, false},
+	{testNet3Params.Params, keysIn{testnetXPub1, mainnetXPub2}, keysOut{hd(testnetXPub1), hd(mainnetXPub2)}, true},
+	{testNet3Params.Params, keysIn{"", mainnetXPub2}, keysOut{hd(""), hd(mainnetXPub2)}, true},
 	//mainnet
-	keyParse{mainNetParams.Params, keysIn{mainnetXPub1, mainnetXPub2}, keysOut{hd(mainnetXPub1), hd(mainnetXPub2)}, false},
-	keyParse{mainNetParams.Params, keysIn{simnetXPub1, mainnetXPub2}, keysOut{hd(simnetXPub1), hd(mainnetXPub2)}, true},
-	keyParse{mainNetParams.Params, keysIn{mainnetXPub1, mainnetXPub2 + "a"}, keysOut{hd(mainnetXPub1), hd(mainnetXPub2 + "a")}, true},
+	{mainNetParams.Params, keysIn{mainnetXPub1, mainnetXPub2}, keysOut{hd(mainnetXPub1), hd(mainnetXPub2)}, false},
+	{mainNetParams.Params, keysIn{simnetXPub1, mainnetXPub2}, keysOut{hd(simnetXPub1), hd(mainnetXPub2)}, true},
+	{mainNetParams.Params, keysIn{mainnetXPub1, mainnetXPub2 + "a"}, keysOut{hd(mainnetXPub1), hd(mainnetXPub2 + "a")}, true},
 	//simnnet
-	keyParse{simNetParams.Params, keysIn{simnetXPub1, simnetXPub2}, keysOut{hd(simnetXPub1), hd(simnetXPub2)}, false},
-	keyParse{simNetParams.Params, keysIn{testnetXPub1, simnetXPub2}, keysOut{hd(testnetXPub1), hd(simnetXPub2)}, true},
-	keyParse{simNetParams.Params, keysIn{simnetXPub1[:len(simnetXPub1)-1], simnetXPub2}, keysOut{hd(simnetXPub1[:len(simnetXPub1)-1]), hd(simnetXPub2)}, true},
+	{simNetParams.Params, keysIn{simnetXPub1, simnetXPub2}, keysOut{hd(simnetXPub1), hd(simnetXPub2)}, false},
+	{simNetParams.Params, keysIn{testnetXPub1, simnetXPub2}, keysOut{hd(testnetXPub1), hd(simnetXPub2)}, true},
+	{simNetParams.Params, keysIn{simnetXPub1[:len(simnetXPub1)-1], simnetXPub2}, keysOut{hd(simnetXPub1[:len(simnetXPub1)-1]), hd(simnetXPub2)}, true},
 }
 
 //helper func string to extended key

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -100,29 +100,11 @@ func getClientIP(r *http.Request, realIPHeader string) string {
 func NewMainController(params *chaincfg.Params, adminIPs []string,
 	adminUserIDs []string, APISecret string, APIVersionsSupported []int,
 	baseURL string, closePool bool, closePoolMsg string, enablestakepoold bool,
-	feeXpubStr string, stakepooldConnMan *stakepooldclient.StakepooldManager, poolFees float64,
-	poolEmail, poolLink string, emailSender email.Sender, walletHosts, walletCerts, walletUsers,
-	walletPasswords []string, minServers int, realIPHeader,
-	votingXpubStr string, maxVotedAge int64, description string,
+	feeKey *hdkeychain.ExtendedKey, stakepooldConnMan *stakepooldclient.StakepooldManager,
+	poolFees float64, poolEmail, poolLink string, emailSender email.Sender, walletHosts,
+	walletCerts, walletUsers, walletPasswords []string, minServers int, realIPHeader string,
+	voteKey *hdkeychain.ExtendedKey, maxVotedAge int64, description string,
 	designation string) (*MainController, error) {
-
-	// Parse the extended public key and the pool fees.
-	feeKey, err := hdkeychain.NewKeyFromString(feeXpubStr)
-	if err != nil {
-		return nil, err
-	}
-	if !feeKey.IsForNet(params) {
-		return nil, fmt.Errorf("fee extended public key is for wrong network")
-	}
-
-	// Parse the extended public key for the voting addresses.
-	voteKey, err := hdkeychain.NewKeyFromString(votingXpubStr)
-	if err != nil {
-		return nil, err
-	}
-	if !voteKey.IsForNet(params) {
-		return nil, fmt.Errorf("voting extended public key is for wrong network")
-	}
 
 	rpcs, err := newWalletSvrManager(walletHosts, walletCerts, walletUsers, walletPasswords, minServers)
 	if err != nil {

--- a/server.go
+++ b/server.go
@@ -100,10 +100,10 @@ func runMain() error {
 	controller, err := controllers.NewMainController(activeNetParams.Params,
 		cfg.AdminIPs, cfg.AdminUserIDs, cfg.APISecret, APIVersionsSupported,
 		cfg.BaseURL, cfg.ClosePool, cfg.ClosePoolMsg, cfg.EnableStakepoold,
-		cfg.GetFeeKey(), stakepooldConnMan, cfg.PoolFees, cfg.PoolEmail,
+		coldWalletFeeKey, stakepooldConnMan, cfg.PoolFees, cfg.PoolEmail,
 		cfg.PoolLink, sender, cfg.WalletHosts, cfg.WalletCerts,
 		cfg.WalletUsers, cfg.WalletPasswords, cfg.MinServers, cfg.RealIPHeader,
-		cfg.GetVoteKey(), cfg.MaxVotedAge, cfg.Description, cfg.Designation)
+		votingWalletVoteKey, cfg.MaxVotedAge, cfg.Description, cfg.Designation)
 	if err != nil {
 		application.Close()
 		return fmt.Errorf("Failed to initialize the main controller: %v",

--- a/server.go
+++ b/server.go
@@ -100,10 +100,10 @@ func runMain() error {
 	controller, err := controllers.NewMainController(activeNetParams.Params,
 		cfg.AdminIPs, cfg.AdminUserIDs, cfg.APISecret, APIVersionsSupported,
 		cfg.BaseURL, cfg.ClosePool, cfg.ClosePoolMsg, cfg.EnableStakepoold,
-		cfg.ColdWalletExtPub, stakepooldConnMan, cfg.PoolFees, cfg.PoolEmail,
+		cfg.GetFeeKey(), stakepooldConnMan, cfg.PoolFees, cfg.PoolEmail,
 		cfg.PoolLink, sender, cfg.WalletHosts, cfg.WalletCerts,
 		cfg.WalletUsers, cfg.WalletPasswords, cfg.MinServers, cfg.RealIPHeader,
-		cfg.VotingWalletExtPub, cfg.MaxVotedAge, cfg.Description, cfg.Designation)
+		cfg.GetVoteKey(), cfg.MaxVotedAge, cfg.Description, cfg.Designation)
 	if err != nil {
 		application.Close()
 		return fmt.Errorf("Failed to initialize the main controller: %v",


### PR DESCRIPTION
part of issue #226 

Move validation of pubkeys, length and network, to config.

I made the parsed keys into package level variables because it felt weird to include them in the config struct since they are not configured by the user.