### PR TITLE
controllers/main.go: tickets rpc error page

### DIFF
--- a/controllers/main.go
+++ b/controllers/main.go
@@ -1855,9 +1855,7 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 	if err != nil {
 		// Render page with message to try again later
 		log.Infof("RPC StakePoolUserInfo failed: %v", err)
-		session.AddFlash("Unable to retrieve voting service user info", "main")
-		c.Env["Flash"] = session.Flashes("main")
-		return controller.Parse(t, "main", c.Env), http.StatusInternalServerError
+		return "/error", http.StatusSeeOther
 	}
 
 	log.Debugf(":: StakePoolUserInfo (msa = %v) execution time: %v",

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -1854,7 +1854,7 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 	spui, err := controller.StakepooldServers.StakePoolUserInfo(multisig.String())
 	if err != nil {
 		// Render page with message to try again later
-		log.Infof("RPC StakePoolUserInfo failed: %v", err)
+		log.Errorf("RPC StakePoolUserInfo failed: %v", err)
 		return "/error", http.StatusSeeOther
 	}
 


### PR DESCRIPTION
If all of the stakepoold servers are down, the comment on the error suggests that the user will see a message about trying again, but as it was written, all they see is `internal server error`. This redirects to the default error page which does have a message saying to try again.