### PR TITLE
Implement client side input validation for captcha

### DIFF
--- a/views/captcha.html
+++ b/views/captcha.html
@@ -24,7 +24,7 @@
             <div class="form-group row mb-0 align-items-center">
                 <label class="pr-4" for="captchaSolution">Text&nbsp;in&nbsp;picture:</label>
                 <div>
-                    <input name=captchaSolution required class="form-control">
+                    <input name=captchaSolution required type="text" maxlength="6" pattern="\d{6}" class="form-control">
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Implements client side input validation for captcha.

I earlier thought we make `type="number"` but discovered that it does not allow for length validation.