### PR TITLE
Show last N voted tickets

### DIFF
--- a/config.go
+++ b/config.go
@@ -23,29 +23,29 @@ import (
 )
 
 const (
-	defaultBaseURL        = "http://127.0.0.1:8000"
-	defaultClosePoolMsg   = "The voting service is temporarily closed to new signups."
-	defaultConfigFilename = "dcrstakepool.conf"
-	defaultDataDirname    = "data"
-	defaultLogLevel       = "info"
-	defaultLogDirname     = "logs"
-	defaultLogFilename    = "dcrstakepool.log"
-	defaultCookieSecure   = false
-	defaultDBHost         = "localhost"
-	defaultDBName         = "stakepool"
-	defaultDBPort         = "3306"
-	defaultDBUser         = "stakepool"
-	defaultListen         = ":8000"
-	defaultPoolEmail      = "admin@example.com"
-	defaultPoolFees       = 7.5
-	defaultPoolLink       = "https://forum.decred.org/threads/rfp-6-setup-and-operate-10-stake-pools.1361/"
-	defaultPublicPath     = "public"
-	defaultTemplatePath   = "views"
-	defaultSMTPHost       = ""
-	defaultMinServers     = 2
-	defaultMaxVotedAge    = 8640
-	defaultDescription    = ""
-	defaultDesignation    = ""
+	defaultBaseURL         = "http://127.0.0.1:8000"
+	defaultClosePoolMsg    = "The voting service is temporarily closed to new signups."
+	defaultConfigFilename  = "dcrstakepool.conf"
+	defaultDataDirname     = "data"
+	defaultLogLevel        = "info"
+	defaultLogDirname      = "logs"
+	defaultLogFilename     = "dcrstakepool.log"
+	defaultCookieSecure    = false
+	defaultDBHost          = "localhost"
+	defaultDBName          = "stakepool"
+	defaultDBPort          = "3306"
+	defaultDBUser          = "stakepool"
+	defaultListen          = ":8000"
+	defaultPoolEmail       = "admin@example.com"
+	defaultPoolFees        = 7.5
+	defaultPoolLink        = "https://forum.decred.org/threads/rfp-6-setup-and-operate-10-stake-pools.1361/"
+	defaultPublicPath      = "public"
+	defaultTemplatePath    = "views"
+	defaultSMTPHost        = ""
+	defaultMinServers      = 2
+	defaultMaxVotedTickets = 1000
+	defaultDescription     = ""
+	defaultDesignation     = ""
 )
 
 var (
@@ -110,7 +110,8 @@ type config struct {
 	AdminUserIDs       []string `long:"adminuserids" description:"User IDs of users who are allowed to access administrative functions."`
 	MinServers         int      `long:"minservers" description:"Minimum number of wallets connected needed to avoid errors"`
 	EnableStakepoold   bool     `long:"enablestakepoold" description:"Deprecated: Do not use. Stakepoold is required."`
-	MaxVotedAge        int64    `long:"maxvotedage" description:"Maximum vote age (blocks since vote) to include in voted tickets table"`
+	MaxVotedAge        int64    `long:"maxvotedage" description:"Deprecated: Use maxvotedtickets instead"`
+	MaxVotedTickets    int      `long:"maxvotedtickets" description:"Maximum number of voted tickets to show on tickets page."`
 	Description        string   `long:"description" description:"Operators own description of their VSP"`
 	Designation        string   `long:"designation" description:"VSP designation (eg. Alpha, Bravo, etc)"`
 }
@@ -309,29 +310,29 @@ func newConfigParser(cfg *config, so *serviceOptions, options flags.Options) *fl
 func loadConfig() (*config, []string, error) {
 	// Default config.
 	cfg := config{
-		BaseURL:      defaultBaseURL,
-		ClosePool:    false,
-		ClosePoolMsg: defaultClosePoolMsg,
-		ConfigFile:   defaultConfigFile,
-		DebugLevel:   defaultLogLevel,
-		DataDir:      defaultDataDir,
-		LogDir:       defaultLogDir,
-		CookieSecure: defaultCookieSecure,
-		DBHost:       defaultDBHost,
-		DBName:       defaultDBName,
-		DBPort:       defaultDBPort,
-		DBUser:       defaultDBUser,
-		Listen:       defaultListen,
-		PoolEmail:    defaultPoolEmail,
-		PoolFees:     defaultPoolFees,
-		PoolLink:     defaultPoolLink,
-		PublicPath:   defaultPublicPath,
-		TemplatePath: defaultTemplatePath,
-		SMTPHost:     defaultSMTPHost,
-		MinServers:   defaultMinServers,
-		MaxVotedAge:  defaultMaxVotedAge,
-		Description:  defaultDescription,
-		Designation:  defaultDesignation,
+		BaseURL:         defaultBaseURL,
+		ClosePool:       false,
+		ClosePoolMsg:    defaultClosePoolMsg,
+		ConfigFile:      defaultConfigFile,
+		DebugLevel:      defaultLogLevel,
+		DataDir:         defaultDataDir,
+		LogDir:          defaultLogDir,
+		CookieSecure:    defaultCookieSecure,
+		DBHost:          defaultDBHost,
+		DBName:          defaultDBName,
+		DBPort:          defaultDBPort,
+		DBUser:          defaultDBUser,
+		Listen:          defaultListen,
+		PoolEmail:       defaultPoolEmail,
+		PoolFees:        defaultPoolFees,
+		PoolLink:        defaultPoolLink,
+		PublicPath:      defaultPublicPath,
+		TemplatePath:    defaultTemplatePath,
+		SMTPHost:        defaultSMTPHost,
+		MinServers:      defaultMinServers,
+		MaxVotedTickets: defaultMaxVotedTickets,
+		Description:     defaultDescription,
+		Designation:     defaultDesignation,
 	}
 
 	// Service options which are only added on Windows.
@@ -681,6 +682,11 @@ func loadConfig() (*config, []string, error) {
 	// Warn about deprecated config items if they have been set
 	if cfg.EnableStakepoold {
 		str := "%s: Config enablestakepoold is deprecated.  Please remove from your config file"
+		log.Warnf(str, funcName)
+	}
+
+	if cfg.MaxVotedAge != 0 {
+		str := "%s: Config maxVotedAge is deprecated and has no effect. Use maxVotedTickets instead"
 		log.Warnf(str, funcName)
 	}
 

--- a/sample-dcrstakepool.conf
+++ b/sample-dcrstakepool.conf
@@ -130,7 +130,11 @@ testnet=1
 
 ; Maximum age of voted tickets to show on tickets page. Specify a threshold in
 ; number of blocks since the spend/vote height.
+; DEPRECATED: This option has no effect. Use maxvotedtickets instead.
 ;maxvotedage=8640
+
+; Maximum number of voted tickets to show on tickets page.
+;maxvotedtickets=1000
 
 ; The designated codename for this VSP. Customises the VSP logo in the top toolbar.
 ; eg. Alpha, Bravo, etc

--- a/server.go
+++ b/server.go
@@ -101,7 +101,7 @@ func runMain() error {
 		stakepooldConnMan, cfg.PoolFees, cfg.PoolEmail, cfg.PoolLink,
 		sender, cfg.WalletHosts, cfg.WalletCerts, cfg.WalletUsers,
 		cfg.WalletPasswords, cfg.MinServers, cfg.RealIPHeader, votingWalletVoteKey,
-		cfg.MaxVotedAge, cfg.Description, cfg.Designation)
+		cfg.MaxVotedTickets, cfg.Description, cfg.Designation)
 	if err != nil {
 		application.Close()
 		return fmt.Errorf("Failed to initialize the main controller: %v",


### PR DESCRIPTION
Rendering the `/tickets` page with a huge number of tickets results in the page loading very slowly.

|No. Tickets|Page Load (ms)|
|---|---|
|10|180|
|100|250|
|500|420|
|1000|600|
|2500|1300|
|5000|2200|
|10000|5000|
|17500|9600|
|25000|14900|
|37500|25200|
|50000|39000|

![g](https://user-images.githubusercontent.com/6762864/59104935-c055f000-892a-11e9-9631-ed271192ae46.png)

We currently mitigate this issue by only rendering the page with tickets which have voted in the last N blocks. This is not ideal for various reasons:

- The default for N is 8064, which means that in the worst possible case the page is rendered with 40,320 tickets. This means a page load of around 30 seconds.
- We need to call dcrwallet RPC to find the current best block
- A user may only have a single voted ticket, but if that ticket voted more than N blocks ago, it wont be displayed on the page.

I propose that we switch from "tickets which voted in the last N blocks" to "last N voted tickets", and I propose that a sensible default value is 1000. This provides the user with a decent amount of historic data whilst ensuring that page load time remains below well below a second.

Relevant to #353
Removes a dcrwallet RPC call, so also progress towards #227 