### PR TITLE
maxusers: Update TODOs

### DIFF
--- a/backend/stakepoold/server.go
+++ b/backend/stakepoold/server.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	// TODO: sync with controllers/main.go MaxUsers
+	// TODO: Remove this.
 	numServicePaymentFeeAddresses uint32 = 10000
 )
 

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -44,6 +44,7 @@ const (
 	// MaxUsers is the maximum number of users supported by a voting service.
 	// This is an artificial limit and can be increased by adjusting the
 	// ticket/fee address indexes above 10000.
+	// TODO Remove this limitation by deriving fee addresses from an imported xpub.
 	MaxUsers = 10000
 	// agendasCacheLife is the amount of time to keep agenda data in memory.
 	agendasCacheLife = time.Hour

--- a/sample-dcrwallet.conf
+++ b/sample-dcrwallet.conf
@@ -1,6 +1,8 @@
 ; Derive 10000 addresses from the specified extended public key for use
 ; as user's payment addresses to the cold wallet/fee collecting wallet.
 ; xpub portion needs to match coldwalletextpub from dcrstakepool configuration.
+; The amount of addresses MUST be set to 10000. This limitation will be removed
+; in a future release.
 ;stakepoolcoldextkey=xpub:10000
 
 ; Fees as a percentage. 7.5 = 7.5%.  Precision of 2, 7.99 = 7.99%.


### PR DESCRIPTION
~-make max users a configurable variable~
~-default 10000~
~-stakepoold start with default 10000~
~-when starting dcrstakepool grpc commands are used to set the max on all servers and re-derive pool fees if there was a change~

~ahh, meant to do the draft thing, adding WIP to title~

This pr took a different direction mid-stream.  I now think that maxusers is an artificial ceiling and it should be removed. If my understanding is incorrect, please comment.