### PR TITLE
 Notify when not all voted tickets are displayed

### DIFF
--- a/controllers/main.go
+++ b/controllers/main.go
@@ -1802,7 +1802,7 @@ func (controller *MainController) Stats(c web.C, r *http.Request) (string, int) 
 
 // ByTicketHeight type implements sort.Sort for types with a TicketHeight field.
 // This includes all valid tickets, including spend tickets.
-type ByTicketHeight []TicketInfoLive
+type ByTicketHeight []TicketInfo
 
 func (a ByTicketHeight) Len() int {
 	return len(a)
@@ -1842,27 +1842,18 @@ type TicketInfoInvalid struct {
 	Ticket string
 }
 
-// TicketInfo represents live immature (mined) tickets that have yet to
+// TicketInfo represents live or immature tickets that have yet to
 // be spent by either a vote or revocation.
 type TicketInfo struct {
 	TicketHeight uint32
 	Ticket       string
 }
 
-// TicketInfoImmature represents immature (mined) tickets that have yet to
-// be spent by either a vote or revocation.
-type TicketInfoImmature TicketInfo
-
-// TicketInfoLive represents live tickets that have yet to
-// be spent by either a vote or revocation.
-type TicketInfoLive TicketInfo
-
 // Tickets renders the tickets page.
 func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int) {
 
 	var ticketInfoInvalid []TicketInfoInvalid
-	var ticketInfoImmature []TicketInfoImmature
-	var ticketInfoLive []TicketInfoLive
+	var ticketInfoLive, ticketInfoImmature []TicketInfo
 	var ticketInfoVoted, ticketInfoExpired, ticketInfoMissed []TicketInfoHistoric
 	var numVoted int
 
@@ -1921,12 +1912,12 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 		for _, ticket := range spui.Tickets {
 			switch ticket.Status {
 			case "immature":
-				ticketInfoImmature = append(ticketInfoImmature, TicketInfoImmature{
+				ticketInfoImmature = append(ticketInfoImmature, TicketInfo{
 					TicketHeight: ticket.TicketHeight,
 					Ticket:       ticket.Ticket,
 				})
 			case "live":
-				ticketInfoLive = append(ticketInfoLive, TicketInfoLive{
+				ticketInfoLive = append(ticketInfoLive, TicketInfo{
 					TicketHeight: ticket.TicketHeight,
 					Ticket:       ticket.Ticket,
 				})
@@ -1944,18 +1935,17 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 					TicketHeight:  ticket.TicketHeight,
 				})
 			case "voted":
-				numVoted++
-				if len(ticketInfoVoted) < controller.maxVotedTickets {
-					ticketInfoVoted = append(ticketInfoVoted, TicketInfoHistoric{
-						Ticket:        ticket.Ticket,
-						SpentBy:       ticket.SpentBy,
-						SpentByHeight: ticket.SpentByHeight,
-						TicketHeight:  ticket.TicketHeight,
-					})
-				}
+				ticketInfoVoted = append(ticketInfoVoted, TicketInfoHistoric{
+					Ticket:        ticket.Ticket,
+					SpentBy:       ticket.SpentBy,
+					SpentByHeight: ticket.SpentByHeight,
+					TicketHeight:  ticket.TicketHeight,
+				})
 			}
 		}
 	}
+
+	numVoted = len(ticketInfoVoted)
 
 	if spui != nil && len(spui.InvalidTickets) > 0 {
 		for _, ticket := range spui.InvalidTickets {
@@ -1963,14 +1953,18 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 		}
 	}
 
-	// Sort live tickets. This is commented because the JS tables will perform
-	// their own sorting anyway. However, depending on the UI implementation, it
-	// may be desirable to sort it here.
-	// sort.Sort(ByTicketHeight(ticketInfoLive))
-
-	// Sort historic (voted and revoked) tickets
+	// Sort tickets for display. Ideally these would be sorted on the front
+	// end by javascript.
+	sort.Sort(sort.Reverse(ByTicketHeight(ticketInfoLive)))
+	sort.Sort(sort.Reverse(ByTicketHeight(ticketInfoImmature)))
+	sort.Sort(BySpentByHeight(ticketInfoExpired))
 	sort.Sort(BySpentByHeight(ticketInfoVoted))
 	sort.Sort(BySpentByHeight(ticketInfoMissed))
+
+	// Truncate the slice of voted tickets if there are too many
+	if len(ticketInfoVoted) > controller.maxVotedTickets {
+		ticketInfoVoted = ticketInfoVoted[0:controller.maxVotedTickets]
+	}
 
 	c.Env["Admin"], _ = controller.isAdmin(c, r)
 	c.Env["TicketsInvalid"] = ticketInfoInvalid
@@ -1979,7 +1973,7 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 	c.Env["TicketsExpired"] = ticketInfoExpired
 	c.Env["TicketsMissed"] = ticketInfoMissed
 	c.Env["TicketsVotedCount"] = numVoted
-	c.Env["TicketsVotedArchivedCount"] = numVoted - len(ticketInfoVoted)
+	c.Env["TicketsVotedMaxDisplay"] = controller.maxVotedTickets
 	c.Env["TicketsVoted"] = ticketInfoVoted
 	widgets := controller.Parse(t, "tickets", c.Env)
 

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -1957,9 +1957,9 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 	// end by javascript.
 	sort.Sort(sort.Reverse(ByTicketHeight(ticketInfoLive)))
 	sort.Sort(sort.Reverse(ByTicketHeight(ticketInfoImmature)))
-	sort.Sort(BySpentByHeight(ticketInfoExpired))
-	sort.Sort(BySpentByHeight(ticketInfoVoted))
-	sort.Sort(BySpentByHeight(ticketInfoMissed))
+	sort.Sort(sort.Reverse(BySpentByHeight(ticketInfoExpired)))
+	sort.Sort(sort.Reverse(BySpentByHeight(ticketInfoVoted)))
+	sort.Sort(sort.Reverse(BySpentByHeight(ticketInfoMissed)))
 
 	// Truncate the slice of voted tickets if there are too many
 	if len(ticketInfoVoted) > controller.maxVotedTickets {

--- a/controllers/main_test.go
+++ b/controllers/main_test.go
@@ -43,16 +43,16 @@ func TestSortByTicketHeight(t *testing.T) {
 	// Create a large list of tickets to sort, voted over many blocks
 	ticketCount, maxTxHeight := 55000, int64(123000)
 
-	ticketInfoLive := make([]TicketInfoLive, 0, ticketCount)
+	ticketInfoLive := make([]TicketInfo, 0, ticketCount)
 	for i := 0; i < ticketCount; i++ {
-		ticketInfoLive = append(ticketInfoLive, TicketInfoLive{
+		ticketInfoLive = append(ticketInfoLive, TicketInfo{
 			TicketHeight: uint32(mrand.Int63n(maxTxHeight)),
 			Ticket:       randHashString(), // could be nothing unless we sort with it
 		})
 	}
 
 	// Make a copy to sort with ref method
-	ticketInfoLive2 := make([]TicketInfoLive, len(ticketInfoLive))
+	ticketInfoLive2 := make([]TicketInfo, len(ticketInfoLive))
 	copy(ticketInfoLive2, ticketInfoLive)
 
 	// Sort with ByTicketHeight, the test subject
@@ -87,9 +87,9 @@ func benchmarkSortByTicketHeight(ticketCount int, b *testing.B) {
 	// Create a large list of tickets to sort, voted over many blocks
 	maxTxHeight := int64(53000)
 
-	ticketInfoLive := make([]TicketInfoLive, 0, ticketCount)
+	ticketInfoLive := make([]TicketInfo, 0, ticketCount)
 	for i := 0; i < ticketCount; i++ {
-		ticketInfoLive = append(ticketInfoLive, TicketInfoLive{
+		ticketInfoLive = append(ticketInfoLive, TicketInfo{
 			TicketHeight: uint32(mrand.Int63n(maxTxHeight)),
 			Ticket:       randHashString(), // could be nothing unless we sort with it
 		})
@@ -97,7 +97,7 @@ func benchmarkSortByTicketHeight(ticketCount int, b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		// Make a copy to sort
-		ticketInfoLive2 := make([]TicketInfoLive, len(ticketInfoLive))
+		ticketInfoLive2 := make([]TicketInfo, len(ticketInfoLive))
 		copy(ticketInfoLive2, ticketInfoLive)
 
 		// Sort with ByTicketHeight, the test subject

--- a/views/tickets.html
+++ b/views/tickets.html
@@ -91,7 +91,7 @@
 							<div class="accordion__contents mb-1">
 
 								{{ if gt .TicketsVotedCount .TicketsVotedMaxDisplay}}
-									<div>
+									<div class="text-center">
 										<span>You have {{.TicketsVotedCount}} voted tickets. Only the most recent {{.TicketsVotedMaxDisplay}} are shown here.</span>
 									</div>
 								{{end}}

--- a/views/tickets.html
+++ b/views/tickets.html
@@ -43,7 +43,8 @@
 							<div>
 								<img src="assets/images/group-1120.svg" alt="">
 								<span><pre class="m-0 d-inline">{{printf "%.16s" $data.Ticket}}...</pre></span>
-								<a style="margin-left:50px" href="https://{{$.Network}}.dcrdata.org/tx/{{$data.Ticket}}" rel="noopener noreferrer">Block Explorer</a>
+								<a style="margin-left:50px; margin-right:50px" href="https://{{$.Network}}.dcrdata.org/tx/{{$data.Ticket}}" rel="noopener noreferrer">Block Explorer</a>
+								<span>Purchase height:&nbsp;{{$data.TicketHeight}}</span>
 							</div>
 							{{else}}
 								<div class="accordion__empty">
@@ -67,7 +68,8 @@
 							<div>
 								<img src="assets/images/group-1119.svg" alt="">
 								<span><pre class="m-0 d-inline">{{printf "%.16s" $data.Ticket}}...</pre></span>
-								<a style="margin-left:50px" href="https://{{$.Network}}.dcrdata.org/tx/{{$data.Ticket}}" rel="noopener noreferrer">Block Explorer</a>
+								<a style="margin-left:50px; margin-right:50px" href="https://{{$.Network}}.dcrdata.org/tx/{{$data.Ticket}}" rel="noopener noreferrer">Block Explorer</a>
+								<span>Purchase height:&nbsp;{{$data.TicketHeight}}</span>
 							</div>
 							{{else}}
 								<div class="accordion__empty">
@@ -87,11 +89,19 @@
 							</div>
 						</label>
 							<div class="accordion__contents mb-1">
+
+								{{ if gt .TicketsVotedCount .TicketsVotedMaxDisplay}}
+									<div>
+										<span>You have {{.TicketsVotedCount}} voted tickets. Only the most recent {{.TicketsVotedMaxDisplay}} are shown here.</span>
+									</div>
+								{{end}}
+
 								{{ range $i, $data := .TicketsVoted }}
 								<div>
 									<img src="assets/images/symbol-8-1.svg" alt="">
 									<span><pre class="m-0 d-inline">{{printf "%.16s" $data.Ticket}}...</pre></span>
-									<a style="margin-left:50px" href="https://{{$.Network}}.dcrdata.org/tx/{{$data.Ticket}}" rel="noopener noreferrer">Block Explorer</a>
+									<a style="margin-left:50px; margin-right:50px" href="https://{{$.Network}}.dcrdata.org/tx/{{$data.Ticket}}" rel="noopener noreferrer">Block Explorer</a>
+									<span>Voted height:&nbsp;{{$data.SpentByHeight}}</span>
 								</div>
 								{{else}}
 									<div class="accordion__empty">
@@ -115,7 +125,8 @@
 									<div>
 										<img src="assets/images/symbol-9-1.svg" alt="">
 										<span><pre class="m-0 d-inline">{{printf "%.16s" $data.Ticket}}...</pre></span>
-										<a style="margin-left:50px" href="https://{{$.Network}}.dcrdata.org/tx/{{$data.Ticket}}" rel="noopener noreferrer">Block Explorer</a>
+										<a style="margin-left:50px; margin-right:50px" href="https://{{$.Network}}.dcrdata.org/tx/{{$data.Ticket}}" rel="noopener noreferrer">Block Explorer</a>
+										<span>Revoked height:&nbsp;{{$data.SpentByHeight}}</span>
 									</div>
 								{{else}}
 									<div class="accordion__empty">
@@ -139,7 +150,8 @@
 								<div>
 									<img src="assets/images/symbol-5-1.svg" alt="">
 									<span><pre class="m-0 d-inline">{{printf "%.16s" $data.Ticket}}...</pre></span>
-									<a style="margin-left:50px" href="https://{{$.Network}}.dcrdata.org/tx/{{$data.Ticket}}" rel="noopener noreferrer">Block Explorer</a>
+									<a style="margin-left:50px; margin-right:50px" href="https://{{$.Network}}.dcrdata.org/tx/{{$data.Ticket}}" rel="noopener noreferrer">Block Explorer</a>
+									<span>Revoked height:&nbsp;{{$data.SpentByHeight}}</span>
 								</div>
 								{{else}}
 									<div class="accordion__empty">
@@ -164,7 +176,8 @@
 								<div>
 									<img src="assets/images/symbol-5-1-1.svg" alt="">
 									<span><pre class="m-0 d-inline">{{printf "%.16s" $data.Ticket}}...</pre></span>
-									<a style="margin-left:50px" href="https://{{$.Network}}.dcrdata.org/tx/{{$data.Ticket}}" rel="noopener noreferrer">Block Explorer</a>
+									<a style="margin-left:50px; margin-right:50px" href="https://{{$.Network}}.dcrdata.org/tx/{{$data.Ticket}}" rel="noopener noreferrer">Block Explorer</a>
+									<span>Purchase height:&nbsp;{{$data.TicketHeight}}</span>
 								</div>
 								{{else}}
 									<div class="accordion__empty">


### PR DESCRIPTION
Closes #353 

- Ticket lists were being displayed in reverse order so I have reversed the sorting.
- Only the oldest 1000 voted tickets were being displayed rather than the most recent 1000. That has been fixed.
- Now also showing each ticket's purchased/voted/revoked height.

![Screenshot from 2019-06-26 14-36-57](https://user-images.githubusercontent.com/6762864/60184396-e2eb7280-981f-11e9-9164-2538fc09767b.png)
