### PR TITLE
rpc: increment api version

### DIFF
--- a/backend/stakepoold/rpc/rpcserver/server.go
+++ b/backend/stakepoold/rpc/rpcserver/server.go
@@ -33,8 +33,8 @@ const (
 	// collection cycle to also trigger a timeout but the current allocation
 	// pattern of stakepoold is not known to cause such conditions at this time.
 	GRPCCommandTimeout = time.Millisecond * 100
-	semverString       = "4.0.0"
-	semverMajor        = 4
+	semverString       = "5.0.0"
+	semverMajor        = 5
 	semverMinor        = 0
 	semverPatch        = 0
 )

--- a/stakepooldclient/stakepooldclient.go
+++ b/stakepooldclient/stakepooldclient.go
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-var requiredStakepooldAPI = semver{major: 4, minor: 0, patch: 0}
+var requiredStakepooldAPI = semver{major: 5, minor: 0, patch: 0}
 
 type StakepooldManager struct {
 	grpcConnections []*grpc.ClientConn


### PR DESCRIPTION
This is an overdue change. The API version should have been incremented when new calls were added for #227 