### PR TITLE
dcrstakepool: correct dcrwallet/stakepoold count check, allow empty smtphost configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 config.toml
 dcrstakepool
-.vendor/
+vendor/
 .vscode/
+.idea/
 controllers/config.go*
 testing/
 *.orig

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ vote on their behalf when the ticket is selected.
 
 ![Voting Service Architecture](https://i.imgur.com/2JDA9dl.png)
 
-- It is highly recommended to use 3 dcrd+dcrwallet+stakepoold nodes for
+- It is highly recommended to use at least 2 dcrd+dcrwallet+stakepoold nodes for
   production use on mainnet.
+  Can use 1 dcrd+dcrwallet+stakepoold node (backend server) on testnet.
 - The architecture is subject to change in the future to lessen the dependence
   on dcrwallet and MySQL.
 

--- a/config.go
+++ b/config.go
@@ -42,7 +42,6 @@ const (
 	defaultPublicPath      = "public"
 	defaultTemplatePath    = "views"
 	defaultSMTPHost        = ""
-	defaultMinServers      = 2
 	defaultMaxVotedTickets = 1000
 	defaultDescription     = ""
 	defaultDesignation     = ""
@@ -329,7 +328,6 @@ func loadConfig() (*config, []string, error) {
 		PublicPath:      defaultPublicPath,
 		TemplatePath:    defaultTemplatePath,
 		SMTPHost:        defaultSMTPHost,
-		MinServers:      defaultMinServers,
 		MaxVotedTickets: defaultMaxVotedTickets,
 		Description:     defaultDescription,
 		Designation:     defaultDesignation,
@@ -423,25 +421,22 @@ func loadConfig() (*config, []string, error) {
 	// Multiple networks can't be selected simultaneously.
 	var numNets int
 
-	// Count number of network flags passed; assign active network params
+	// Count number of network flags passed;
+	// assign active network params
+	// and min required backend servers
 	// while we're at it
+	var minRequiredBackendServers = 2
 	activeNetParams = &mainNetParams
 	if cfg.TestNet {
 		numNets++
 		activeNetParams = &testNet3Params
+		minRequiredBackendServers = 1
 	}
 	if cfg.SimNet {
 		numNets++
 		// Also disable dns seeding on the simulation test network.
 		activeNetParams = &simNetParams
-	}
-	if numNets > 1 {
-		str := "%s: The testnet and simnet params can't be " +
-			"used together -- choose one of the three"
-		err := fmt.Errorf(str, funcName)
-		fmt.Fprintln(os.Stderr, err)
-		fmt.Fprintln(os.Stderr, usageMessage)
-		return nil, nil, err
+		minRequiredBackendServers = 1
 	}
 
 	// Append the network type to the data directory so it is "namespaced"
@@ -582,9 +577,15 @@ func loadConfig() (*config, []string, error) {
 	// Add default wallet port for the active network if there's no port specified
 	cfg.WalletHosts = normalizeAddresses(cfg.WalletHosts, activeNetParams.WalletRPCServerPort)
 
-	if len(cfg.WalletHosts) < cfg.MinServers {
+	// Check if deprecated minservers config option is set
+	if cfg.MinServers != 0 {
+		str := "%s: Config minservers is deprecated.  Please remove from your config file"
+		log.Warnf(str, funcName)
+	}
+
+	if len(cfg.WalletHosts) < minRequiredBackendServers {
 		str := "%s: you must specify at least %d wallethosts"
-		err := fmt.Errorf(str, funcName, cfg.MinServers)
+		err := fmt.Errorf(str, funcName, minRequiredBackendServers)
 		fmt.Fprintln(os.Stderr, err)
 		return nil, nil, err
 	}
@@ -646,9 +647,9 @@ func loadConfig() (*config, []string, error) {
 	// no port specified
 	cfg.StakepooldHosts = normalizeAddresses(cfg.StakepooldHosts,
 		activeNetParams.StakepooldRPCServerPort)
-	if len(cfg.StakepooldHosts) < cfg.MinServers {
+	if len(cfg.StakepooldHosts) < minRequiredBackendServers {
 		str := "%s: you must specify at least %d stakepooldhosts"
-		err := fmt.Errorf(str, funcName, cfg.MinServers)
+		err := fmt.Errorf(str, funcName, minRequiredBackendServers)
 		fmt.Fprintln(os.Stderr, err)
 		return nil, nil, err
 	}

--- a/config.go
+++ b/config.go
@@ -421,10 +421,7 @@ func loadConfig() (*config, []string, error) {
 	// Multiple networks can't be selected simultaneously.
 	var numNets int
 
-	// Count number of network flags passed;
-	// assign active network params
-	// and min required backend servers
-	// while we're at it
+	// Assign active network params and min required backend servers
 	var minRequiredBackendServers = 2
 	activeNetParams = &mainNetParams
 	if cfg.TestNet {
@@ -436,6 +433,15 @@ func loadConfig() (*config, []string, error) {
 		numNets++
 		// Also disable dns seeding on the simulation test network.
 		activeNetParams = &simNetParams
+		minRequiredBackendServers = 1
+	}
+	if numNets > 1 {
+		str := "%s: The testnet and simnet params can't be " +
+			"used together -- choose one of the three"
+		err := fmt.Errorf(str, funcName)
+		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, usageMessage)
+		return nil, nil, err
 		minRequiredBackendServers = 1
 	}
 

--- a/config.go
+++ b/config.go
@@ -582,9 +582,9 @@ func loadConfig() (*config, []string, error) {
 	// Add default wallet port for the active network if there's no port specified
 	cfg.WalletHosts = normalizeAddresses(cfg.WalletHosts, activeNetParams.WalletRPCServerPort)
 
-	if len(cfg.WalletHosts) < 2 {
-		str := "%s: you must specify at least 2 wallethosts"
-		err := fmt.Errorf(str, funcName)
+	if len(cfg.WalletHosts) < cfg.MinServers {
+		str := "%s: you must specify at least %d wallethosts"
+		err := fmt.Errorf(str, funcName, cfg.MinServers)
 		fmt.Fprintln(os.Stderr, err)
 		return nil, nil, err
 	}
@@ -646,9 +646,9 @@ func loadConfig() (*config, []string, error) {
 	// no port specified
 	cfg.StakepooldHosts = normalizeAddresses(cfg.StakepooldHosts,
 		activeNetParams.StakepooldRPCServerPort)
-	if len(cfg.StakepooldHosts) < 2 {
-		str := "%s: you must specify at least 2 stakepooldhosts"
-		err := fmt.Errorf(str, funcName)
+	if len(cfg.StakepooldHosts) < cfg.MinServers {
+		str := "%s: you must specify at least %d stakepooldhosts"
+		err := fmt.Errorf(str, funcName, cfg.MinServers)
 		fmt.Fprintln(os.Stderr, err)
 		return nil, nil, err
 	}

--- a/config.go
+++ b/config.go
@@ -442,7 +442,6 @@ func loadConfig() (*config, []string, error) {
 		fmt.Fprintln(os.Stderr, err)
 		fmt.Fprintln(os.Stderr, usageMessage)
 		return nil, nil, err
-		minRequiredBackendServers = 1
 	}
 
 	// Append the network type to the data directory so it is "namespaced"

--- a/sample-dcrstakepool.conf
+++ b/sample-dcrstakepool.conf
@@ -106,11 +106,12 @@ testnet=1
 ; You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set
 ; log level for individual subsystems.  Use dcrstakepool --debuglevel=show to
 ; list available subsystems.
-; debuglevel=info
+;debuglevel=info
 
-; minservers lets you specify how many active wallet connections are required
-; for actions to occur (default 2)
-; minservers=2
+; DEPRECATED: This option has no effect.
+; Minimum of 2 servers are required when running on mainnet.
+; Testnet and simnet require at least 1 backend server.
+;minservers=2
 
 ; Various HTTP settings are in this section.
 

--- a/server.go
+++ b/server.go
@@ -89,10 +89,13 @@ func runMain() error {
 		return fmt.Errorf("Failed to connect to stakepoold host: %v", err)
 	}
 
-	sender, err := email.NewSender(cfg.SMTPHost, cfg.SMTPUsername, cfg.SMTPPassword, cfg.SMTPFrom, cfg.UseSMTPS)
-	if err != nil {
-		application.Close()
-		return fmt.Errorf("Failed to initialize the smtp server: %v", err)
+	var sender email.Sender
+	if cfg.SMTPHost != "" {
+		sender, err = email.NewSender(cfg.SMTPHost, cfg.SMTPUsername, cfg.SMTPPassword, cfg.SMTPFrom, cfg.UseSMTPS)
+		if err != nil {
+			application.Close()
+			return fmt.Errorf("Failed to initialize the smtp server: %v", err)
+		}
 	}
 
 	controller, err := controllers.NewMainController(activeNetParams.Params,


### PR DESCRIPTION
- Use `config.MinServers` parameter to check the number of required dcrwallet and dcrstakepoold instances.
- Readme says `SMTPHost now defaults to an empty string so a voting service can be used for development or testing purposes without a configured mail server.`
This doesn't work currently, producing the error message instead: `Failed to initialize the smtp server: invalid smtpfrom address ""`. Support for empty `smpthost` config value is implemented in this PR.