### PR TITLE
Do not attempt to display Invalid ticket height

### DIFF
--- a/views/tickets.html
+++ b/views/tickets.html
@@ -177,7 +177,6 @@
 									<img src="/assets/images/symbol-5-1-1.svg" alt="">
 									<span><pre class="m-0 d-inline">{{printf "%.16s" $data.Ticket}}...</pre></span>
 									<a style="margin-left:50px; margin-right:50px" href="https://{{$.Network}}.dcrdata.org/tx/{{$data.Ticket}}" rel="noopener noreferrer">Block Explorer</a>
-									<span>Purchase height:&nbsp;{{$data.TicketHeight}}</span>
 								</div>
 								{{else}}
 									<div class="accordion__empty">


### PR DESCRIPTION
Purchase height is not available for invalid tickets, so should not attempt to display it

Closes #460 