### PR TITLE
rpcserver: Add walletConnected method

### DIFF
--- a/backend/stakepoold/rpc/rpcserver/server.go
+++ b/backend/stakepoold/rpc/rpcserver/server.go
@@ -13,6 +13,7 @@
 package rpcserver
 
 import (
+	"errors"
 	"time"
 
 	"golang.org/x/net/context"
@@ -37,6 +38,12 @@ const (
 	semverMajor        = 7
 	semverMinor        = 0
 	semverPatch        = 0
+)
+
+var (
+	// ErrWalletNotConnected is an error to describe the condition where
+	// dcrwallet is not connected through dcrcleint.
+	ErrWalletNotConnected = errors.New("wallet is disconnected")
 )
 
 // versionServer provides RPC clients with the ability to query the RPC server
@@ -73,6 +80,21 @@ func StartStakepooldService(appContext *AppContext, server *grpc.Server) {
 	})
 }
 
+// walletConnected logs an error and returns false if the connection to
+// dcrwallet is broken.
+//
+// It should be noted that this is a temporary fix. Ideally rpcclient would
+// return an error when it is trying to reconnect to dcrwallet. The permanent
+// answer is to change that behavior.
+// TODO Remove this.
+func (s *stakepooldServer) walletConnected() bool {
+	if s.appContext.WalletConnection.Disconnected() {
+		log.Error(ErrWalletNotConnected)
+		return false
+	}
+	return true
+}
+
 func processTickets(ticketsMSA map[chainhash.Hash]string) []*pb.Ticket {
 	tickets := make([]*pb.Ticket, 0)
 	for tickethash, msa := range ticketsMSA {
@@ -85,6 +107,10 @@ func processTickets(ticketsMSA map[chainhash.Hash]string) []*pb.Ticket {
 }
 
 func (s *stakepooldServer) GetAddedLowFeeTickets(c context.Context, req *pb.GetAddedLowFeeTicketsRequest) (*pb.GetAddedLowFeeTicketsResponse, error) {
+	if !s.walletConnected() {
+		return nil, ErrWalletNotConnected
+	}
+
 	s.appContext.RLock()
 	ticketsMSA := s.appContext.AddedLowFeeTicketsMSA
 	s.appContext.RUnlock()
@@ -94,6 +120,10 @@ func (s *stakepooldServer) GetAddedLowFeeTickets(c context.Context, req *pb.GetA
 }
 
 func (s *stakepooldServer) GetIgnoredLowFeeTickets(c context.Context, req *pb.GetIgnoredLowFeeTicketsRequest) (*pb.GetIgnoredLowFeeTicketsResponse, error) {
+	if !s.walletConnected() {
+		return nil, ErrWalletNotConnected
+	}
+
 	s.appContext.RLock()
 	ticketsMSA := s.appContext.IgnoredLowFeeTicketsMSA
 	s.appContext.RUnlock()
@@ -103,6 +133,10 @@ func (s *stakepooldServer) GetIgnoredLowFeeTickets(c context.Context, req *pb.Ge
 }
 
 func (s *stakepooldServer) GetLiveTickets(c context.Context, req *pb.GetLiveTicketsRequest) (*pb.GetLiveTicketsResponse, error) {
+	if !s.walletConnected() {
+		return nil, ErrWalletNotConnected
+	}
+
 	s.appContext.RLock()
 	ticketsMSA := s.appContext.LiveTicketsMSA
 	s.appContext.RUnlock()
@@ -112,6 +146,10 @@ func (s *stakepooldServer) GetLiveTickets(c context.Context, req *pb.GetLiveTick
 }
 
 func (s *stakepooldServer) SetAddedLowFeeTickets(ctx context.Context, req *pb.SetAddedLowFeeTicketsRequest) (*pb.SetAddedLowFeeTicketsResponse, error) {
+	if !s.walletConnected() {
+		return nil, ErrWalletNotConnected
+	}
+
 	addedLowFeeTickets := make(map[chainhash.Hash]string)
 
 	for _, ticket := range req.Tickets {
@@ -128,6 +166,10 @@ func (s *stakepooldServer) SetAddedLowFeeTickets(ctx context.Context, req *pb.Se
 }
 
 func (s *stakepooldServer) SetUserVotingPrefs(ctx context.Context, req *pb.SetUserVotingPrefsRequest) (*pb.SetUserVotingPrefsResponse, error) {
+	if !s.walletConnected() {
+		return nil, ErrWalletNotConnected
+	}
+
 	userVotingPrefs := make(map[string]userdata.UserVotingConfig)
 	for _, data := range req.UserVotingConfig {
 		userVotingPrefs[data.MultiSigAddress] = userdata.UserVotingConfig{
@@ -143,6 +185,10 @@ func (s *stakepooldServer) SetUserVotingPrefs(ctx context.Context, req *pb.SetUs
 }
 
 func (s *stakepooldServer) ImportScript(ctx context.Context, req *pb.ImportScriptRequest) (*pb.ImportScriptResponse, error) {
+	if !s.walletConnected() {
+		return nil, ErrWalletNotConnected
+	}
+
 	heightImported, err := s.appContext.ImportScript(req.Script, req.Rescan, req.RescanHeight)
 	if err != nil {
 		return nil, err
@@ -153,6 +199,10 @@ func (s *stakepooldServer) ImportScript(ctx context.Context, req *pb.ImportScrip
 }
 
 func (s *stakepooldServer) ListScripts(ctx context.Context, req *pb.ListScriptsRequest) (*pb.ListScriptsResponse, error) {
+	if !s.walletConnected() {
+		return nil, ErrWalletNotConnected
+	}
+
 	scripts, err := s.appContext.ListScripts()
 	if err != nil {
 		return nil, err
@@ -162,6 +212,10 @@ func (s *stakepooldServer) ListScripts(ctx context.Context, req *pb.ListScriptsR
 }
 
 func (s *stakepooldServer) AccountSyncAddressIndex(ctx context.Context, req *pb.AccountSyncAddressIndexRequest) (*pb.AccountSyncAddressIndexResponse, error) {
+	if !s.walletConnected() {
+		return nil, ErrWalletNotConnected
+	}
+
 	err := s.appContext.AccountSyncAddressIndex(req.Account, req.Branch, int(req.Index))
 	if err != nil {
 		return nil, err
@@ -171,6 +225,10 @@ func (s *stakepooldServer) AccountSyncAddressIndex(ctx context.Context, req *pb.
 }
 
 func (s *stakepooldServer) GetTickets(ctx context.Context, req *pb.GetTicketsRequest) (*pb.GetTicketsResponse, error) {
+	if !s.walletConnected() {
+		return nil, ErrWalletNotConnected
+	}
+
 	tickets, err := s.appContext.GetTickets(req.IncludeImmature)
 	if err != nil {
 		return nil, err
@@ -187,6 +245,10 @@ func (s *stakepooldServer) GetTickets(ctx context.Context, req *pb.GetTicketsReq
 }
 
 func (s *stakepooldServer) AddMissingTicket(ctx context.Context, req *pb.AddMissingTicketRequest) (*pb.AddMissingTicketResponse, error) {
+	if !s.walletConnected() {
+		return nil, ErrWalletNotConnected
+	}
+
 	err := s.appContext.AddMissingTicket(req.Hash)
 	if err != nil {
 		return nil, err
@@ -195,6 +257,10 @@ func (s *stakepooldServer) AddMissingTicket(ctx context.Context, req *pb.AddMiss
 }
 
 func (s *stakepooldServer) StakePoolUserInfo(ctx context.Context, req *pb.StakePoolUserInfoRequest) (*pb.StakePoolUserInfoResponse, error) {
+	if !s.walletConnected() {
+		return nil, ErrWalletNotConnected
+	}
+
 	response, err := s.appContext.StakePoolUserInfo(req.MultiSigAddress)
 	if err != nil {
 		return nil, err
@@ -218,6 +284,10 @@ func (s *stakepooldServer) StakePoolUserInfo(ctx context.Context, req *pb.StakeP
 }
 
 func (s *stakepooldServer) WalletInfo(ctx context.Context, req *pb.WalletInfoRequest) (*pb.WalletInfoResponse, error) {
+	if !s.walletConnected() {
+		return nil, ErrWalletNotConnected
+	}
+
 	response, err := s.appContext.WalletInfo()
 	if err != nil {
 		return nil, err
@@ -232,6 +302,10 @@ func (s *stakepooldServer) WalletInfo(ctx context.Context, req *pb.WalletInfoReq
 }
 
 func (s *stakepooldServer) ValidateAddress(ctx context.Context, req *pb.ValidateAddressRequest) (*pb.ValidateAddressResponse, error) {
+	if !s.walletConnected() {
+		return nil, ErrWalletNotConnected
+	}
+
 	response, err := s.appContext.ValidateAddress(req.Address)
 	if err != nil {
 		return nil, err
@@ -244,6 +318,10 @@ func (s *stakepooldServer) ValidateAddress(ctx context.Context, req *pb.Validate
 }
 
 func (s *stakepooldServer) CreateMultisig(ctx context.Context, req *pb.CreateMultisigRequest) (*pb.CreateMultisigResponse, error) {
+	if !s.walletConnected() {
+		return nil, ErrWalletNotConnected
+	}
+
 	response, err := s.appContext.CreateMultisig(req.Address)
 	if err != nil {
 		return nil, err
@@ -256,6 +334,10 @@ func (s *stakepooldServer) CreateMultisig(ctx context.Context, req *pb.CreateMul
 }
 
 func (s *stakepooldServer) GetStakeInfo(ctx context.Context, req *pb.GetStakeInfoRequest) (*pb.GetStakeInfoResponse, error) {
+	if !s.walletConnected() {
+		return nil, ErrWalletNotConnected
+	}
+
 	response, err := s.appContext.GetStakeInfo()
 	if err != nil {
 		return nil, err

--- a/backend/stakepoold/rpc/rpcserver/server.go
+++ b/backend/stakepoold/rpc/rpcserver/server.go
@@ -42,7 +42,7 @@ const (
 
 var (
 	// ErrWalletNotConnected is an error to describe the condition where
-	// dcrwallet is not connected through dcrcleint.
+	// dcrwallet is not connected through rpccleint.
 	ErrWalletNotConnected = errors.New("wallet is disconnected")
 )
 


### PR DESCRIPTION
Check whether the wallet is connected before sending rpc commands.
part of #475 

Perhaps this is the easiest solution. It's solving the original problem that I described in that issue. Simply check that the wallet is connected before continuing to send rpc commands.  Another solution I suggested was to write our own reconnect function, but maybe that's not necessary to solve this problem.