### PR TITLE
Remove referrer parameter from error page

### DIFF
--- a/controllers/main.go
+++ b/controllers/main.go
@@ -1266,7 +1266,6 @@ func (controller *MainController) Error(c web.C, r *http.Request) (string, int) 
 	c.Env["Title"] = "Decred VSP - Error"
 	c.Env["RPCStatus"] = rpcstatus
 	c.Env["RateLimited"] = r.URL.Query().Get("rl")
-	c.Env["Referer"] = r.URL.Query().Get("r")
 
 	widgets := controller.Parse(t, "error", c.Env)
 	c.Env["Designation"] = controller.designation

--- a/views/error.html
+++ b/views/error.html
@@ -13,12 +13,12 @@
     <h1>We could not process your request</h1>
 	{{if .RateLimited}}
             <p>Your request has been rate limited to lighten the load on the servers.
-            {{if .Referer}}<a href="{{ .Referer }}">{{end}}Please re-try your request.{{if .Referer}}</a>{{end}}</p>
+            Please re-try your request.</p>
         {{end}}
         {{if not .RateLimited}}
 	{{if eq .RPCStatus "Running"}}
            <p>A temporary error occurred. This can happen due to RPC results being temporarily out of sync.
-         {{if .Referer}}<a href="{{ .Referer }}">{{end}}Please re-try your request.{{if .Referer}}</a>{{end}}</p>
+         Please re-try your request.</p>
          {{end}}
          {{if eq .RPCStatus "Stopped"}}
             <p>The voting service is currently not processing RPC commands so most functionality of the web interface will not work until connections to the RPC server is restored.  <b>Wallets are still online and voting.</b></p>


### PR DESCRIPTION
Fixes #378 
This removes `c.Env["Referer"]` and `error.html` will no longer offer a redirect link.

