### PR TITLE
Rework "Connect to Wallet" Page

### DIFF
--- a/controllers/main.go
+++ b/controllers/main.go
@@ -685,21 +685,28 @@ func (controller *MainController) Address(c web.C, r *http.Request) (string, int
 
 func validateUserPubKeyAddr(pubKeyAddr string) (dcrutil.Address, error) {
 	if len(pubKeyAddr) < 40 {
-		return nil, errors.New("Address is too short")
+		str := "Address is too short"
+		log.Warnf("User submitted invalid address: %s - %s", pubKeyAddr, str)
+		return nil, errors.New(str)
 	}
 
 	if len(pubKeyAddr) > 65 {
-		return nil, errors.New("Address is too long")
+		str := "Address is too long"
+		log.Warnf("User submitted invalid address: %s - %s", pubKeyAddr, str)
+		return nil, errors.New(str)
 	}
 
 	u, err := dcrutil.DecodeAddress(pubKeyAddr)
 	if err != nil {
+		log.Warnf("User submitted invalid address: %s - %v", pubKeyAddr, err)
 		return nil, errors.New("Couldn't decode address")
 	}
 
 	_, is := u.(*dcrutil.AddressSecpPubKey)
 	if !is {
-		return nil, errors.New("Incorrect address type")
+		str := "Incorrect address type"
+		log.Warnf("User submitted invalid address: %s - %s", pubKeyAddr, str)
+		return nil, errors.New(str)
 	}
 
 	return u, nil

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -222,22 +222,9 @@ func (controller *MainController) APIAddress(c web.C, r *http.Request) ([]string
 
 	userPubKeyAddr := r.FormValue("UserPubKeyAddr")
 
-	if len(userPubKeyAddr) < 40 {
-		return nil, codes.InvalidArgument, "address error", errors.New("address too short")
-	}
-
-	if len(userPubKeyAddr) > 65 {
-		return nil, codes.InvalidArgument, "address error", errors.New("address too long")
-	}
-
-	u, err := dcrutil.DecodeAddress(userPubKeyAddr)
+	u, err := validateUserPubKeyAddr(userPubKeyAddr)
 	if err != nil {
-		return nil, codes.InvalidArgument, "address error", errors.New("couldn't decode address")
-	}
-
-	_, is := u.(*dcrutil.AddressSecpPubKey)
-	if !is {
-		return nil, codes.InvalidArgument, "address error", errors.New("incorrect address type")
+		return nil, codes.InvalidArgument, "address error", err
 	}
 
 	// Get the ticket address for this user
@@ -696,6 +683,28 @@ func (controller *MainController) Address(c web.C, r *http.Request) (string, int
 	return controller.Parse(t, "main", c.Env), http.StatusOK
 }
 
+func validateUserPubKeyAddr(pubKeyAddr string) (dcrutil.Address, error) {
+	if len(pubKeyAddr) < 40 {
+		return nil, errors.New("Address is too short")
+	}
+
+	if len(pubKeyAddr) > 65 {
+		return nil, errors.New("Address is too long")
+	}
+
+	u, err := dcrutil.DecodeAddress(pubKeyAddr)
+	if err != nil {
+		return nil, errors.New("Couldn't decode address")
+	}
+
+	_, is := u.(*dcrutil.AddressSecpPubKey)
+	if !is {
+		return nil, errors.New("Incorrect address type")
+	}
+
+	return u, nil
+}
+
 // AddressPost is address form submit route.
 func (controller *MainController) AddressPost(c web.C, r *http.Request) (string, int) {
 	session := controller.GetSession(c)
@@ -719,26 +728,9 @@ func (controller *MainController) AddressPost(c web.C, r *http.Request) (string,
 
 	log.Infof("Address POST from %v, pubkeyaddr %v", remoteIP, userPubKeyAddr)
 
-	if len(userPubKeyAddr) < 40 {
-		session.AddFlash("Address is too short", "address")
-		return controller.Address(c, r)
-	}
-
-	if len(userPubKeyAddr) > 65 {
-		session.AddFlash("Address is too long", "address")
-		return controller.Address(c, r)
-	}
-
-	// Get dcrutil.Address for user from pubkey address string
-	u, err := dcrutil.DecodeAddress(userPubKeyAddr)
+	u, err := validateUserPubKeyAddr(userPubKeyAddr)
 	if err != nil {
-		session.AddFlash("Couldn't decode address", "address")
-		return controller.Address(c, r)
-	}
-
-	_, is := u.(*dcrutil.AddressSecpPubKey)
-	if !is {
-		session.AddFlash("Incorrect address type", "address")
+		session.AddFlash(err.Error(), "address")
 		return controller.Address(c, r)
 	}
 

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -75,6 +75,18 @@ body {
   text-align: left;
   background-color: #fff; }
 
+/* 
+   Read this link to understand the purpose of the following two lines.
+   https://stackoverflow.com/questions/32862394/bootstrap-modals-keep-adding-padding-right-to-body-after-closed
+*/
+body:not(.modal-open){
+  padding-right: 0px !important;
+}
+.modal-open {
+    overflow: hidden;
+    padding-right: 0 !important;
+}
+
 [tabindex="-1"]:focus {
   outline: 0 !important; }
 

--- a/views/address.html
+++ b/views/address.html
@@ -2,142 +2,256 @@
 <section class="site-content">
 		<div class="container container--narrow">
 			<div class="row mx-3">
-				{{if .User.MultiSigAddress}}
-          <section class="block">
-              <div class="col-12 block__title">
-                <div class="d-sm-flex d-none justify-content-between align-items-center">
-                  <h1><span>Connected to Wallet</span> <img src="assets/images/wallet-icon.svg" alt=""></h1>
-                  <img class="icon--info" src="assets/images/info-icon.svg" data-toggle="modal" data-target="#connectSubAddress" alt="">
-                </div>
-                <div class="d-flex d-sm-none justify-content-between align-items-start">
-                  <h1><img src="assets/images/wallet-icon.svg" alt=""> <span>Connected to Wallet</span></h1>
-                  <img class="icon--info" src="assets/images/info-icon.svg" data-toggle="modal" data-target="#connectSubAddress" alt="">
-                </div>
-              </div>
+		{{if .User.MultiSigAddress}}
+		<section class="block">
+			<div class="col-12 block__title">
+				<div class="d-sm-flex justify-content-between align-items-center">
+					<h1>
+						<span>Connected to Wallet</span>
+						<img src="assets/images/wallet-icon.svg" alt="">
+					</h1>
+				</div>
+			</div>
 
-            <div class="modal fade" id="connectSubAddress" tabindex="-1" role="dialog" aria-labelledby="connectSubAddressTitle" aria-hidden="true">
-              <div class="container container--narrow modal-dialog px-0" role="document">
-                <div class="modal-content px-md-3 py-md-4">
-                  <div class="modal-header d-md-flex d-none">
-                    <h1 class="modal-title d-flex justify-content-between align-items-center" id="connectSubAddressTitle"><img src="assets/images/info-icon-lg.svg" alt=""> <span class="px-3">Submitted Address</span></h1>
-                    <button type="button" class="modal-close" data-dismiss="modal" aria-label="Close">
-                      <span aria-hidden="true"><img src="assets/images/close-cross-icon.svg" alt=""></span>
-                    </button>
-                  </div>
-                  <div class="modal-header d-md-none d-block mb-3 p-4">
-                    <div class="d-flex justify-content-between align-items-center">
-                      <button type="button" class="modal-close" data-dismiss="modal" aria-label="Close">
-                        <span aria-hidden="true"><img src="assets/images/arrow-back--blue.svg" alt=""></span>
-                      </button>
-                      <h1 class="modal-title" id="connectSubAddressTitle"><img src="assets/images/info-icon-sm.svg" alt=""> <span class="pl-1">Submitted Address</span></h1>
-                    </div>
-                  </div>
-                  <div class="modal-body mx-3 px-sm-5 px-0">
-                    <p>When you submit an address, the VSP binds that address from your wallet together with an address from the VSP’s voting wallet. This is done by creating a 1-of-2 multisignature script which lets you, the VSP, or both parties vote. This “binding” of the wallets means that if you ever delete your current wallet and create a new wallet with a different seed, importing your multisignature script will not work because it contains an address that is not present in your new wallet.</p>
-
-                    <p>If you wish to verify that this address belongs to your wallet, you may run the following command:</p>
-
-                    <div class="modal-code">
-                      <pre>$ dcrctl {{ if eq .Network "testnet"}}--testnet{{end}} --wallet validateaddress {{ .User.UserPubKeyAddr }}</pre>
-                    </div>
-
-                    <p>In the result, you will see fields such as “ismine” and “account” if the address is present.</p>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <div class="col-12 block__description--white">
-              <p>Your public key address has been accepted and registration is complete. If you need to re-register with a new address from a new wallet, please create a new VSP account.</p>
-            </div>
-            <div class="col-12 mb-5 block__key">
-              <h2>Public Key Address</h2>
-              <p>{{ .User.UserPubKeyAddr }}</p>
-            </div>
-          </section>
-						
-				{{ else }}
-				<section class="block">
-						<div class="col-12 block__title">
-							<h1 class="d-flex justify-content-between align-items-center"><span>Connect via API Key</span> <img class="icon--info" src="assets/images/info-icon.svg" data-toggle="modal" data-target="#connectApiKey" alt=""></h1>
+			<div class="modal fade" id="connectSubAddress" tabindex="-1" role="dialog" aria-labelledby="connectSubAddressTitle" aria-hidden="true">
+				<div class="container container--narrow modal-dialog px-0" role="document">
+					<div class="modal-content px-md-3 py-md-4">
+						<div class="modal-header d-md-flex d-none">
+							<h1 class="modal-title d-flex justify-content-between align-items-center" id="connectSubAddressTitle"><img src="assets/images/info-icon-lg.svg" alt=""> <span class="px-3">Submitted Address</span></h1>
+							<button type="button" class="modal-close" data-dismiss="modal" aria-label="Close">
+								<span aria-hidden="true"><img src="assets/images/close-cross-icon.svg" alt=""></span>
+							</button>
 						</div>
-
-						<div class="modal fade" id="connectApiKey" tabindex="-1" role="dialog" aria-labelledby="connectApiKeyTitle" aria-hidden="true">
-							<div class="container container--narrow modal-dialog px-0" role="document">
-								<div class="modal-content px-md-3 py-md-4">
-									<div class="modal-header d-md-flex d-none">
-										<h1 class="modal-title d-flex justify-content-between align-items-center" id="connectApiKeyTitle"><img src="assets/images/info-icon-lg.svg" alt=""> <span class="px-3">Connect via API Key</span></h1>
-										<button type="button" class="modal-close" data-dismiss="modal" aria-label="Close">
-											<span aria-hidden="true"><img src="assets/images/close-cross-icon.svg" alt=""></span>
-										</button>
-									</div>
-									<div class="modal-header d-md-none d-block mb-3 p-4">
-										<div class="d-flex justify-content-between align-items-center">
-											<button type="button" data-dismiss="modal" aria-label="Close" class="modal-close">
-												<span aria-hidden="true"><img src="assets/images/arrow-back--blue.svg" alt=""></span>
-											</button>
-											<h1 class="modal-title" id="connectApiKeyTitle"><img src="assets/images/info-icon-sm.svg" alt=""> <span class="pl-1">Connect via API Key</span></h1>
-										</div>
-									</div>
-									<div class="modal-body mx-3 px-sm-5 px-0">
-										<p>The official Decred GUI wallet Decrediton is the recommended way to use VSPs. All you need to get started is to copy and paste the API Token below when prompted. More comprehensive guides are available for Decrediton as well a general overview of the staking process.</p>
-
-										<strong>Submit your API key</strong>
-
-										<img src="assets/images/code-example@2x.png" class="img-fluid">
-									</div>
-								</div>
+						<div class="modal-header d-md-none d-block mb-3 p-4">
+							<div class="d-flex justify-content-between align-items-center">
+								<button type="button" class="modal-close" data-dismiss="modal" aria-label="Close">
+									<span aria-hidden="true"><img src="assets/images/arrow-back--blue.svg" alt=""></span>
+								</button>
+								<h1 class="modal-title" id="connectSubAddressTitle"><img src="assets/images/info-icon-sm.svg" alt=""> <span class="pl-1">Submitted Address</span></h1>
 							</div>
 						</div>
+						<div class="modal-body mx-3 px-sm-5 px-0">
+							<p>When you submit an address, the VSP binds that address from your wallet together with an address from the VSP’s voting wallet. This is done by creating a 1-of-2 multisignature script which lets you, the VSP, or both parties vote. This “binding” of the wallets means that if you ever delete your current wallet and create a new wallet with a different seed, importing your multisignature script will not work because it contains an address that is not present in your new wallet.</p>
 
-						<div class="col-12 block__description">
-							<p>To connect the VSP to your wallet, copy and paste this API key to Decrediton.</p>
+							<p>If you wish to verify that this address belongs to your wallet, you may run the following command:</p>
+
+							<div class="modal-code">
+								<pre>$ dcrctl {{ if eq .Network "testnet"}}--testnet{{end}} --wallet validateaddress {{ .User.UserPubKeyAddr }}</pre>
+							</div>
+
+							<p>In the result, you will see fields such as “ismine” and “account” if the address is present.</p>
 						</div>
+					</div>
+			  	</div>
+			</div>
 
-						<div class="col-12 mb-5 block__key">
-							<p>{{ $.APIToken }}</p>
+			<div class="col-12 block__description--white">
+				<p>Your public key address has been accepted and registration is complete. If you need to re-register with a new address from a new wallet, please create a new VSP account.</p>
+			</div>
+
+			<div class="col-12 mb-4 block__key">
+				<h2 class="d-flex justify-content-between align-items-center">
+					<span>Submitted Address</span>
+					<img class="icon--info mr-3" src="assets/images/info-icon.svg" data-toggle="modal" data-target="#connectSubAddress" alt="">
+				</h2>
+				<p>{{ .User.UserPubKeyAddr }}</p>
+			</div>
+
+			<div class="col-12 mb-4 block__key">
+				<h2>Decrediton API Key</h2>
+				<p>{{ $.APIToken }}</p>
+			</div>
+
+			<div class="col-12 block__title">
+				<h1 class="d-flex justify-content-between align-items-center">
+					<span>Ticket Information</span>
+					<img class="icon--info" src="assets/images/info-icon.svg" data-toggle="modal" data-target="#connectTicketInfo" alt="">
+				</h1>
+			</div>
+
+			<div class="modal fade" id="connectTicketInfo" tabindex="-1" role="dialog" aria-labelledby="connectTicketInfoTitle" aria-hidden="true">
+				<div class="container container--narrow modal-dialog px-0" role="document">
+					<div class="modal-content px-md-3 py-md-4">
+						<div class="modal-header d-md-flex d-none">
+							<h1 class="modal-title d-flex justify-content-between align-items-center" id="connectSubAddressTitle"><img src="assets/images/info-icon-lg.svg" alt=""><span class="px-3">Buying Tickets with dcrwallet using command-line tools</span></h1>
+							<button type="button" class="modal-close" data-dismiss="modal" aria-label="Close">
+								<span aria-hidden="true"><img src="assets/images/close-cross-icon.svg" alt=""></span>
+							</button>
 						</div>
+						<div class="modal-header modal-header--long-title d-md-none d-block mb-3 p-4">
+							<div class="d-flex justify-content-between align-items-start">
+								<button type="button" class="modal-close" data-dismiss="modal" aria-label="Close">
+									<span aria-hidden="true"><img src="assets/images/arrow-back--blue.svg" alt=""></span>
+								</button>
+								<h1 class="modal-title" id="connectSubAddressTitle"><img src="assets/images/info-icon-sm.svg" alt=""><span class="pl-1">Buying Tickets with dcrwallet using command-line tools</span></h1>
+							</div>
+						</div>
+						<div class="modal-body mx-3 px-sm-5 px-0">
+							<blockquote class="modal-blockquote"><span>Note!</span> <br>
+							For command-line users, in-depth dcrwallet instructions can be found at <a href="https://docs.decred.org/getting-started/user-guides/dcrwallet-tickets/" rel="noopener noreferrer">docs.decred.org</a>.<br>
+							Below is just a brief introduction.</blockquote>
 
-					</section>
+							<p>Your multisignature script for delegating votes has been generated. Please first import it locally into your wallet using dcrctl for safe keeping, so you can recover your funds and vote in the unlikely event of a VSP failure:</p>
+
+							<p>dcrctl{{ if eq .Network "testnet"}} --testnet{{end}} --wallet importscript “script”
+
+							<p>For example:</p>
+
+							<div class="modal-code">
+								<p>
+									$ dcrctl{{ if eq .Network "testnet"}} --testnet{{end}} --wallet importscript {{ .User.MultiSigScript }}
+								</p>
+							</div>
+
+							<p>After successfully importing the script into your wallet, you may purchase tickets with voting rights delegated to the VSP in either of two ways:</p>
+
+							<strong>Option A - dcrwallet - Automatic purchasing</strong>
+
+							<p>Stop dcrwallet if it is currently running and add the following to dcrwallet.conf:</p>
+
+							<div class="modal-code">
+								<p>
+									[Application Options] <br>
+									enableticketbuyer=true <br>
+									pooladdress={{ .User.UserFeeAddr }} <br>
+									poolfees={{ .PoolFees }} <br>
+									;; DEPRECATED -- use ticketbuyer.votingaddress instead <br>
+									;; ticketaddress={{ .User.MultiSigAddress }} <br>
+									[Ticket Buyer Options] <br>
+									ticketbuyer.votingaddress={{ .User.MultiSigAddress }} <br>
+									ticketbuyer.maxpriceabsolute=100
+								</p>
+							</div>
+							
+							<p>Unlock dcrwallet and it will automatically purchase stake tickets delegated to the voting service address.</p>
+
+							<strong>Option B - dcrwallet - Manual purchasing</strong>
+
+							<p>Start a wallet with funds available and manually purchase tickets with the following command using dcrctl:</p>
+
+							<p>dcrctl{{ if eq .Network "testnet"}} --testnet{{end}} --wallet purchaseticket "fromaccount" spendlimit minconf ticketaddress numtickets poolfeeaddress poolfeeamt</p>
+
+							<div class="modal-code">
+								<p>
+									dcrctl{{ if eq .Network "testnet"}} --testnet{{end}} --wallet purchaseticket "default" 100 1 {{ .User.MultiSigAddress }} 1 {{ .User.UserFeeAddr }} {{ .PoolFees}}
+								</p>
+							</div>
+
+							<p>Will purchase a ticket delegated to the the multisig address which allows either your or the VSP to vote when the ticket is called. This uses funds from the default account only if the current network price for a ticket is less than 100.0 coins.</p>
+
+							<strong>Voting</strong>
+
+							<p>If you wish to cast votes yourself, please review the guides
+							<a href="https://docs.decred.org/getting-started/user-guides/agenda-voting/#how-to-vote" rel="noopener noreferrer">How To Vote</a>
+							and
+							<a href="https://docs.decred.org/getting-started/user-guides/agenda-voting/#solo-voting" rel="noopener noreferrer">Solo-Voting</a>.
+							The preferences you set on this voting service's <a href="/voting">voting page</a>
+							only affect the stake voting service's voting wallets and not your own.</p>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<div class="col-12 mb-4 block__key">
+				<h2>P2SH Address</h2>
+				<p>{{ .User.MultiSigAddress }}</p>
+			</div>
+
+			<div class="col-12 mb-4 block__key">
+				<h2>Redeem Script</h2>
+				<p>{{ .User.MultiSigScript }}</p>
+			</div>
+
+		</section>
+						
+		{{ else }}
+		<section class="block">
+			<div class="col-12 block__title">
+				<h1 class="d-flex justify-content-between align-items-center">
+					<span>Decrediton Wallet</span>
+					<img class="icon--info" src="assets/images/info-icon.svg" data-toggle="modal" data-target="#connectApiKey" alt="">
+				</h1>
+			</div>
+
+			<div class="modal fade" id="connectApiKey" tabindex="-1" role="dialog" aria-labelledby="connectApiKeyTitle" aria-hidden="true">
+				<div class="container container--narrow modal-dialog px-0" role="document">
+					<div class="modal-content px-md-3 py-md-4">
+						<div class="modal-header d-md-flex d-none">
+							<h1 class="modal-title d-flex justify-content-between align-items-center" id="connectApiKeyTitle"><img src="assets/images/info-icon-lg.svg" alt=""> <span class="px-3">Connect via API Key</span></h1>
+							<button type="button" class="modal-close" data-dismiss="modal" aria-label="Close">
+								<span aria-hidden="true"><img src="assets/images/close-cross-icon.svg" alt=""></span>
+							</button>
+						</div>
+						<div class="modal-header d-md-none d-block mb-3 p-4">
+							<div class="d-flex justify-content-between align-items-center">
+								<button type="button" data-dismiss="modal" aria-label="Close" class="modal-close">
+									<span aria-hidden="true"><img src="assets/images/arrow-back--blue.svg" alt=""></span>
+								</button>
+								<h1 class="modal-title" id="connectApiKeyTitle"><img src="assets/images/info-icon-sm.svg" alt=""> <span class="pl-1">Connect via API Key</span></h1>
+							</div>
+						</div>
+						<div class="modal-body mx-3 px-sm-5 px-0">
+							<p>The official Decred wallet Decrediton is the recommended way to use VSPs. All you need to get started is to copy and paste the API Token below when prompted. More comprehensive guides are available for Decrediton as well a general overview of the staking process.</p>
+
+							<strong>Submit your API key</strong>
+
+							<img src="assets/images/code-example@2x.png" class="img-fluid">
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<div class="col-12 block__description">
+				<p>To connect the VSP to your wallet, copy and paste this API key to Decrediton.</p>
+			</div>
+
+			<div class="col-12 mb-5 block__key">
+				<p>{{ $.APIToken }}</p>
+			</div>
+
+		</section>
 				
-  				<section class="block">
-						<div class="col-12 block__title">
-							<h1 class="d-flex justify-content-between align-items-center"><span>Connect Manually</span> <img class="icon--info" src="assets/images/info-icon.svg" data-toggle="modal" data-target="#connectManually" alt=""></h1>
+		<section class="block">
+			<div class="col-12 block__title">
+				<h1 class="d-flex justify-content-between align-items-center">
+					<span>Command Line Wallet</span>
+					<img class="icon--info" src="assets/images/info-icon.svg" data-toggle="modal" data-target="#connectManually" alt="">
+				</h1>
+			</div>
+
+			<div class="modal fade" id="connectManually" tabindex="-1" role="dialog" aria-labelledby="connectManuallyTitle" aria-hidden="true">
+				<div class="container container--narrow modal-dialog px-0" role="document">
+					<div class="modal-content px-md-3 py-md-4">
+						<div class="modal-header d-md-flex d-none">
+							<h1 class="modal-title d-flex justify-content-between align-items-center" id="connectManuallyTitle"><img src="assets/images/info-icon-lg.svg" alt=""> <span class="px-3">Connect Manually</span></h1>
+							<button type="button" class="modal-close" data-dismiss="modal" aria-label="Close">
+								<span aria-hidden="true"><img src="assets/images/close-cross-icon.svg" alt=""></span>
+							</button>
 						</div>
+						<div class="modal-header d-md-none d-block mb-3 p-4">
+							<div class="d-flex justify-content-between align-items-center">
+								<button type="button" class="modal-close" data-dismiss="modal" aria-label="Close">
+									<span aria-hidden="true"><img src="assets/images/arrow-back--blue.svg" alt=""></span>
+								</button>
+								<h1 class="modal-title" id="connectManuallyTitle"><img src="assets/images/info-icon-sm.svg" alt=""> <span class="pl-1">Connect Manually</span></h1>
+							</div>
+						</div>
+						<div class="modal-body mx-3 px-sm-5 px-0">
+							<p>To join the voting service, provide a public key
+							address which will be used to generate a 1-of-2 multisignature script.
+							The multisignature script will be generated by the service and returned to you
+							along with a P2SH address to give voting rights to. The P2SH address has the
+							prefix
+							<b>{{ if eq .Network "mainnet"}}D{{end}}{{ if eq .Network "testnet"}}T{{end}}c</b>.</p>
 
-					<div class="modal fade" id="connectManually" tabindex="-1" role="dialog" aria-labelledby="connectManuallyTitle" aria-hidden="true">
-						<div class="container container--narrow modal-dialog px-0" role="document">
-							<div class="modal-content px-md-3 py-md-4">
-								<div class="modal-header d-md-flex d-none">
-									<h1 class="modal-title d-flex justify-content-between align-items-center" id="connectManuallyTitle"><img src="assets/images/info-icon-lg.svg" alt=""> <span class="px-3">Connect Manually</span></h1>
-									<button type="button" class="modal-close" data-dismiss="modal" aria-label="Close">
-										<span aria-hidden="true"><img src="assets/images/close-cross-icon.svg" alt=""></span>
-									</button>
-								</div>
-								<div class="modal-header d-md-none d-block mb-3 p-4">
-									<div class="d-flex justify-content-between align-items-center">
-										<button type="button" class="modal-close" data-dismiss="modal" aria-label="Close">
-											<span aria-hidden="true"><img src="assets/images/arrow-back--blue.svg" alt=""></span>
-										</button>
-										<h1 class="modal-title" id="connectManuallyTitle"><img src="assets/images/info-icon-sm.svg" alt=""> <span class="pl-1">Connect Manually</span></h1>
-									</div>
-								</div>
-								<div class="modal-body mx-3 px-sm-5 px-0">
-									<p>To join the voting service, provide a public key
-									address which will be used to generate a 1-of-2 multisignature script.
-									The multisignature script will be generated by the service and returned to you
-									along with a P2SH address to give voting rights to. The P2SH address has the
-									prefix
-									<b>{{ if eq .Network "mainnet"}}D{{end}}{{ if eq .Network "testnet"}}T{{end}}c</b>.</p>
+							<p>To generate a public key address, create
+							a new wallet address with <b>getnewaddress</b>. Then,
+							call <b>validateaddress &lt;yourAddress&gt;</b> and retrieve the address
+							listed in the <b>pubkeyaddr</b> field of the response. The <b>pubkeyaddr</b>
+							starts with
+							<b>{{ if eq .Network "mainnet"}}D{{end}}{{ if eq .Network "testnet"}}T{{end}}k</b>.</p>
 
-									<p>To generate a public key address, create
-									a new wallet address with <b>getnewaddress</b>. Then,
-									call <b>validateaddress &lt;yourAddress&gt;</b> and retrieve the address
-									listed in the <b>pubkeyaddr</b> field of the response. The <b>pubkeyaddr</b>
-									starts with
-									<b>{{ if eq .Network "mainnet"}}D{{end}}{{ if eq .Network "testnet"}}T{{end}}k</b>.</p>
-
-									<p>The following is an example:</p>
+							<p>The following is an example:</p>
 
 <div class="modal-code"><pre>$ dcrctl {{ if eq .Network "testnet"}}--testnet{{end}} --wallet getnewaddress
 {{ if eq .Network "mainnet"}}D{{end}}{{ if eq .Network "testnet"}}T{{end}}sExampleAddr1For2Demo3PurposesOnly
@@ -151,41 +265,41 @@ $ dcrctl {{ if eq .Network "testnet"}}--testnet{{end}} --wallet validateaddress 
   "iscompressed": true,
   "account": "default"
 }</pre></div>
-								</div>
-							</div>
 						</div>
 					</div>
-
-						<div class="col-12 block__description">
-							<p>To connect manually using the command-line tools, copy and paste <strong>pubkeyaddr</strong> that start’s with  <b>{{ if eq .Network "mainnet"}}D{{end}}{{ if eq .Network "testnet"}}T{{end}}k</b> into the form below.</p>
-						</div>
-
-						{{range .Flash}}
-							<div class="snackbar snackbar-key-failed">
-								<div class="snackbar-message">
-									<div class="snackbar-close-button-top d-none"></div>
-									<p>{{.}}</p>
-								</div>
-							</div>
-						{{end}}
-
-						<form class="w-100 form" method="post">
-							<div class="col-12 mb-4">
-								<div class="form-group row mb-0 align-items-center">
-								<label for="inputAddress" class="col-md-3">Public Key Address:</label>
-								<div class="col-md-9">
-									<input type="text" class="form-control" name="UserPubKeyAddr" id="inputAddress" placeholder="Enter address">
-								</div>
-							</div>
-							</div>
-							{{ $.csrfField }}
-							<input type="submit" class="btn mb-2" value="Submit Address">
-						</form>
-  				</section>
-					{{end}}
-
+				</div>
 			</div>
+
+			<div class="col-12 block__description">
+				<p>To connect manually using the command-line tools, copy and paste <strong>pubkeyaddr</strong> that start’s with <b>{{ if eq .Network "mainnet"}}D{{end}}{{ if eq .Network "testnet"}}T{{end}}k</b> into the form below.</p>
+			</div>
+
+			{{range .Flash}}
+				<div class="snackbar snackbar-key-failed">
+					<div class="snackbar-message">
+						<div class="snackbar-close-button-top d-none"></div>
+						<p>{{.}}</p>
+					</div>
+				</div>
+			{{end}}
+
+			<form class="w-100 form" method="post">
+				<div class="col-12 mb-4">
+					<div class="form-group row mb-0 align-items-center">
+					<label for="inputAddress" class="col-md-3">Public Key Address:</label>
+					<div class="col-md-9">
+						<input type="text" class="form-control" name="UserPubKeyAddr" id="inputAddress" placeholder="Enter address">
+					</div>
+				</div>
+				</div>
+				{{ $.csrfField }}
+				<input type="submit" class="btn mb-2" value="Submit Address">
+			</form>
+		</section>
+		{{end}}
+
 		</div>
+	</div>
 
 </section>
 {{end}}

--- a/views/tickets.html
+++ b/views/tickets.html
@@ -24,7 +24,7 @@
 
 		<section class="block">
 				<div class="col-12 block__title">
-					<h1><span>Ticket Groups</span></h1>
+					<h1><span>Your Tickets</span></h1>
 				</div>
 
 				<div class="col-12 mb-4 px-0">
@@ -191,107 +191,7 @@
 
 				</div>
 			</section>
-
-			<section class="block">
-					<div class="col-12 block__title">
-						<h1 class="d-flex justify-content-between align-items-center"><span>Ticket Information</span> <img class="icon--info" src="assets/images/info-icon.svg" data-toggle="modal" data-target="#connectTicketInfo" alt=""></h1>
-					</div>
-
-				<div class="modal fade" id="connectTicketInfo" tabindex="-1" role="dialog" aria-labelledby="connectTicketInfoTitle" aria-hidden="true">
-					<div class="container container--narrow modal-dialog px-0" role="document">
-						<div class="modal-content px-md-3 py-md-4">
-							<div class="modal-header d-md-flex d-none">
-								<h1 class="modal-title d-flex justify-content-between align-items-center" id="connectSubAddressTitle"><img src="assets/images/info-icon-lg.svg" alt=""><span class="px-3">Buying Tickets with dcrwallet using command-line tools</span></h1>
-								<button type="button" class="modal-close" data-dismiss="modal" aria-label="Close">
-									<span aria-hidden="true"><img src="assets/images/close-cross-icon.svg" alt=""></span>
-								</button>
-							</div>
-							<div class="modal-header modal-header--long-title d-md-none d-block mb-3 p-4">
-								<div class="d-flex justify-content-between align-items-start">
-									<button type="button" class="modal-close" data-dismiss="modal" aria-label="Close">
-										<span aria-hidden="true"><img src="assets/images/arrow-back--blue.svg" alt=""></span>
-									</button>
-									<h1 class="modal-title" id="connectSubAddressTitle"><img src="assets/images/info-icon-sm.svg" alt=""><span class="pl-1">Buying Tickets with dcrwallet using command-line tools</span></h1>
-								</div>
-							</div>
-							<div class="modal-body mx-3 px-sm-5 px-0">
-								<blockquote class="modal-blockquote"><span>Note!</span> <br>
-								For ease of use, it’s recommended to participate in staking by using the <a href="https://decred.org/downloads" rel="noopener noreferrer">Decrediton Wallet &darr;</a><br>
-								For command-line users, in-depth dcrwallet instructions can be founds at <a href="https://docs.decred.org/getting-started/user-guides/dcrwallet-tickets/" rel="noopener noreferrer">docs.decred.org.</a><br>
-								Below is a brief introduction for staking the command line environment.</blockquote>
-
-								<p>Your multisignature script for delegating votes has been generated. Please first import it locally into your wallet using dcrctl for safe keeping, so you can recover your funds and vote in the unlikely event of a VSP failure:</p>
-
-								<p>dcrctl{{ if eq .Network "testnet"}} --testnet{{end}} --wallet importscript “script”
-
-								<p>For example:</p>
-
-								<div class="modal-code">
-									<p>
-										$ dcrctl{{ if eq .Network "testnet"}} --testnet{{end}} --wallet importscript {{ .User.MultiSigScript }}
-									</p>
-								</div>
-
-								<p>After successfully importing the script into your wallet, you may purchase tickets with voting rights delegated to the VSP in either of two ways:</p>
-
-								<strong>Option A - dcrwallet - Automatic purchasing</strong>
-
-								<p>Stop dcrwallet if it is currently running and add the following to dcrwallet.conf:</p>
-
-								<div class="modal-code">
-									<p>
-										[Application Options] <br>
-										enableticketbuyer=true <br>
-										pooladdress={{ .User.UserFeeAddr }} <br>
-										poolfees={{ .PoolFees }} <br>
-										;; DEPRECATED -- use ticketbuyer.votingaddress instead <br>
-										;; ticketaddress={{ .User.MultiSigAddress }} <br>
-										[Ticket Buyer Options] <br>
-										ticketbuyer.votingaddress={{ .User.MultiSigAddress }} <br>
-										ticketbuyer.maxpriceabsolute=100
-									</p>
-								</div>
-								
-								<p>Unlock dcrwallet and it will automatically purchase stake tickets delegated to the voting service address.</p>
-
-								<strong>Option B - dcrwallet - Manual purchasing</strong>
-
-								<p>Start a wallet with funds available and manually purchase tickets with the following command using dcrctl:</p>
-
-								<p>dcrctl{{ if eq .Network "testnet"}} --testnet{{end}} --wallet purchaseticket "fromaccount" spendlimit minconf ticketaddress numtickets poolfeeaddress poolfeeamt</p>
-
-								<div class="modal-code">
-									<p>
-										dcrctl{{ if eq .Network "testnet"}} --testnet{{end}} --wallet purchaseticket "default" 100 1 {{ .User.MultiSigAddress }} 1 {{ .User.UserFeeAddr }} {{ .PoolFees}}
-									</p>
-								</div>
-
-								<p>Will purchase a ticket delegated to the the multisig address which allows either your or the VSP to vote when the ticket is called. This uses funds from the default account only if the current network price for a ticket is less than 100.0 coins.</p>
-
-								<strong>Voting</strong>
-
-								<p>If you wish to cast votes yourself, please review the guides
-								<a href="https://docs.decred.org/getting-started/user-guides/agenda-voting/#how-to-vote" rel="noopener noreferrer">How To Vote</a>
-								and
-								<a href="https://docs.decred.org/getting-started/user-guides/agenda-voting/#solo-voting" rel="noopener noreferrer">Solo-Voting</a>.
-								The preferences you set on this voting service's <a href="/voting">voting page</a>
-								only affect the stake voting service's voting wallets and not your own.</p>
-							</div>
-						</div>
-					</div>
-				</div>
-
-					<div class="col-12 mb-4 block__key">
-						<h2>P2SH Address</h2>
-						<p>{{ .User.MultiSigAddress }}</p>
-					</div>
-
-					<div class="col-12 mb-5 block__key">
-						<h2>Redeem Script</h2>
-						<p>{{ .User.MultiSigScript }}</p>
-					</div>
-
-				</section>
+			
 			</div>
 		</div>
 </section>


### PR DESCRIPTION
- Moved "i" icon which explains the submitted public key address. It is now found next to the pubkey, rather than next to the page header.
- Always show Decrediton API key (Closes #416)
- Moved "Ticket Information" section from the Tickets page into the Connect to Wallet page (Closes #415)
- Remove duplicate code which validates addresses submitted through the Connect to Wallet page

I suggest reviewing with "Ignore whitespace changes"