### PR TITLE
middleware: bad check

### DIFF
--- a/system/middleware.go
+++ b/system/middleware.go
@@ -90,7 +90,7 @@ func (application *Application) ApplyCaptcha(c *web.C, h http.Handler) http.Hand
 func (application *Application) ApplyAuth(c *web.C, h http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		session := c.Env["Session"].(*sessions.Session)
-		if userId, ok := session.Values["UserId"]; ok {
+		if userId := session.Values["UserId"]; userId != nil {
 			dbMap := c.Env["DbMap"].(*gorp.DbMap)
 
 			user, err := dbMap.Get(models.User{}, userId)


### PR DESCRIPTION
Setting interface value to nil does not remove it as a map item.

This check is nearly always true as we often set session.Values["UserId"] = nil in the code, but this does not remove the interface from the map.  you can see this behaviour demonstrated here https://play.golang.org/p/WfodUJh2U6u

I believe the intent of this function was not to fire if there is no user id.  Right now it is searching for nothing anyway when there is no user id.