### PR TITLE
stakepoold: Add shutdown context

### DIFF
--- a/backend/stakepoold/rpcclient.go
+++ b/backend/stakepoold/rpcclient.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
+	"sync"
 	"time"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
@@ -62,7 +64,7 @@ func connectNodeRPC(ctx *rpcserver.AppContext, cfg *config) (*rpcclient.Client, 
 	return dcrdClient, nodeVer, nil
 }
 
-func connectWalletRPC(cfg *config) (*rpcserver.Client, semver, error) {
+func connectWalletRPC(ctx context.Context, wg *sync.WaitGroup, cfg *config) (*rpcserver.Client, semver, error) {
 	var walletVer semver
 
 	dcrwCert, err := ioutil.ReadFile(cfg.WalletCert)
@@ -88,7 +90,7 @@ func connectWalletRPC(cfg *config) (*rpcserver.Client, semver, error) {
 	ntfnHandlers := getWalletNtfnHandlers()
 
 	// New also starts an autoreconnect function.
-	dcrwClient, err := rpcserver.NewClient(connCfgWallet, ntfnHandlers)
+	dcrwClient, err := rpcserver.NewClient(ctx, wg, connCfgWallet, ntfnHandlers)
 	if err != nil {
 		log.Errorf("Verify that username and password is correct and that "+
 			"rpc.cert is for your wallet: %v", cfg.WalletCert)

--- a/backend/stakepoold/server.go
+++ b/backend/stakepoold/server.go
@@ -5,15 +5,16 @@
 package main
 
 import (
+	"context"
 	"encoding/gob"
 	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/signal"
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/decred/dcrd/chaincfg"
@@ -117,7 +118,10 @@ func deriveChildAddresses(key *hdkeychain.ExtendedKey, startIndex, count uint32,
 	return addresses, nil
 }
 
-func runMain() error {
+func runMain(shutdownContext context.Context) error {
+	// WaitGroup to pass around and wait, after shutdown signal is received,
+	// for goroutines to safely stop.
+	wg := new(sync.WaitGroup)
 	// Load configuration and parse command line.  This function also
 	// initializes logging and configures it accordingly.
 	loadedCfg, _, err := loadConfig()
@@ -155,7 +159,7 @@ func runMain() error {
 	rpcclient.UseLogger(clientLog)
 
 	var walletVer semver
-	walletConn, walletVer, err := connectWalletRPC(cfg)
+	walletConn, walletVer, err := connectWalletRPC(shutdownContext, wg, cfg)
 	if err != nil || walletConn == nil {
 		log.Infof("Connection to dcrwallet failed: %v", err)
 		return err
@@ -214,7 +218,6 @@ func runMain() error {
 		PoolFees:               cfg.PoolFees,
 		NewTicketsChan:         make(chan rpcserver.NewTicketsForBlock),
 		Params:                 activeNetParams.Params,
-		Quit:                   make(chan struct{}),
 		SpentmissedTicketsChan: make(chan rpcserver.SpentMissedTicketsForBlock),
 		UserData:               userData,
 		UserVotingConfig:       userVotingConfig,
@@ -339,27 +342,9 @@ func runMain() error {
 		}
 	}
 
-	// Only accept a single CTRL+C
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
-
-	// Start waiting for the interrupt signal
-	go func() {
-		<-c
-		signal.Stop(c)
-		// Close the channel so multiple goroutines can get the message
-		log.Info("CTRL+C hit.  Closing goroutines.")
-		// Stop autoreconnect.
-		ctx.WalletConnection.Stop()
-
-		saveData(ctx)
-		close(ctx.Quit)
-	}()
-
-	ctx.Wg.Add(3)
-	go ctx.NewTicketHandler()
-	go ctx.SpentmissedTicketHandler()
-	go ctx.WinningTicketHandler()
+	go ctx.NewTicketHandler(shutdownContext, wg)
+	go ctx.SpentmissedTicketHandler(shutdownContext, wg)
+	go ctx.WinningTicketHandler(shutdownContext, wg)
 
 	if cfg.NoRPCListen {
 		// Start reloading when a ticker fires
@@ -378,18 +363,22 @@ func runMain() error {
 		}()
 	}
 
-	// Wait for CTRL+C to signal goroutines to terminate via quit channel.
-	ctx.Wg.Wait()
+	// Wait for CTRL+C to signal goroutines to terminate
+	wg.Wait()
+	saveData(ctx)
 
 	return nil
 }
 
 func main() {
-	if err := runMain(); err != nil {
+	// Create a context that is cancelled when a shutdown request is received
+	// through an interrupt signal
+	shutdownContext := withShutdownCancel(context.Background())
+	go shutdownListener()
+	if err := runMain(shutdownContext); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
-	os.Exit(0)
 }
 
 func getDataNames() map[string]string {

--- a/backend/stakepoold/signal.go
+++ b/backend/stakepoold/signal.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2013-2014 The btcsuite developers
+// Copyright (c) 2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+)
+
+// shutdownSignaled is closed whenever shutdown is invoked through an interrupt
+// signal. Any contexts created using withShutdownChannel are cancelled when
+// this is closed.
+var shutdownSignaled = make(chan struct{})
+
+// withShutdownCancel creates a copy of a context that is cancelled whenever
+// shutdown is invoked through an interrupt signal or from an JSON-RPC stop
+// request.
+func withShutdownCancel(ctx context.Context) context.Context {
+	ctx, cancel := context.WithCancel(ctx)
+	go func() {
+		<-shutdownSignaled
+		cancel()
+	}()
+	return ctx
+}
+
+// shutdownListener listens for shutdown requests and cancels all contexts
+// created from withShutdownCancel.  This function never returns and is intended
+// to be spawned in a new goroutine.
+func shutdownListener() {
+	interruptChannel := make(chan os.Signal, 1)
+	// Only accept a single CTRL+C.
+	signal.Notify(interruptChannel, os.Interrupt)
+
+	// Listen for the initial shutdown signal
+	sig := <-interruptChannel
+	log.Infof("Received signal (%s).  Shutting down...", sig)
+
+	// Cancel all contexts created from withShutdownCancel.
+	close(shutdownSignaled)
+
+	// Listen for any more shutdown signals and log that shutdown has already
+	// been signaled.
+	for {
+		<-interruptChannel
+		log.Info("Shutdown signaled.  Already shutting down...")
+	}
+}


### PR DESCRIPTION
A struct channel was used in order to signal shutdowns. This changes
that to a context.Context that we can spawn new contexts from. Abstracts
the task to a seperate file signal.go

This is pretty much a copy/paste from dcrd and dcrwallet.  This gives us a base context to spawn new contexts off of.

One difference is that the name "ctx" is taken. Can we rename all "ctx" to something else?

Also, no idea what to do with the copyrights. Help me out.