### PR TITLE
multi: new sql store and session nullification on password change and logout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/decred/dcrstakepool
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.3.3
 	github.com/apoydence/onpar v0.0.0-20190519213022-ee068f8ea4d1 // indirect
 	github.com/dajohi/goemail v1.0.0
 	github.com/dchest/captcha v0.0.0-20170622155422-6a29415a8364
@@ -22,6 +23,7 @@ require (
 	github.com/golang/protobuf v1.3.2
 	github.com/gorilla/context v1.1.1
 	github.com/gorilla/csrf v1.5.1
+	github.com/gorilla/securecookie v1.1.1
 	github.com/gorilla/sessions v1.1.3
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/jrick/logrotate v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFDnH08=
+github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/aead/siphash v0.0.0-20170329201724-e404fcfc8885/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=

--- a/models/user.go
+++ b/models/user.go
@@ -113,6 +113,15 @@ type PasswordReset struct {
 	Expires int64
 }
 
+type Session struct {
+	Id      int64 `db:"SessionID"`
+	Token   string
+	Data    []byte
+	UserId  int64
+	Created int64
+	Expires int64
+}
+
 type User struct {
 	Id               int64 `db:"UserId"`
 	Email            string
@@ -313,6 +322,7 @@ func GetDbMap(APISecret, baseURL, user, password, hostname, port, database strin
 	dbMap.AddTableWithName(EmailChange{}, "EmailChange").SetKeys(true, "Id")
 	dbMap.AddTableWithName(LowFeeTicket{}, "LowFeeTicket").SetKeys(true, "Id")
 	dbMap.AddTableWithName(PasswordReset{}, "PasswordReset").SetKeys(true, "Id")
+	dbMap.AddTableWithName(Session{}, "Session").SetKeys(true, "Id")
 	usersTableName := "Users"
 	dbMap.AddTableWithName(User{}, usersTableName).SetKeys(true, "Id")
 

--- a/system/middleware.go
+++ b/system/middleware.go
@@ -24,7 +24,10 @@ func (application *Application) ApplyTemplates(c *web.C, h http.Handler) http.Ha
 // Makes sure controllers can have access to session
 func (application *Application) ApplySessions(c *web.C, h http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
-		session, _ := application.Store.Get(r, "session")
+		session, err := application.Store.New(r, "session")
+		if err != nil {
+			log.Warnf("session load err: %v ", err)
+		}
 		c.Env["Session"] = session
 		h.ServeHTTP(w, r)
 	}

--- a/system/sqlstore.go
+++ b/system/sqlstore.go
@@ -1,0 +1,200 @@
+package system
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/base32"
+	"encoding/gob"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/decred/dcrstakepool/models"
+	"github.com/go-gorp/gorp"
+	"github.com/gorilla/securecookie"
+	"github.com/gorilla/sessions"
+)
+
+// SQLStore stores gorilla sessions in a database.
+type SQLStore struct {
+	Options *sessions.Options
+	codecs  []securecookie.Codec
+	dbMap   *gorp.DbMap
+}
+
+// NewSQLStore returns a new SQLStore. The keyPairs are used in the same way as
+// the gorilla sessions CookieStore.
+func NewSQLStore(dbMap *gorp.DbMap, keyPairs ...[]byte) *SQLStore {
+	s := &SQLStore{
+		codecs: securecookie.CodecsFromPairs(keyPairs...),
+		dbMap:  dbMap,
+	}
+	// clean db of expired sessions once a day
+	go func() {
+		for {
+			time.Sleep(time.Hour * 24)
+			if err := s.destroyExpiredSessions(); err != nil {
+				log.Warn(err)
+			}
+		}
+	}()
+	return s
+}
+
+// Get returns a cached session.
+func (s *SQLStore) Get(r *http.Request, name string) (*sessions.Session, error) {
+	return sessions.GetRegistry(r).Get(s, name)
+}
+
+// New creates a new session for the given request r. If the request
+// contains a valid session ID for an existing, non-expired session,
+// then that session will be loaded from the database.
+func (s *SQLStore) New(r *http.Request, name string) (*sessions.Session, error) {
+	session := sessions.NewSession(s, name)
+	opts := *s.Options
+	session.Options = &opts
+	c, err := r.Cookie(name)
+	if err != nil {
+		if err == http.ErrNoCookie {
+			return session, nil
+		}
+		return session, err
+	}
+	err = securecookie.DecodeMulti(name, c.Value, &session.ID, s.codecs...)
+	if err != nil {
+		// these are not the sessions you are looking for
+		log.Infof("sqlstore: New: unable to decode cookie: %v", err)
+		return session, nil
+	}
+	err = s.load(session)
+	if err != nil {
+		return session, err
+	}
+	return session, nil
+}
+
+// Save stores the session in the database. If session.Options.MaxAge
+// is < 0, the session is deleted from the database.
+func (s *SQLStore) Save(r *http.Request, w http.ResponseWriter, session *sessions.Session) error {
+	if session.Options.MaxAge < 0 {
+		return s.destroy(session)
+	}
+	if len(session.ID) == 0 {
+		session.ID = base32.StdEncoding.EncodeToString(securecookie.GenerateRandomKey(32))
+	}
+	if err := s.save(session); err != nil {
+		return err
+	}
+	// data is not stored in the cookie, only the session id
+	encoded, err := securecookie.EncodeMulti(session.Name(), &session.ID, s.codecs...)
+	if err != nil {
+		return err
+	}
+	http.SetCookie(w, sessions.NewCookie(session.Name(), encoded, session.Options))
+	return nil
+}
+
+// load loads the session identified by its ID from the database if it
+// exists. If the session has expired, it is destroyed.
+func (s *SQLStore) load(session *sessions.Session) error {
+	var dbSession models.Session
+	if err := s.dbMap.SelectOne(&dbSession, "SELECT * FROM Session WHERE Token = ?", session.ID); err != nil {
+		// if no rows are found nothing is done
+		if err == sql.ErrNoRows {
+			return nil
+		}
+		return fmt.Errorf("Could not select session to destroy: %v", err)
+	}
+	if dbSession.Expires < time.Now().Unix() {
+		return s.destroy(session)
+	}
+	// write db Data to session.Values
+	return gob.NewDecoder(bytes.NewBuffer(dbSession.Data)).Decode(&session.Values)
+}
+
+// save checks whether the session is new and inserts if new. Updates if
+// not.
+func (s *SQLStore) save(session *sessions.Session) error {
+	var dbSession models.Session
+	var buf bytes.Buffer
+	var isNew bool
+	if err := s.dbMap.SelectOne(&dbSession, "SELECT * FROM Session WHERE Token = ?", session.ID); err != nil {
+		if err != sql.ErrNoRows {
+			return fmt.Errorf("Could not select session: %v", err)
+		}
+		// no rows found so new
+		isNew = true
+	}
+	if userID, ok := session.Values["UserId"].(int64); ok {
+		dbSession.UserId = userID
+	} else {
+		// all sessions with no user specified are UserId -1
+		dbSession.UserId = -1
+	}
+	if err := gob.NewEncoder(&buf).Encode(session.Values); err != nil {
+		return err
+	}
+	dbSession.Data = buf.Bytes()
+	if isNew {
+		now := time.Now().Unix()
+		dbSession.Token = session.ID
+		dbSession.Created = now
+		dbSession.Expires = now + int64(session.Options.MaxAge)
+		if err := s.dbMap.Insert(&dbSession); err != nil {
+			return fmt.Errorf("Could not insert session: %v", err)
+		}
+	} else {
+		if _, err := s.dbMap.Update(&dbSession); err != nil {
+			return fmt.Errorf("Could not update session: %v", err)
+		}
+	}
+	return nil
+}
+
+// delete one session from the db
+func (s *SQLStore) destroy(session *sessions.Session) error {
+	var dbSession models.Session
+	if err := s.dbMap.SelectOne(&dbSession, "SELECT * FROM Session WHERE Token = ?", session.ID); err != nil {
+		// if no rows are found nothing is done
+		if err == sql.ErrNoRows {
+			return nil
+		}
+		return fmt.Errorf("Could not select session to destroy: %v", err)
+	}
+	if _, err := s.dbMap.Delete(&dbSession); err != nil {
+		return fmt.Errorf("Could not destroy session: %v", err)
+	}
+	return nil
+}
+
+// delete expired sessions from the db
+func (s *SQLStore) destroyExpiredSessions() error {
+	var dbSession models.Session
+	dbSessions, err := s.dbMap.Select(&dbSession, "SELECT * FROM Session WHERE Expires < ?", time.Now().Unix())
+	if err != nil {
+		return fmt.Errorf("Could not select expired sessions: %v", err)
+	}
+	_, err = s.dbMap.Delete(dbSessions...)
+	if err != nil {
+		return fmt.Errorf("Could not destroy expired sessions: %v", err)
+	}
+	return nil
+}
+
+// DestroySessionsForUserID deletes all sessions from the db for userId
+//
+// It should be noted that this does not prevent the user's current
+// session from being saved again, which can be achieved by setting
+// MaxAge to -1
+func DestroySessionsForUserID(dbMap *gorp.DbMap, userID int64) error {
+	var dbSession models.Session
+	dbSessions, err := dbMap.Select(&dbSession, "SELECT * FROM Session WHERE UserId = ?", userID)
+	if err != nil {
+		return fmt.Errorf("Could not select user sessions to destroy: %v", err)
+	}
+	_, err = dbMap.Delete(dbSessions...)
+	if err != nil {
+		return fmt.Errorf("Could not destroy user sessions: %v", err)
+	}
+	return nil
+}

--- a/system/sqlstore_test.go
+++ b/system/sqlstore_test.go
@@ -1,0 +1,244 @@
+package system
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"database/sql"
+	"database/sql/driver"
+	"encoding/base32"
+	"encoding/gob"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/decred/dcrstakepool/models"
+	"github.com/go-gorp/gorp"
+	"github.com/gorilla/securecookie"
+	"github.com/gorilla/sessions"
+)
+
+// tokens used for sessions
+func newTokens(n int) []string {
+	toks := make([]string, n)
+	for i := range toks {
+		toks[i] = base32.StdEncoding.EncodeToString(securecookie.GenerateRandomKey(32))
+	}
+	return toks
+}
+
+// Get Data representation of session.Values. Currently only testing for
+// user id
+func gobFromValues(i int64) []byte {
+	m := map[interface{}]interface{}{"UserId": i}
+	var buf bytes.Buffer
+	gob.NewEncoder(&buf).Encode(m)
+	return buf.Bytes()
+}
+
+// dbSession.Data with no... data
+func nilGob() []byte {
+	m := map[interface{}]interface{}{}
+	var buf bytes.Buffer
+	gob.NewEncoder(&buf).Encode(m)
+	return buf.Bytes()
+}
+
+// helper for sqlmock select
+func expectSelect(mock sqlmock.Sqlmock, args []driver.Value, rows *sqlmock.Rows, err error) {
+	mock.ExpectQuery(`^SELECT (.*) FROM Session WHERE Token = (.+)$`).
+		WithArgs(args...).
+		WillReturnRows(rows).
+		WillReturnError(err)
+}
+
+// helper for sqlmock delete
+func expectDelete(mock sqlmock.Sqlmock, args []driver.Value) {
+	mock.ExpectExec("^delete from `Session` where `SessionID`=(.+)$").
+		WithArgs(args...).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+}
+
+// helper for sqlmock update
+func expectUpdate(mock sqlmock.Sqlmock, args []driver.Value) {
+	mock.ExpectExec("^update `Session` set `Token`=(.+), `Data`=(.+), `UserId`=(.+), `Created`=(.+), `Expires`=(.+) where `SessionID`=(.+);$").
+		WithArgs(args...).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+}
+
+// setup db, mock db, and sqlstore
+func makeDbAndStore() (sqlmock.Sqlmock, *sql.DB, *SQLStore) {
+	// Open new mock database
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		panic(err)
+	}
+	dbMap := &gorp.DbMap{
+		Db:              db,
+		Dialect:         gorp.MySQLDialect{Engine: "InnoDB", Encoding: "UTF8MB4"},
+		ExpandSliceArgs: true,
+	}
+	dbMap.AddTableWithName(models.Session{}, "Session").SetKeys(true, "Id")
+	hash := sha256.New()
+	io.WriteString(hash, "abrakadabra")
+	s := NewSQLStore(dbMap, hash.Sum(nil))
+	s.Options = &sessions.Options{
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   true,
+		//six hours
+		MaxAge: 60 * 60 * 6,
+	}
+	return mock, db, s
+}
+
+// add session token to request cookies
+func setSessionForUserID(r *http.Request, store *SQLStore, maxAge int, userID int64) *sessions.Session {
+	session := sessions.NewSession(store, "session")
+	session.Values["UserId"] = userID
+	session.ID = tokens[userID]
+	opts := *store.Options
+	opts.MaxAge = maxAge
+	session.Options = &opts
+	encoded, err := securecookie.EncodeMulti(session.Name(), &session.ID, store.codecs...)
+	if err != nil {
+		panic(err)
+	}
+	cookie := sessions.NewCookie(session.Name(), encoded, session.Options)
+	if r != nil {
+		r.AddCookie(cookie)
+	}
+	return session
+}
+
+var (
+	tokens          = newTokens(4)
+	now             = time.Now().Unix()
+	oneDay    int64 = 60 * 60 * 24
+	yesterday       = now - oneDay
+	tomorrow        = now + oneDay
+	col             = []string{"Token", "Data", "UserId", "Created", "Expires", "SessionID"}
+)
+
+type testNew struct {
+	userID     int64
+	hasCookie  bool
+	isExpired  bool
+	args       []driver.Value
+	row        []driver.Value
+	err        error
+	sessValues map[interface{}]interface{}
+}
+
+var testsNew = []testNew{
+	{0, true, false, []driver.Value{tokens[0]}, []driver.Value{tokens[0], gobFromValues(0), 0, now, tomorrow, 0}, nil, map[interface{}]interface{}{"UserId": int64(0)}},
+	//expired
+	{1, true, true, []driver.Value{tokens[1]}, []driver.Value{tokens[1], gobFromValues(1), 1, now, yesterday, 0}, nil, map[interface{}]interface{}{}},
+	//no cookie in request
+	{2, false, false, []driver.Value{tokens[2]}, []driver.Value{tokens[2], gobFromValues(2), 2, now, tomorrow, 0}, nil, map[interface{}]interface{}{}},
+	//no rows
+	{3, true, false, []driver.Value{tokens[3]}, []driver.Value{tokens[3], gobFromValues(3), 3, now, tomorrow, 0}, sql.ErrNoRows, map[interface{}]interface{}{}},
+}
+
+func TestNew(t *testing.T) {
+	mock, db, store := makeDbAndStore()
+	defer db.Close()
+	for _, test := range testsNew {
+		r, err := http.NewRequest("GET", "http://localhost/blah", nil)
+		if err != nil {
+			t.Error(err)
+		}
+		// cookie was previously saved
+		if test.hasCookie {
+			setSessionForUserID(r, store, 60, test.userID)
+			expectSelect(mock, test.args, sqlmock.NewRows(col).AddRow(test.row...), test.err)
+			// session is expired in db
+			if test.isExpired {
+				expectSelect(mock, test.args, sqlmock.NewRows(col).AddRow(test.row...), test.err)
+				expectDelete(mock, []driver.Value{0})
+			}
+		}
+		// testing
+		s, err := store.New(r, "session")
+		if err != nil {
+			t.Errorf("session load err: %v ", err)
+		}
+		// expected session.Values must equal actual
+		eq := reflect.DeepEqual(s.Values, test.sessValues)
+		if !eq {
+			t.Errorf("expected session values %v but got %v", test.sessValues, s.Values)
+		}
+		if err = mock.ExpectationsWereMet(); err != nil {
+			t.Errorf("unmet expectation error: %s", err)
+		}
+	}
+}
+
+type testSave struct {
+	userID      int64
+	hasUserID   bool
+	isNew       bool
+	isDestroyed bool
+	maxAge      int
+	args        []driver.Value
+	row         []driver.Value
+	err         error
+}
+
+var testsSave = []testSave{
+	{0, true, false, false, 60, []driver.Value{tokens[0]}, []driver.Value{tokens[0], gobFromValues(0), 0, now, tomorrow, 0}, nil},
+	// maxAge is -1
+	{1, true, false, true, -1, []driver.Value{tokens[1]}, []driver.Value{tokens[1], gobFromValues(1), 1, now, tomorrow, 0}, nil},
+	// is new with no user id
+	{0, false, true, false, 60, []driver.Value{sqlmock.AnyArg(), nilGob(), -1, sqlmock.AnyArg(), sqlmock.AnyArg()}, []driver.Value{}, sql.ErrNoRows},
+	// is new with user id
+	{2, true, true, false, 60, []driver.Value{sqlmock.AnyArg(), gobFromValues(2), 2, sqlmock.AnyArg(), sqlmock.AnyArg()}, []driver.Value{}, sql.ErrNoRows},
+}
+
+func TestSave(t *testing.T) {
+	mock, db, store := makeDbAndStore()
+	defer db.Close()
+	for _, test := range testsSave {
+		r, err := http.NewRequest("GET", "http://localhost/blah", nil)
+		w := httptest.NewRecorder()
+		s := sessions.NewSession(store, "session")
+		if err != nil {
+			t.Error(err)
+		}
+		// cookie was previously saved
+		if test.hasUserID {
+			// save doesn't matter what's in the request
+			s = setSessionForUserID(nil, store, test.maxAge, test.userID)
+		}
+		// maxAge of -1 is destroyed
+		if test.isDestroyed {
+			expectSelect(mock, test.args, sqlmock.NewRows(col).AddRow(test.row...), test.err)
+			expectDelete(mock, []driver.Value{0})
+		} else {
+			if test.isNew {
+				// a new session is inserted, we cant be sure of the exact ID and time
+				mock.ExpectQuery(`^SELECT (.*) FROM Session WHERE Token = (.+)$`).
+					WillReturnError(test.err)
+				mock.ExpectExec("^insert into `Session` \\(`SessionID`,`Token`,`Data`,`UserId`,`Created`,`Expires`\\) values \\(null,(.+),(.+),(.+),(.+),(.+)\\);$").
+					WithArgs(test.args...).
+					WillReturnResult(sqlmock.NewResult(0, 0))
+			} else {
+				// a found session is updated
+				expectSelect(mock, test.args, sqlmock.NewRows(col).AddRow(test.row...), test.err)
+				expectUpdate(mock, test.row)
+			}
+		}
+		// testing
+		err = store.Save(r, w, s)
+		if err != nil {
+			t.Errorf("session save err: %v ", err)
+		}
+		// if the database transactions went as expected pass
+		if err = mock.ExpectationsWereMet(); err != nil {
+			t.Errorf("unmet expectation error: %s", err)
+		}
+	}
+}


### PR DESCRIPTION
This PR Creates a new column in the dbo to hold a token which is used to monitor password changes and nullify the session if the password was reset from anywhere else. It also adds a timeout of one day to idle sessions (too long?).

You can test the code here https://test.dcrstakedinner.com/
If you make an account, the emails will probably go to your junk folder

A couple questions, should there be a page or alert to inform a user that their session has ended? And, I'm doing something kind of funky in the middleware so that checks don't fire for loading images and captcha. Without this check the middleware fires multiple times per page load. perhaps this is not wanted behaviour and should be handled in another pr?



closes #328, closes #235, closes #379