### PR TITLE
Remove duplicated js-only code

### DIFF
--- a/public/js/global.js
+++ b/public/js/global.js
@@ -114,6 +114,14 @@ $('.form-check-input').change(function () {
 });
 
 $(document).ready(function () {
+  // Display elements with class js-only
+  var els = document.getElementsByClassName("js-only")
+  for (var i = 0; i < els.length; i++) {
+    els[i].classList.remove('d-none')
+  }
+});
+
+$(document).ready(function () {
   // display close buttons on snackbar notifications
   $('.snackbar-close-button-top').removeClass('d-none');
   // add click listener to close buttons

--- a/views/admin/tickets.html
+++ b/views/admin/tickets.html
@@ -30,7 +30,7 @@
 					<span>Ignored Low Fee Tickets</span>
 						{{if gt (len .IgnoredLowFeeTickets) 1 }}
 						<div class="text--size-13">
-							<a id="select_all_ignored" class="js-only" style="display:none;" href="#">Select all</a>
+							<a id="select_all_ignored" class="js-only d-none" href="#">Select all</a>
 						</div>
 						{{end}}
 				</h1>	
@@ -77,7 +77,7 @@
 					<span>Added Low Fee Tickets</span>
 					{{if gt (len .AddedLowFeeTickets) 1 }}
 					<div class="text--size-13">
-						<a id="select_all_added" class="js-only" style="display:none;" href="#">Select all</a>
+						<a id="select_all_added" class="js-only d-none" href="#">Select all</a>
 					</div>
 					{{end}}
 				</h1>
@@ -121,12 +121,6 @@
 
 		<script type="text/javascript">
 			(function() {
-				// Display elements with class js-only
-				var elements = document.getElementsByClassName("js-only");
-				for (var i = 0; i < elements.length; i++) {
-					elements[i].style.display = "block";
-				}
-
 				// Change checkbox state if user clicks anywhere on the row.
 				// Not just the actual checkbox
 				var rows = document.getElementsByTagName("tr")

--- a/views/stats.html
+++ b/views/stats.html
@@ -75,7 +75,7 @@
 					</div>
 				</div>
 
-				<div class="row js-only" style="display:none;">
+				<div class="row js-only d-none">
 					<div class="col-md-6 col-12 mb-3">
 						<div class="row">
 							<div class="col-12 px-5 mb-3">
@@ -144,18 +144,6 @@
 						transform: translateX(-50%);
 					}
 				</style>
-
-				<script type="text/javascript">
-					(function() {
-						
-						// Display elements with class js-only
-						var elements = document.getElementsByClassName("js-only");
-						for (var i = 0; i < elements.length; i++) {
-							elements[i].style.display = "flex";
-						}
-
-					})();
-				</script>
 				
 				<noscript>
 					<div class="row col-12 block__description">


### PR DESCRIPTION
This PR standardises the approach of hiding page elements when Javascript is not available, removing some duplicated code.

I started this work with the intention of implementing #354, however the code provided in the design spec is not suitable for production use. It has simply been written as a demonstration of the intended functionality, therefore this would need to be implemented from scratch and a lot of the existing code would need to be reworked to accommodate it.

As #354 is only a minor cosmetic change, it seems like more effort and added complexity than it is worth, therefore I am going to say this PR Closes #354.