### PR TITLE
Autoreconnect

### DIFF
--- a/backend/stakepoold/ntfnhandlers.go
+++ b/backend/stakepoold/ntfnhandlers.go
@@ -30,6 +30,8 @@ func getNodeNtfnHandlers(ctx *rpcserver.AppContext) *rpcclient.NotificationHandl
 				BlockHeight: blockHeight,
 				SmTickets:   ticketsFixed,
 			}
+			// Wait for a wallet connection if not connected.
+			<-ctx.WalletConnection.Connected()
 			ctx.SpentmissedTicketsChan <- smt
 		},
 		OnWinningTickets: func(blockHash *chainhash.Hash, blockHeight int64, winningTickets []*chainhash.Hash) {

--- a/backend/stakepoold/rpc/rpcserver/client.go
+++ b/backend/stakepoold/rpc/rpcserver/client.go
@@ -1,0 +1,167 @@
+package rpcserver
+
+import (
+	"sync"
+	"time"
+
+	"github.com/decred/dcrd/rpcclient/v3"
+)
+
+const (
+	// connectionRetryInterval is the amount of time to wait in between
+	// retries when automatically reconnecting to an RPC server.
+	connectionRetryInterval = time.Second * 5
+	// disconnectCheckInterval is the amount of time to wait between
+	// checks for a disconnection.
+	disconnectCheckInterval = time.Second * 10
+)
+
+// Client holds the information related to an rpcclient and handles access to
+// that client through a mutex.
+//
+// It should be noted that this is a temporary fix to the problem that rpcclient
+// does not return an error when autoreconnect is turned on but the client is
+// disconnected. The permanent solution is to change the behaviour of rpccleint.
+// TODO: Remove this file.
+type Client struct {
+	// client is protected by a mutex that must be held for reads/writes.
+	client *rpcclient.Client
+	mux    sync.RWMutex
+
+	cfg          *rpcclient.ConnConfig
+	ntfnHandlers *rpcclient.NotificationHandlers
+	wg           sync.WaitGroup
+	stop         chan struct{}
+
+	connected    chan struct{}
+	connectedMux sync.Mutex
+}
+
+// Connected returns a receiving copy of the current connected channel. If
+// disconnected and the channel is not yet blocking, creates a new channel that
+// will be closed on a successful reconnect.
+func (c *Client) Connected() <-chan struct{} {
+	c.connectedMux.Lock()
+	defer c.connectedMux.Unlock()
+	if c.RPCClient().Disconnected() {
+		// Start blocking on connected chan if not already.
+		select {
+		case <-c.connected:
+			c.connected = make(chan struct{})
+		default:
+		}
+	}
+	return c.connected
+}
+
+// IsConnected checks and returns whethere the client is currently connected.
+func (c *Client) IsConnected() bool {
+	select {
+	case <-c.Connected():
+		return true
+	default:
+		return false
+	}
+}
+
+// RPCClient allows access to the underlying rpcclient by providing a copy of
+// its address.
+func (c *Client) RPCClient() *rpcclient.Client {
+	c.mux.RLock()
+	defer c.mux.RUnlock()
+	return c.client
+}
+
+// New creates a new Client and starts the automatic reconnection handler.
+// Returns an error if unable to construct a new rpcclient.
+func NewClient(cfg *rpcclient.ConnConfig, ntfnHandlers *rpcclient.NotificationHandlers) (*Client, error) {
+	client, err := rpcclient.New(cfg, ntfnHandlers)
+	if err != nil {
+		return nil, err
+	}
+	c := &Client{
+		client:       client,
+		cfg:          cfg,
+		ntfnHandlers: ntfnHandlers,
+		stop:         make(chan struct{}),
+		connected:    make(chan struct{}),
+	}
+	// A closed connected channel indcates successfully connected.
+	close(c.connected)
+	c.wg.Add(1)
+	go c.autoReconnect()
+	return c, nil
+}
+
+// Stop stops automatic reconnections.
+func (c *Client) Stop() {
+	c.stop <- struct{}{}
+	// Wait for autoReconnect to stop.
+	c.wg.Wait()
+	// Stop blocking on connected if blocking, as we will never reconnect again.
+	if !c.IsConnected() {
+		close(c.connected)
+	}
+}
+
+// autoReconnect waits for a disconnect or stop. On disconnect it attempts to
+// reconnect to the client every connectionRetryInterval.
+//
+// This function must be run as a goroutine.
+func (c *Client) autoReconnect() {
+out:
+	for {
+		select {
+		case <-c.stop:
+			break out
+		case <-time.After(disconnectCheckInterval):
+			if c.IsConnected() {
+				continue out
+			}
+			// Client is disconnected. Try to reconnect.
+		}
+
+	reconnect:
+		for {
+			select {
+			case <-c.stop:
+				break out
+			default:
+			}
+
+			// Start a new client.
+			client, err := rpcclient.New(c.cfg, c.ntfnHandlers)
+
+			if err != nil {
+				log.Warnf("Failed to connect to %s: %v",
+					c.cfg.Host, err)
+
+				log.Infof("Retrying connection to %s in "+
+					"%s", c.cfg.Host, connectionRetryInterval)
+				time.Sleep(connectionRetryInterval)
+				continue reconnect
+			}
+
+			// Properly shutdown old client.
+			c.mux.Lock()
+			c.client.Shutdown()
+			c.client.WaitForShutdown()
+			// Switch the new client with the old, shutdown one.
+			c.client = client
+			c.mux.Unlock()
+
+			// Close the connected channel so that all waiting
+			// processes can continue.
+			close(c.connected)
+
+			log.Infof("Reestablished connection to RPC server %s",
+				c.cfg.Host)
+
+			// Break out of the reconnect loop back to wait for
+			// disconnect again.
+			break
+		}
+	}
+	c.wg.Done()
+	log.Tracef("RPC client reconnect handler done for %s", c.cfg.Host)
+}

--- a/backend/stakepoold/rpc/rpcserver/server.go
+++ b/backend/stakepoold/rpc/rpcserver/server.go
@@ -13,7 +13,6 @@
 package rpcserver
 
 import (
-	"errors"
 	"time"
 
 	"golang.org/x/net/context"
@@ -38,12 +37,6 @@ const (
 	semverMajor        = 8
 	semverMinor        = 0
 	semverPatch        = 0
-)
-
-var (
-	// ErrWalletNotConnected is an error to describe the condition where
-	// dcrwallet is not connected through rpccleint.
-	ErrWalletNotConnected = errors.New("wallet is disconnected")
 )
 
 // versionServer provides RPC clients with the ability to query the RPC server
@@ -80,21 +73,6 @@ func StartStakepooldService(appContext *AppContext, server *grpc.Server) {
 	})
 }
 
-// walletConnected logs an error and returns false if the connection to
-// dcrwallet is broken.
-//
-// It should be noted that this is a temporary fix. Ideally rpcclient would
-// return an error when it is trying to reconnect to dcrwallet. The permanent
-// answer is to change that behavior.
-// TODO Remove this.
-func (s *stakepooldServer) walletConnected() bool {
-	if s.appContext.WalletConnection.Disconnected() {
-		log.Error(ErrWalletNotConnected)
-		return false
-	}
-	return true
-}
-
 func processTickets(ticketsMSA map[chainhash.Hash]string) []*pb.Ticket {
 	tickets := make([]*pb.Ticket, 0)
 	for tickethash, msa := range ticketsMSA {
@@ -107,9 +85,6 @@ func processTickets(ticketsMSA map[chainhash.Hash]string) []*pb.Ticket {
 }
 
 func (s *stakepooldServer) GetAddedLowFeeTickets(c context.Context, req *pb.GetAddedLowFeeTicketsRequest) (*pb.GetAddedLowFeeTicketsResponse, error) {
-	if !s.walletConnected() {
-		return nil, ErrWalletNotConnected
-	}
 
 	s.appContext.RLock()
 	ticketsMSA := s.appContext.AddedLowFeeTicketsMSA
@@ -120,9 +95,6 @@ func (s *stakepooldServer) GetAddedLowFeeTickets(c context.Context, req *pb.GetA
 }
 
 func (s *stakepooldServer) GetIgnoredLowFeeTickets(c context.Context, req *pb.GetIgnoredLowFeeTicketsRequest) (*pb.GetIgnoredLowFeeTicketsResponse, error) {
-	if !s.walletConnected() {
-		return nil, ErrWalletNotConnected
-	}
 
 	s.appContext.RLock()
 	ticketsMSA := s.appContext.IgnoredLowFeeTicketsMSA
@@ -133,9 +105,6 @@ func (s *stakepooldServer) GetIgnoredLowFeeTickets(c context.Context, req *pb.Ge
 }
 
 func (s *stakepooldServer) GetLiveTickets(c context.Context, req *pb.GetLiveTicketsRequest) (*pb.GetLiveTicketsResponse, error) {
-	if !s.walletConnected() {
-		return nil, ErrWalletNotConnected
-	}
 
 	s.appContext.RLock()
 	ticketsMSA := s.appContext.LiveTicketsMSA
@@ -146,9 +115,6 @@ func (s *stakepooldServer) GetLiveTickets(c context.Context, req *pb.GetLiveTick
 }
 
 func (s *stakepooldServer) SetAddedLowFeeTickets(ctx context.Context, req *pb.SetAddedLowFeeTicketsRequest) (*pb.SetAddedLowFeeTicketsResponse, error) {
-	if !s.walletConnected() {
-		return nil, ErrWalletNotConnected
-	}
 
 	addedLowFeeTickets := make(map[chainhash.Hash]string)
 
@@ -166,9 +132,6 @@ func (s *stakepooldServer) SetAddedLowFeeTickets(ctx context.Context, req *pb.Se
 }
 
 func (s *stakepooldServer) SetUserVotingPrefs(ctx context.Context, req *pb.SetUserVotingPrefsRequest) (*pb.SetUserVotingPrefsResponse, error) {
-	if !s.walletConnected() {
-		return nil, ErrWalletNotConnected
-	}
 
 	userVotingPrefs := make(map[string]userdata.UserVotingConfig)
 	for _, data := range req.UserVotingConfig {
@@ -185,10 +148,6 @@ func (s *stakepooldServer) SetUserVotingPrefs(ctx context.Context, req *pb.SetUs
 }
 
 func (s *stakepooldServer) ImportNewScript(ctx context.Context, req *pb.ImportNewScriptRequest) (*pb.ImportNewScriptResponse, error) {
-	if !s.walletConnected() {
-		return nil, ErrWalletNotConnected
-	}
-
 	heightImported, err := s.appContext.ImportNewScript(req.Script)
 	if err != nil {
 		return nil, err
@@ -199,10 +158,6 @@ func (s *stakepooldServer) ImportNewScript(ctx context.Context, req *pb.ImportNe
 }
 
 func (s *stakepooldServer) ImportMissingScripts(ctx context.Context, req *pb.ImportMissingScriptsRequest) (*pb.ImportMissingScriptsResponse, error) {
-	if !s.walletConnected() {
-		return nil, ErrWalletNotConnected
-	}
-
 	err := s.appContext.ImportMissingScripts(req.Scripts, int(req.RescanHeight))
 	if err != nil {
 		return nil, err
@@ -211,9 +166,6 @@ func (s *stakepooldServer) ImportMissingScripts(ctx context.Context, req *pb.Imp
 }
 
 func (s *stakepooldServer) ListScripts(ctx context.Context, req *pb.ListScriptsRequest) (*pb.ListScriptsResponse, error) {
-	if !s.walletConnected() {
-		return nil, ErrWalletNotConnected
-	}
 
 	scripts, err := s.appContext.ListScripts()
 	if err != nil {
@@ -224,9 +176,6 @@ func (s *stakepooldServer) ListScripts(ctx context.Context, req *pb.ListScriptsR
 }
 
 func (s *stakepooldServer) AccountSyncAddressIndex(ctx context.Context, req *pb.AccountSyncAddressIndexRequest) (*pb.AccountSyncAddressIndexResponse, error) {
-	if !s.walletConnected() {
-		return nil, ErrWalletNotConnected
-	}
 
 	err := s.appContext.AccountSyncAddressIndex(req.Account, req.Branch, int(req.Index))
 	if err != nil {
@@ -237,9 +186,6 @@ func (s *stakepooldServer) AccountSyncAddressIndex(ctx context.Context, req *pb.
 }
 
 func (s *stakepooldServer) GetTickets(ctx context.Context, req *pb.GetTicketsRequest) (*pb.GetTicketsResponse, error) {
-	if !s.walletConnected() {
-		return nil, ErrWalletNotConnected
-	}
 
 	tickets, err := s.appContext.GetTickets(req.IncludeImmature)
 	if err != nil {
@@ -257,9 +203,6 @@ func (s *stakepooldServer) GetTickets(ctx context.Context, req *pb.GetTicketsReq
 }
 
 func (s *stakepooldServer) AddMissingTicket(ctx context.Context, req *pb.AddMissingTicketRequest) (*pb.AddMissingTicketResponse, error) {
-	if !s.walletConnected() {
-		return nil, ErrWalletNotConnected
-	}
 
 	err := s.appContext.AddMissingTicket(req.Hash)
 	if err != nil {
@@ -269,9 +212,6 @@ func (s *stakepooldServer) AddMissingTicket(ctx context.Context, req *pb.AddMiss
 }
 
 func (s *stakepooldServer) StakePoolUserInfo(ctx context.Context, req *pb.StakePoolUserInfoRequest) (*pb.StakePoolUserInfoResponse, error) {
-	if !s.walletConnected() {
-		return nil, ErrWalletNotConnected
-	}
 
 	response, err := s.appContext.StakePoolUserInfo(req.MultiSigAddress)
 	if err != nil {
@@ -296,9 +236,6 @@ func (s *stakepooldServer) StakePoolUserInfo(ctx context.Context, req *pb.StakeP
 }
 
 func (s *stakepooldServer) WalletInfo(ctx context.Context, req *pb.WalletInfoRequest) (*pb.WalletInfoResponse, error) {
-	if !s.walletConnected() {
-		return nil, ErrWalletNotConnected
-	}
 
 	response, err := s.appContext.WalletInfo()
 	if err != nil {
@@ -314,9 +251,6 @@ func (s *stakepooldServer) WalletInfo(ctx context.Context, req *pb.WalletInfoReq
 }
 
 func (s *stakepooldServer) ValidateAddress(ctx context.Context, req *pb.ValidateAddressRequest) (*pb.ValidateAddressResponse, error) {
-	if !s.walletConnected() {
-		return nil, ErrWalletNotConnected
-	}
 
 	response, err := s.appContext.ValidateAddress(req.Address)
 	if err != nil {
@@ -330,9 +264,6 @@ func (s *stakepooldServer) ValidateAddress(ctx context.Context, req *pb.Validate
 }
 
 func (s *stakepooldServer) CreateMultisig(ctx context.Context, req *pb.CreateMultisigRequest) (*pb.CreateMultisigResponse, error) {
-	if !s.walletConnected() {
-		return nil, ErrWalletNotConnected
-	}
 
 	response, err := s.appContext.CreateMultisig(req.Address)
 	if err != nil {
@@ -346,9 +277,6 @@ func (s *stakepooldServer) CreateMultisig(ctx context.Context, req *pb.CreateMul
 }
 
 func (s *stakepooldServer) GetStakeInfo(ctx context.Context, req *pb.GetStakeInfoRequest) (*pb.GetStakeInfoResponse, error) {
-	if !s.walletConnected() {
-		return nil, ErrWalletNotConnected
-	}
 
 	response, err := s.appContext.GetStakeInfo()
 	if err != nil {

--- a/backend/stakepoold/server.go
+++ b/backend/stakepoold/server.go
@@ -162,7 +162,7 @@ func runMain() error {
 	}
 	log.Infof("Connected to dcrwallet (JSON-RPC API v%s)",
 		walletVer.String())
-	walletInfoRes, err := walletConn.WalletInfo()
+	walletInfoRes, err := walletConn.RPCClient().WalletInfo()
 	if err != nil || walletInfoRes == nil {
 		log.Errorf("Unable to retrieve walletinfo results")
 		return err
@@ -348,6 +348,9 @@ func runMain() error {
 		signal.Stop(c)
 		// Close the channel so multiple goroutines can get the message
 		log.Info("CTRL+C hit.  Closing goroutines.")
+		// Stop autoreconnect.
+		ctx.WalletConnection.Stop()
+
 		saveData(ctx)
 		close(ctx.Quit)
 	}()


### PR DESCRIPTION
Turn off rpcclient's autoreconnect and use our own.  This is done to remove the checks before ever wallet rpc call.  Checks for a disconnect every so often and starts trying to reconnect.