### PR TITLE
stakepoold: context -> stakepool

### DIFF
--- a/backend/stakepoold/grpcserver.go
+++ b/backend/stakepoold/grpcserver.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/decred/dcrd/certgen"
 	"github.com/decred/dcrstakepool/backend/stakepoold/rpc/rpcserver"
+	"github.com/decred/dcrstakepool/backend/stakepoold/stakepool"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -188,7 +189,7 @@ func openRPCKeyPair() (tls.Certificate, error) {
 	return tls.LoadX509KeyPair(cfg.RPCCert, cfg.RPCKey)
 }
 
-func startGRPCServers(appContext *rpcserver.AppContext) (*grpc.Server, error) {
+func startGRPCServers(stakepoold *stakepool.Stakepoold) (*grpc.Server, error) {
 	var (
 		server  *grpc.Server
 		keyPair tls.Certificate
@@ -208,7 +209,7 @@ func startGRPCServers(appContext *rpcserver.AppContext) (*grpc.Server, error) {
 	creds := credentials.NewServerTLSFromCert(&keyPair)
 	server = grpc.NewServer(grpc.Creds(creds), grpc.UnaryInterceptor(interceptUnary))
 	rpcserver.StartVersionService(server)
-	rpcserver.StartStakepooldService(appContext, server)
+	rpcserver.StartStakepooldService(stakepoold, server)
 	for _, lis := range listeners {
 		lis := lis
 		go func() {

--- a/backend/stakepoold/log.go
+++ b/backend/stakepoold/log.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/decred/dcrstakepool/backend/stakepoold/rpc/rpcserver"
+	"github.com/decred/dcrstakepool/backend/stakepoold/stakepool"
 	"github.com/decred/dcrstakepool/backend/stakepoold/userdata"
 	"github.com/decred/slog"
 	"github.com/jrick/logrotate/rotator"
@@ -42,10 +43,11 @@ var (
 	// application shutdown.
 	logRotator *rotator.Rotator
 
-	clientLog = backendLog.Logger("RPCC")
-	dbLog     = backendLog.Logger("DB")
-	grpcLog   = backendLog.Logger("GRPC")
-	log       = backendLog.Logger("STPK")
+	clientLog    = backendLog.Logger("RPCC")
+	dbLog        = backendLog.Logger("DB")
+	grpcLog      = backendLog.Logger("GRPC")
+	log          = backendLog.Logger("STPK")
+	stakepoolLog = backendLog.Logger("CORE")
 )
 
 // subsystemLoggers maps each subsystem identifier to its associated logger.
@@ -54,12 +56,14 @@ var subsystemLoggers = map[string]slog.Logger{
 	"DB":   dbLog,
 	"GRPC": grpcLog,
 	"STPK": log,
+	"CORE": stakepoolLog,
 }
 
 // Initialize package-global logger variables.
 func init() {
 	userdata.UseLogger(dbLog)
 	rpcserver.UseLogger(grpcLog)
+	stakepool.UseLogger(stakepoolLog)
 }
 
 // initLogRotator initializes the logging rotater to write logs to logFile and

--- a/backend/stakepoold/rpcclient.go
+++ b/backend/stakepoold/rpcclient.go
@@ -9,14 +9,14 @@ import (
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/rpcclient/v3"
-	"github.com/decred/dcrstakepool/backend/stakepoold/rpc/rpcserver"
+	"github.com/decred/dcrstakepool/backend/stakepoold/stakepool"
 	"github.com/decred/dcrstakepool/backend/stakepoold/userdata"
 )
 
 var requiredChainServerAPI = semver{major: 6, minor: 0, patch: 0}
 var requiredWalletAPI = semver{major: 6, minor: 0, patch: 1}
 
-func connectNodeRPC(ctx *rpcserver.AppContext, cfg *config) (*rpcclient.Client, semver, error) {
+func connectNodeRPC(spd *stakepool.Stakepoold, cfg *config) (*rpcclient.Client, semver, error) {
 	var nodeVer semver
 
 	dcrdCert, err := ioutil.ReadFile(cfg.DcrdCert)
@@ -38,7 +38,7 @@ func connectNodeRPC(ctx *rpcserver.AppContext, cfg *config) (*rpcclient.Client, 
 		Certificates: dcrdCert,
 	}
 
-	ntfnHandlers := getNodeNtfnHandlers(ctx)
+	ntfnHandlers := getNodeNtfnHandlers(spd)
 	dcrdClient, err := rpcclient.New(connCfgDaemon, ntfnHandlers)
 	if err != nil {
 		log.Errorf("Failed to start dcrd RPC client: %s\n", err.Error())
@@ -64,7 +64,7 @@ func connectNodeRPC(ctx *rpcserver.AppContext, cfg *config) (*rpcclient.Client, 
 	return dcrdClient, nodeVer, nil
 }
 
-func connectWalletRPC(ctx context.Context, wg *sync.WaitGroup, cfg *config) (*rpcserver.Client, semver, error) {
+func connectWalletRPC(spd context.Context, wg *sync.WaitGroup, cfg *config) (*stakepool.Client, semver, error) {
 	var walletVer semver
 
 	dcrwCert, err := ioutil.ReadFile(cfg.WalletCert)
@@ -90,7 +90,7 @@ func connectWalletRPC(ctx context.Context, wg *sync.WaitGroup, cfg *config) (*rp
 	ntfnHandlers := getWalletNtfnHandlers()
 
 	// New also starts an autoreconnect function.
-	dcrwClient, err := rpcserver.NewClient(ctx, wg, connCfgWallet, ntfnHandlers)
+	dcrwClient, err := stakepool.NewClient(spd, wg, connCfgWallet, ntfnHandlers)
 	if err != nil {
 		log.Errorf("Verify that username and password is correct and that "+
 			"rpc.cert is for your wallet: %v", cfg.WalletCert)
@@ -117,16 +117,16 @@ func connectWalletRPC(ctx context.Context, wg *sync.WaitGroup, cfg *config) (*rp
 	return dcrwClient, walletVer, nil
 }
 
-func walletGetTickets(ctx *rpcserver.AppContext) (map[chainhash.Hash]string, map[chainhash.Hash]string, error) {
+func walletGetTickets(spd *stakepool.Stakepoold) (map[chainhash.Hash]string, map[chainhash.Hash]string, error) {
 	blockHashToHeightCache := make(map[chainhash.Hash]int32)
 
 	// This is suboptimal to copy and needs fixing.
 	userVotingConfig := make(map[string]userdata.UserVotingConfig)
-	ctx.RLock()
-	for k, v := range ctx.UserVotingConfig {
+	spd.RLock()
+	for k, v := range spd.UserVotingConfig {
 		userVotingConfig[k] = v
 	}
-	ctx.RUnlock()
+	spd.RUnlock()
 
 	ignoredLowFeeTickets := make(map[chainhash.Hash]string)
 	liveTickets := make(map[chainhash.Hash]string)
@@ -134,7 +134,7 @@ func walletGetTickets(ctx *rpcserver.AppContext) (map[chainhash.Hash]string, map
 
 	log.Info("Calling GetTickets...")
 	timenow := time.Now()
-	tickets, err := ctx.WalletConnection.RPCClient().GetTickets(false)
+	tickets, err := spd.WalletConnection.RPCClient().GetTickets(false)
 	log.Infof("GetTickets: took %v", time.Since(timenow))
 
 	if err != nil {
@@ -150,7 +150,7 @@ func walletGetTickets(ctx *rpcserver.AppContext) (map[chainhash.Hash]string, map
 	log.Debugf("setting up GetTransactionAsync for %v tickets", len(tickets))
 	for _, ticket := range tickets {
 		// lookup ownership of each ticket
-		promises = append(promises, promise{ctx.WalletConnection.RPCClient().GetTransactionAsync(ticket)})
+		promises = append(promises, promise{spd.WalletConnection.RPCClient().GetTransactionAsync(ticket)})
 	}
 
 	var counter int
@@ -180,11 +180,11 @@ func walletGetTickets(ctx *rpcserver.AppContext) (map[chainhash.Hash]string, map
 			// All tickets are present in the GetTickets response, whether they
 			// pay the correct fee or not.  So we need to verify fees and
 			// sort the tickets into their respective maps.
-			_, isAdded := ctx.AddedLowFeeTicketsMSA[*hash]
+			_, isAdded := spd.AddedLowFeeTicketsMSA[*hash]
 			if isAdded {
 				liveTickets[*hash] = userVotingConfig[addr].MultiSigAddress
 			} else {
-				msgTx, err := rpcserver.MsgTxFromHex(gt.Hex)
+				msgTx, err := stakepool.MsgTxFromHex(gt.Hex)
 				if err != nil {
 					log.Warnf("MsgTxFromHex failed for %v: %v", gt.Hex, err)
 					continue
@@ -202,7 +202,7 @@ func walletGetTickets(ctx *rpcserver.AppContext) (map[chainhash.Hash]string, map
 				if inCache {
 					ticketBlockHeight = height
 				} else {
-					gbh, err := ctx.NodeConnection.GetBlockHeader(ticketBlockHash)
+					gbh, err := spd.NodeConnection.GetBlockHeader(ticketBlockHash)
 					if err != nil {
 						log.Warnf("GetBlockHeader failed for %v: %v", ticketBlockHash, err)
 						continue
@@ -212,18 +212,18 @@ func walletGetTickets(ctx *rpcserver.AppContext) (map[chainhash.Hash]string, map
 					ticketBlockHeight = int32(gbh.Height)
 				}
 
-				ticketFeesValid, err := ctx.EvaluateStakePoolTicket(msgTx, ticketBlockHeight)
+				ticketFeesValid, err := spd.EvaluateStakePoolTicket(msgTx, ticketBlockHeight)
 
 				if err != nil {
 					log.Warnf("ignoring ticket %v for multisig %v due to error: %v",
-						*hash, ctx.UserVotingConfig[addr].MultiSigAddress, err)
+						*hash, spd.UserVotingConfig[addr].MultiSigAddress, err)
 					ignoredLowFeeTickets[*hash] = userVotingConfig[addr].MultiSigAddress
 				} else if ticketFeesValid {
 					normalFee++
 					liveTickets[*hash] = userVotingConfig[addr].MultiSigAddress
 				} else {
 					log.Warnf("ignoring ticket %v for multisig %v due to invalid fee",
-						*hash, ctx.UserVotingConfig[addr].MultiSigAddress)
+						*hash, spd.UserVotingConfig[addr].MultiSigAddress)
 					ignoredLowFeeTickets[*hash] = userVotingConfig[addr].MultiSigAddress
 				}
 			}
@@ -232,7 +232,7 @@ func walletGetTickets(ctx *rpcserver.AppContext) (map[chainhash.Hash]string, map
 	}
 
 	log.Infof("tickets loaded -- addedLowFee %v ignoredLowFee %v normalFee %v "+
-		"live %v total %v", len(ctx.AddedLowFeeTicketsMSA),
+		"live %v total %v", len(spd.AddedLowFeeTicketsMSA),
 		len(ignoredLowFeeTickets), normalFee, len(liveTickets),
 		len(tickets))
 

--- a/backend/stakepoold/rpcclient.go
+++ b/backend/stakepoold/rpcclient.go
@@ -64,7 +64,7 @@ func connectNodeRPC(spd *stakepool.Stakepoold, cfg *config) (*rpcclient.Client, 
 	return dcrdClient, nodeVer, nil
 }
 
-func connectWalletRPC(spd context.Context, wg *sync.WaitGroup, cfg *config) (*stakepool.Client, semver, error) {
+func connectWalletRPC(ctx context.Context, wg *sync.WaitGroup, cfg *config) (*stakepool.Client, semver, error) {
 	var walletVer semver
 
 	dcrwCert, err := ioutil.ReadFile(cfg.WalletCert)
@@ -90,7 +90,7 @@ func connectWalletRPC(spd context.Context, wg *sync.WaitGroup, cfg *config) (*st
 	ntfnHandlers := getWalletNtfnHandlers()
 
 	// New also starts an autoreconnect function.
-	dcrwClient, err := stakepool.NewClient(spd, wg, connCfgWallet, ntfnHandlers)
+	dcrwClient, err := stakepool.NewClient(ctx, wg, connCfgWallet, ntfnHandlers)
 	if err != nil {
 		log.Errorf("Verify that username and password is correct and that "+
 			"rpc.cert is for your wallet: %v", cfg.WalletCert)

--- a/backend/stakepoold/server.go
+++ b/backend/stakepoold/server.go
@@ -21,7 +21,7 @@ import (
 	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrd/hdkeychain"
 	"github.com/decred/dcrd/rpcclient/v3"
-	"github.com/decred/dcrstakepool/backend/stakepoold/rpc/rpcserver"
+	"github.com/decred/dcrstakepool/backend/stakepoold/stakepool"
 	"github.com/decred/dcrstakepool/backend/stakepoold/userdata"
 	"github.com/decred/dcrwallet/wallet/v2/txrules"
 	"github.com/decred/dcrwallet/wallet/v2/udb"
@@ -179,7 +179,7 @@ func runMain(shutdownContext context.Context) error {
 		return err
 	}
 
-	votingConfig := rpcserver.VotingConfig{
+	votingConfig := stakepool.VotingConfig{
 		VoteBits:         walletInfoRes.VoteBits,
 		VoteBitsExtended: walletInfoRes.VoteBitsExtended,
 		VoteVersion:      walletInfoRes.VoteVersion,
@@ -210,30 +210,30 @@ func runMain(shutdownContext context.Context) error {
 		return err
 	}
 
-	ctx := &rpcserver.AppContext{
+	spd := &stakepool.Stakepoold{
 		AddedLowFeeTicketsMSA:  addedLowFeeTicketsMSA,
 		DataPath:               cfg.DataDir,
 		ColdWalletExtPub:       cfg.ColdWalletExtPub,
 		FeeAddrs:               feeAddrs,
 		PoolFees:               cfg.PoolFees,
-		NewTicketsChan:         make(chan rpcserver.NewTicketsForBlock),
+		NewTicketsChan:         make(chan stakepool.NewTicketsForBlock),
 		Params:                 activeNetParams.Params,
-		SpentmissedTicketsChan: make(chan rpcserver.SpentMissedTicketsForBlock),
+		SpentmissedTicketsChan: make(chan stakepool.SpentMissedTicketsForBlock),
 		UserData:               userData,
 		UserVotingConfig:       userVotingConfig,
 		VotingConfig:           &votingConfig,
 		WalletConnection:       walletConn,
-		WinningTicketsChan:     make(chan rpcserver.WinningTicketsForBlock),
+		WinningTicketsChan:     make(chan stakepool.WinningTicketsForBlock),
 		Testing:                false,
 	}
 
 	// Daemon client connection
-	nodeConn, nodeVer, err := connectNodeRPC(ctx, cfg)
+	nodeConn, nodeVer, err := connectNodeRPC(spd, cfg)
 	if err != nil || nodeConn == nil {
 		log.Infof("Connection to dcrd failed: %v", err)
 		return err
 	}
-	ctx.NodeConnection = nodeConn
+	spd.NodeConnection = nodeConn
 
 	// Display connected network
 	curnet, err := nodeConn.GetCurrentNet()
@@ -245,27 +245,27 @@ func runMain(shutdownContext context.Context) error {
 		nodeVer.String(), curnet.String())
 
 	// prune save data
-	err = pruneData(ctx)
+	err = pruneData(spd)
 	if err != nil {
 		log.Warnf("pruneData error: %v", err)
 	}
 
 	// load AddedLowFeeTicketsMSA from disk cache if necessary
-	if len(ctx.AddedLowFeeTicketsMSA) == 0 && errMySQLFetchAddedLowFeeTickets != nil {
-		err = loadData(ctx, "AddedLowFeeTickets")
+	if len(spd.AddedLowFeeTicketsMSA) == 0 && errMySQLFetchAddedLowFeeTickets != nil {
+		err = loadData(spd, "AddedLowFeeTickets")
 		if err != nil {
 			// might not have any so continue
 			log.Warnf("unable to load added low fee tickets from disk "+
 				"cache: %v", err)
 		} else {
 			log.Infof("Loaded %v AddedLowFeeTickets from disk cache",
-				len(ctx.AddedLowFeeTicketsMSA))
+				len(spd.AddedLowFeeTicketsMSA))
 		}
 	}
 
 	// load userVotingConfig from disk cache if necessary
-	if len(ctx.UserVotingConfig) == 0 && errMySQLFetchUserVotingConfig != nil {
-		err = loadData(ctx, "UserVotingConfig")
+	if len(spd.UserVotingConfig) == 0 && errMySQLFetchUserVotingConfig != nil {
+		err = loadData(spd, "UserVotingConfig")
 		if err != nil {
 			// we could possibly die out here but it's probably better
 			// to let stakepoold vote with default preferences rather than
@@ -274,11 +274,11 @@ func runMain(shutdownContext context.Context) error {
 				"cache: %v", err)
 		} else {
 			log.Infof("Loaded UserVotingConfig for %d users from disk cache",
-				len(ctx.UserVotingConfig))
+				len(spd.UserVotingConfig))
 		}
 	}
 
-	if len(ctx.UserVotingConfig) == 0 {
+	if len(spd.UserVotingConfig) == 0 {
 		log.Warn("0 active users")
 	}
 
@@ -292,7 +292,7 @@ func runMain(shutdownContext context.Context) error {
 		}
 		log.Infof("current block height %v hash %v", curHeight, curHash)
 
-		ctx.IgnoredLowFeeTicketsMSA, ctx.LiveTicketsMSA, err = walletGetTickets(ctx)
+		spd.IgnoredLowFeeTicketsMSA, spd.LiveTicketsMSA, err = walletGetTickets(spd)
 		if err != nil {
 			log.Errorf("unable to get tickets: %v", err)
 			return err
@@ -336,26 +336,26 @@ func runMain(shutdownContext context.Context) error {
 	log.Info("subscribed to notifications from dcrd")
 
 	if !cfg.NoRPCListen {
-		if _, err = startGRPCServers(ctx); err != nil {
+		if _, err = startGRPCServers(spd); err != nil {
 			fmt.Printf("Failed to start GRPCServers: %s\n", err.Error())
 			return err
 		}
 	}
 
-	go ctx.NewTicketHandler(shutdownContext, wg)
-	go ctx.SpentmissedTicketHandler(shutdownContext, wg)
-	go ctx.WinningTicketHandler(shutdownContext, wg)
+	go spd.NewTicketHandler(shutdownContext, wg)
+	go spd.SpentmissedTicketHandler(shutdownContext, wg)
+	go spd.WinningTicketHandler(shutdownContext, wg)
 
 	if cfg.NoRPCListen {
 		// Start reloading when a ticker fires
 		configTicker := time.NewTicker(time.Second * 240)
 		go func() {
 			for range configTicker.C {
-				err := ctx.UpdateTicketDataFromMySQL()
+				err := spd.UpdateTicketDataFromMySQL()
 				if err != nil {
 					log.Warnf("UpdateTicketDataFromMySQL failed %v:", err)
 				}
-				err = ctx.UpdateUserDataFromMySQL()
+				err = spd.UpdateUserDataFromMySQL()
 				if err != nil {
 					log.Warnf("UpdateUserDataFromMySQL failed %v:", err)
 				}
@@ -365,7 +365,7 @@ func runMain(shutdownContext context.Context) error {
 
 	// Wait for CTRL+C to signal goroutines to terminate
 	wg.Wait()
-	saveData(ctx)
+	saveData(spd)
 
 	return nil
 }
@@ -397,17 +397,17 @@ func getDataNames() map[string]string {
 }
 
 // pruneData prunes any extra save files.
-func pruneData(ctx *rpcserver.AppContext) error {
+func pruneData(spd *stakepool.Stakepoold) error {
 	saveFiles := getDataNames()
 
-	if !fileExists(ctx.DataPath) {
-		return fmt.Errorf("datapath %v doesn't exist", ctx.DataPath)
+	if !fileExists(spd.DataPath) {
+		return fmt.Errorf("datapath %v doesn't exist", spd.DataPath)
 	}
 
 	for dataKind, dataVersion := range saveFiles {
 		var filesToPrune []string
 
-		files, err := ioutil.ReadDir(ctx.DataPath)
+		files, err := ioutil.ReadDir(spd.DataPath)
 		if err != nil {
 			return err
 		}
@@ -417,7 +417,7 @@ func pruneData(ctx *rpcserver.AppContext) error {
 			if strings.HasPrefix(file.Name(), strings.ToLower(dataKind)) &&
 				strings.Contains(file.Name(), dataVersion) &&
 				strings.HasSuffix(file.Name(), ".gob") {
-				filesToPrune = append(filesToPrune, filepath.Join(ctx.DataPath, file.Name()))
+				filesToPrune = append(filesToPrune, filepath.Join(spd.DataPath, file.Name()))
 			}
 		}
 
@@ -444,7 +444,7 @@ func pruneData(ctx *rpcserver.AppContext) error {
 
 // loadData looks for and attempts to load into memory the most recent save
 // file for a passed data kind.
-func loadData(ctx *rpcserver.AppContext, dataKind string) error {
+func loadData(spd *stakepool.Stakepoold, dataKind string) error {
 	var dataVersion string
 	found := false
 	saveFiles := getDataNames()
@@ -460,8 +460,8 @@ func loadData(ctx *rpcserver.AppContext, dataKind string) error {
 		return errors.New("unhandled data kind of " + dataKind)
 	}
 
-	if fileExists(ctx.DataPath) {
-		files, err := ioutil.ReadDir(ctx.DataPath)
+	if fileExists(spd.DataPath) {
+		files, err := ioutil.ReadDir(spd.DataPath)
 		if err != nil {
 			return err
 		}
@@ -484,7 +484,7 @@ func loadData(ctx *rpcserver.AppContext, dataKind string) error {
 			return nil
 		}
 
-		fullPath := filepath.Join(ctx.DataPath, lastseen)
+		fullPath := filepath.Join(spd.DataPath, lastseen)
 
 		r, err := os.Open(fullPath)
 		if err != nil {
@@ -493,17 +493,17 @@ func loadData(ctx *rpcserver.AppContext, dataKind string) error {
 		dec := gob.NewDecoder(r)
 		switch dataKind {
 		case "AddedLowFeeTickets":
-			err = dec.Decode(&ctx.AddedLowFeeTicketsMSA)
+			err = dec.Decode(&spd.AddedLowFeeTicketsMSA)
 			if err != nil {
 				return err
 			}
 		case "LiveTickets":
-			err = dec.Decode(&ctx.LiveTicketsMSA)
+			err = dec.Decode(&spd.LiveTicketsMSA)
 			if err != nil {
 				return err
 			}
 		case "UserVotingConfig":
-			err = dec.Decode(&ctx.UserVotingConfig)
+			err = dec.Decode(&spd.UserVotingConfig)
 			if err != nil {
 				return err
 			}
@@ -513,14 +513,14 @@ func loadData(ctx *rpcserver.AppContext, dataKind string) error {
 	}
 
 	// shouldn't get here -- data dir is created on startup
-	return errors.New("loadData - path " + ctx.DataPath + " does not exist")
+	return errors.New("loadData - path " + spd.DataPath + " does not exist")
 }
 
-// saveData saves some appContext fields to a file so they can be loaded back
+// saveData saves some stakepoold fields to a file so they can be loaded back
 // into memory at next run.
-func saveData(ctx *rpcserver.AppContext) {
-	ctx.Lock()
-	defer ctx.Unlock()
+func saveData(spd *stakepool.Stakepoold) {
+	spd.Lock()
+	defer spd.Unlock()
 
 	saveFiles := getDataNames()
 
@@ -529,22 +529,22 @@ func saveData(ctx *rpcserver.AppContext) {
 		destFilename := strings.Replace(dataFilenameTemplate, "KIND", filenameprefix, -1)
 		destFilename = strings.Replace(destFilename, "DATE", t.Format("2006_01_02_15_04_05"), -1)
 		destFilename = strings.Replace(destFilename, "VERSION", dataversion, -1)
-		destPath := strings.ToLower(filepath.Join(ctx.DataPath, destFilename))
+		destPath := strings.ToLower(filepath.Join(spd.DataPath, destFilename))
 
 		// Pre-validate whether we'll be saving or not.
 		switch filenameprefix {
 		case "AddedLowFeeTickets":
-			if len(ctx.AddedLowFeeTicketsMSA) == 0 {
+			if len(spd.AddedLowFeeTicketsMSA) == 0 {
 				log.Warn("saveData: addedLowFeeTicketsMSA is empty; skipping save")
 				continue
 			}
 		case "LiveTickets":
-			if len(ctx.LiveTicketsMSA) == 0 {
+			if len(spd.LiveTicketsMSA) == 0 {
 				log.Warn("saveData: liveTicketsMSA is empty; skipping save")
 				continue
 			}
 		case "UserVotingConfig":
-			if len(ctx.UserVotingConfig) == 0 {
+			if len(spd.UserVotingConfig) == 0 {
 				log.Warn("saveData: UserVotingConfig is empty; skipping save")
 				continue
 			}
@@ -555,7 +555,7 @@ func saveData(ctx *rpcserver.AppContext) {
 
 		w, err := os.Create(destPath)
 		if err != nil {
-			log.Errorf("Error opening file %s: %v", ctx.DataPath, err)
+			log.Errorf("Error opening file %s: %v", spd.DataPath, err)
 			continue
 		}
 		defer w.Close()
@@ -563,20 +563,20 @@ func saveData(ctx *rpcserver.AppContext) {
 		switch filenameprefix {
 		case "AddedLowFeeTickets":
 			enc := gob.NewEncoder(w)
-			if err := enc.Encode(&ctx.AddedLowFeeTicketsMSA); err != nil {
-				log.Errorf("Failed to encode file %s: %v", ctx.DataPath, err)
+			if err := enc.Encode(&spd.AddedLowFeeTicketsMSA); err != nil {
+				log.Errorf("Failed to encode file %s: %v", spd.DataPath, err)
 				continue
 			}
 		case "LiveTickets":
 			enc := gob.NewEncoder(w)
-			if err := enc.Encode(&ctx.LiveTicketsMSA); err != nil {
-				log.Errorf("Failed to encode file %s: %v", ctx.DataPath, err)
+			if err := enc.Encode(&spd.LiveTicketsMSA); err != nil {
+				log.Errorf("Failed to encode file %s: %v", spd.DataPath, err)
 				continue
 			}
 		case "UserVotingConfig":
 			enc := gob.NewEncoder(w)
-			if err := enc.Encode(&ctx.UserVotingConfig); err != nil {
-				log.Errorf("Failed to encode file %s: %v", ctx.DataPath, err)
+			if err := enc.Encode(&spd.UserVotingConfig); err != nil {
+				log.Errorf("Failed to encode file %s: %v", spd.DataPath, err)
 				continue
 			}
 		}

--- a/backend/stakepoold/server.go
+++ b/backend/stakepoold/server.go
@@ -118,7 +118,7 @@ func deriveChildAddresses(key *hdkeychain.ExtendedKey, startIndex, count uint32,
 	return addresses, nil
 }
 
-func runMain(shutdownContext context.Context) error {
+func runMain(ctx context.Context) error {
 	// WaitGroup to pass around and wait, after shutdown signal is received,
 	// for goroutines to safely stop.
 	wg := new(sync.WaitGroup)
@@ -159,7 +159,7 @@ func runMain(shutdownContext context.Context) error {
 	rpcclient.UseLogger(clientLog)
 
 	var walletVer semver
-	walletConn, walletVer, err := connectWalletRPC(shutdownContext, wg, cfg)
+	walletConn, walletVer, err := connectWalletRPC(ctx, wg, cfg)
 	if err != nil || walletConn == nil {
 		log.Infof("Connection to dcrwallet failed: %v", err)
 		return err
@@ -342,9 +342,9 @@ func runMain(shutdownContext context.Context) error {
 		}
 	}
 
-	go spd.NewTicketHandler(shutdownContext, wg)
-	go spd.SpentmissedTicketHandler(shutdownContext, wg)
-	go spd.WinningTicketHandler(shutdownContext, wg)
+	go spd.NewTicketHandler(ctx, wg)
+	go spd.SpentmissedTicketHandler(ctx, wg)
+	go spd.WinningTicketHandler(ctx, wg)
 
 	if cfg.NoRPCListen {
 		// Start reloading when a ticker fires
@@ -373,9 +373,9 @@ func runMain(shutdownContext context.Context) error {
 func main() {
 	// Create a context that is cancelled when a shutdown request is received
 	// through an interrupt signal
-	shutdownContext := withShutdownCancel(context.Background())
+	ctx := withShutdownCancel(context.Background())
 	go shutdownListener()
-	if err := runMain(shutdownContext); err != nil {
+	if err := runMain(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}

--- a/backend/stakepoold/server_test.go
+++ b/backend/stakepoold/server_test.go
@@ -86,12 +86,12 @@ func randString(n int) string {
 }
 
 var (
-	c  *stakepool.Stakepoold
-	wt stakepool.WinningTicketsForBlock
+	spd *stakepool.Stakepoold
+	wt  stakepool.WinningTicketsForBlock
 )
 
 func init() {
-	c = &stakepool.Stakepoold{
+	spd = &stakepool.Stakepoold{
 		LiveTicketsMSA: make(map[chainhash.Hash]string),
 		VotingConfig: &stakepool.VotingConfig{
 			VoteBits:         1,
@@ -107,11 +107,11 @@ func init() {
 	// leave out last 5, as they will be inserted when tickets are generated
 	for i := 0; i < userCount-5; i++ {
 		msa := "Tc" + randString(33)
-		c.UserVotingConfig[msa] = userdata.UserVotingConfig{
+		spd.UserVotingConfig[msa] = userdata.UserVotingConfig{
 			Userid:          int64(i),
 			MultiSigAddress: msa,
-			VoteBits:        c.VotingConfig.VoteBits,
-			VoteBitsVersion: c.VotingConfig.VoteVersion,
+			VoteBits:        spd.VotingConfig.VoteBits,
+			VoteBitsVersion: spd.VotingConfig.VoteVersion,
 		}
 	}
 
@@ -124,18 +124,18 @@ func init() {
 		ticket := &chainhash.Hash{b[0], b[1], b[2], b[3]}
 
 		// use ticket as the key
-		c.LiveTicketsMSA[*ticket] = msa
+		spd.LiveTicketsMSA[*ticket] = msa
 
 		// last 5 tickets win
 		if i > ticketCount-6 {
 			wt.WinningTickets = append(wt.WinningTickets, ticket)
-			c.UserVotingConfig[msa] = userdata.UserVotingConfig{}
+			spd.UserVotingConfig[msa] = userdata.UserVotingConfig{}
 		}
 	}
 }
 
 func BenchmarkProcessWinningTickets(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		c.ProcessWinningTickets(wt)
+		spd.ProcessWinningTickets(wt)
 	}
 }

--- a/backend/stakepoold/server_test.go
+++ b/backend/stakepoold/server_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/chaincfg/chainhash"
-	"github.com/decred/dcrstakepool/backend/stakepoold/rpc/rpcserver"
+	"github.com/decred/dcrstakepool/backend/stakepoold/stakepool"
 	"github.com/decred/dcrstakepool/backend/stakepoold/userdata"
 )
 
@@ -86,14 +86,14 @@ func randString(n int) string {
 }
 
 var (
-	c  *rpcserver.AppContext
-	wt rpcserver.WinningTicketsForBlock
+	c  *stakepool.Stakepoold
+	wt stakepool.WinningTicketsForBlock
 )
 
 func init() {
-	c = &rpcserver.AppContext{
+	c = &stakepool.Stakepoold{
 		LiveTicketsMSA: make(map[chainhash.Hash]string),
-		VotingConfig: &rpcserver.VotingConfig{
+		VotingConfig: &stakepool.VotingConfig{
 			VoteBits:         1,
 			VoteBitsExtended: "05000000",
 			VoteVersion:      5,

--- a/backend/stakepoold/signal.go
+++ b/backend/stakepoold/signal.go
@@ -19,13 +19,13 @@ var shutdownSignaled = make(chan struct{})
 // withShutdownCancel creates a copy of a context that is cancelled whenever
 // shutdown is invoked through an interrupt signal or from an JSON-RPC stop
 // request.
-func withShutdownCancel(spd context.Context) context.Context {
-	spd, cancel := context.WithCancel(spd)
+func withShutdownCancel(ctx context.Context) context.Context {
+	ctx, cancel := context.WithCancel(ctx)
 	go func() {
 		<-shutdownSignaled
 		cancel()
 	}()
-	return spd
+	return ctx
 }
 
 // shutdownListener listens for shutdown requests and cancels all contexts

--- a/backend/stakepoold/signal.go
+++ b/backend/stakepoold/signal.go
@@ -19,13 +19,13 @@ var shutdownSignaled = make(chan struct{})
 // withShutdownCancel creates a copy of a context that is cancelled whenever
 // shutdown is invoked through an interrupt signal or from an JSON-RPC stop
 // request.
-func withShutdownCancel(ctx context.Context) context.Context {
-	ctx, cancel := context.WithCancel(ctx)
+func withShutdownCancel(spd context.Context) context.Context {
+	spd, cancel := context.WithCancel(spd)
 	go func() {
 		<-shutdownSignaled
 		cancel()
 	}()
-	return ctx
+	return spd
 }
 
 // shutdownListener listens for shutdown requests and cancels all contexts

--- a/backend/stakepoold/stakepool/client.go
+++ b/backend/stakepoold/stakepool/client.go
@@ -1,4 +1,4 @@
-package rpcserver
+package stakepool
 
 import (
 	"context"

--- a/backend/stakepoold/stakepool/log.go
+++ b/backend/stakepoold/stakepool/log.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2013-2015 The btcsuite developers
+// Copyright (c) 2018 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package stakepool
+
+import "github.com/decred/slog"
+
+// log is a logger that is initialized with no output filters.  This
+// means the package will not perform any logging by default until the caller
+// requests it.
+var log = slog.Disabled
+
+// DisableLog disables all library log output.  Logging output is disabled
+// by default until either UseLogger or SetLogWriter are called.
+func DisableLog() {
+	log = slog.Disabled
+}
+
+// UseLogger uses a specified Logger to output package logging info.
+// This should be used in preference to SetLogWriter if the caller is also
+// using slog.
+func UseLogger(logger slog.Logger) {
+	log = logger
+}

--- a/backend/stakepoold/stakepool/stakepool.go
+++ b/backend/stakepoold/stakepool/stakepool.go
@@ -798,7 +798,7 @@ func (spd *Stakepoold) ProcessWinningTickets(wt WinningTicketsForBlock) {
 	}()
 }
 
-func (spd *Stakepoold) NewTicketHandler(shutdownContext context.Context, wg *sync.WaitGroup) {
+func (spd *Stakepoold) NewTicketHandler(ctx context.Context, wg *sync.WaitGroup) {
 	wg.Add(1)
 	defer wg.Done()
 
@@ -806,13 +806,13 @@ func (spd *Stakepoold) NewTicketHandler(shutdownContext context.Context, wg *syn
 		select {
 		case nt := <-spd.NewTicketsChan:
 			go spd.processNewTickets(nt)
-		case <-shutdownContext.Done():
+		case <-ctx.Done():
 			return
 		}
 	}
 }
 
-func (spd *Stakepoold) SpentmissedTicketHandler(shutdownContext context.Context, wg *sync.WaitGroup) {
+func (spd *Stakepoold) SpentmissedTicketHandler(ctx context.Context, wg *sync.WaitGroup) {
 	wg.Add(1)
 	defer wg.Done()
 
@@ -820,13 +820,13 @@ func (spd *Stakepoold) SpentmissedTicketHandler(shutdownContext context.Context,
 		select {
 		case smt := <-spd.SpentmissedTicketsChan:
 			go spd.processSpentMissedTickets(smt)
-		case <-shutdownContext.Done():
+		case <-ctx.Done():
 			return
 		}
 	}
 }
 
-func (spd *Stakepoold) WinningTicketHandler(shutdownContext context.Context, wg *sync.WaitGroup) {
+func (spd *Stakepoold) WinningTicketHandler(ctx context.Context, wg *sync.WaitGroup) {
 	wg.Add(1)
 	defer wg.Done()
 
@@ -834,7 +834,7 @@ func (spd *Stakepoold) WinningTicketHandler(shutdownContext context.Context, wg 
 		select {
 		case wt := <-spd.WinningTicketsChan:
 			go spd.ProcessWinningTickets(wt)
-		case <-shutdownContext.Done():
+		case <-ctx.Done():
 			return
 		}
 	}

--- a/backend/stakepoold/stakepool/stakepool.go
+++ b/backend/stakepoold/stakepool/stakepool.go
@@ -1,4 +1,8 @@
-package rpcserver
+// Copyright (c) 2019 The Decred developers
+
+// Package stakepool holds the Stakepool struct and processes incomming commands
+// and notifications.
+package stakepool
 
 import (
 	"bytes"
@@ -30,7 +34,7 @@ var (
 	ticketTypeSpentMissed = "SpentMissed"
 )
 
-type AppContext struct {
+type Stakepoold struct {
 	sync.RWMutex
 
 	// locking required
@@ -102,7 +106,7 @@ type ticketMetadata struct {
 // EvaluateStakePoolTicket evaluates a voting service ticket to see if it's
 // acceptable to the voting service. The ticket must pay out to the voting
 // service cold wallet, and must have a sufficient fee.
-func (ctx *AppContext) EvaluateStakePoolTicket(tx *wire.MsgTx, blockHeight int32) (bool, error) {
+func (spd *Stakepoold) EvaluateStakePoolTicket(tx *wire.MsgTx, blockHeight int32) (bool, error) {
 	// Check the first commitment output (txOuts[1])
 	// and ensure that the address found there exists
 	// in the list of approved addresses. Also ensure
@@ -110,7 +114,7 @@ func (ctx *AppContext) EvaluateStakePoolTicket(tx *wire.MsgTx, blockHeight int32
 	// requested by the pool.
 	commitmentOut := tx.TxOut[1]
 	commitAddr, err := stake.AddrFromSStxPkScrCommitment(
-		commitmentOut.PkScript, ctx.Params)
+		commitmentOut.PkScript, spd.Params)
 	if err != nil {
 		return false, fmt.Errorf("Failed to parse commit out addr: %s",
 			err.Error())
@@ -135,7 +139,7 @@ func (ctx *AppContext) EvaluateStakePoolTicket(tx *wire.MsgTx, blockHeight int32
 	}
 	fees := in - out
 
-	_, exists := ctx.FeeAddrs[commitAddr.EncodeAddress()]
+	_, exists := spd.FeeAddrs[commitAddr.EncodeAddress()]
 	if exists {
 		commitAmt, err := stake.AmountFromSStxPkScrCommitment(
 			commitmentOut.PkScript)
@@ -147,8 +151,8 @@ func (ctx *AppContext) EvaluateStakePoolTicket(tx *wire.MsgTx, blockHeight int32
 		// Calculate the fee required based on the current
 		// height and the required amount from the pool.
 		feeNeeded := txrules.StakePoolTicketFee(dcrutil.Amount(
-			tx.TxOut[0].Value), fees, blockHeight, ctx.PoolFees,
-			ctx.Params)
+			tx.TxOut[0].Value), fees, blockHeight, spd.PoolFees,
+			spd.Params)
 		if commitAmt < feeNeeded {
 			log.Warnf("User %s submitted ticket %v which "+
 				"has less fees than are required to use this "+
@@ -186,7 +190,7 @@ func MsgTxFromHex(txhex string) (*wire.MsgTx, error) {
 }
 
 // getticket pulls the transaction information for a ticket from dcrwallet. This is a go routine!
-func (ctx *AppContext) getticket(wg *sync.WaitGroup, nt *ticketMetadata) {
+func (spd *Stakepoold) getticket(wg *sync.WaitGroup, nt *ticketMetadata) {
 	start := time.Now()
 
 	defer func() {
@@ -197,7 +201,7 @@ func (ctx *AppContext) getticket(wg *sync.WaitGroup, nt *ticketMetadata) {
 	// Ask wallet to look up vote transaction to see if it belongs to us
 	log.Debugf("calling GetTransaction for %v ticket %v",
 		strings.ToLower(nt.ticketType), nt.ticket)
-	res, err := ctx.WalletConnection.RPCClient().GetTransaction(nt.ticket)
+	res, err := spd.WalletConnection.RPCClient().GetTransaction(nt.ticket)
 	nt.getDuration = time.Since(start)
 	if err != nil {
 		// suppress "No information for transaction ..." errors
@@ -208,7 +212,7 @@ func (ctx *AppContext) getticket(wg *sync.WaitGroup, nt *ticketMetadata) {
 		return
 	}
 	for i := range res.Details {
-		_, ok := ctx.UserVotingConfig[res.Details[i].Address]
+		_, ok := spd.UserVotingConfig[res.Details[i].Address]
 		if ok {
 			// multisigaddress will match if it belongs a pool user
 			nt.msa = res.Details[i].Address
@@ -228,31 +232,31 @@ func (ctx *AppContext) getticket(wg *sync.WaitGroup, nt *ticketMetadata) {
 		strings.ToLower(nt.ticketType), nt.ticket)
 }
 
-func (ctx *AppContext) UpdateTicketData(newAddedLowFeeTicketsMSA map[chainhash.Hash]string) {
-	ctx.Lock()
+func (spd *Stakepoold) UpdateTicketData(newAddedLowFeeTicketsMSA map[chainhash.Hash]string) {
+	spd.Lock()
 
 	// apply unconditional updates
 	for tickethash, msa := range newAddedLowFeeTicketsMSA {
 		// remove from ignored list if present
-		delete(ctx.IgnoredLowFeeTicketsMSA, tickethash)
+		delete(spd.IgnoredLowFeeTicketsMSA, tickethash)
 		// add to live list
-		ctx.LiveTicketsMSA[tickethash] = msa
+		spd.LiveTicketsMSA[tickethash] = msa
 	}
 
 	// if something is being deleted from the db by this update then
 	// we need to put it back on the ignored list
-	for th, m := range ctx.AddedLowFeeTicketsMSA {
+	for th, m := range spd.AddedLowFeeTicketsMSA {
 		_, exists := newAddedLowFeeTicketsMSA[th]
 		if !exists {
-			ctx.IgnoredLowFeeTicketsMSA[th] = m
+			spd.IgnoredLowFeeTicketsMSA[th] = m
 		}
 	}
 
-	ctx.AddedLowFeeTicketsMSA = newAddedLowFeeTicketsMSA
-	addedLowFeeTicketsCount := len(ctx.AddedLowFeeTicketsMSA)
-	ignoredLowFeeTicketsCount := len(ctx.IgnoredLowFeeTicketsMSA)
-	liveTicketsCount := len(ctx.LiveTicketsMSA)
-	ctx.Unlock()
+	spd.AddedLowFeeTicketsMSA = newAddedLowFeeTicketsMSA
+	addedLowFeeTicketsCount := len(spd.AddedLowFeeTicketsMSA)
+	ignoredLowFeeTicketsCount := len(spd.IgnoredLowFeeTicketsMSA)
+	liveTicketsCount := len(spd.LiveTicketsMSA)
+	spd.Unlock()
 	// Log ticket information outside of the handler.
 	go func() {
 		log.Infof("tickets loaded -- addedLowFee %v ignoredLowFee %v live %v "+
@@ -262,14 +266,14 @@ func (ctx *AppContext) UpdateTicketData(newAddedLowFeeTicketsMSA map[chainhash.H
 	}()
 }
 
-func (ctx *AppContext) UpdateTicketDataFromMySQL() error {
+func (spd *Stakepoold) UpdateTicketDataFromMySQL() error {
 	start := time.Now()
-	newAddedLowFeeTicketsMSA, err := ctx.UserData.MySQLFetchAddedLowFeeTickets()
+	newAddedLowFeeTicketsMSA, err := spd.UserData.MySQLFetchAddedLowFeeTickets()
 	log.Infof("MySQLFetchAddedLowFeeTickets took %v", time.Since(start))
 	if err != nil {
 		return err
 	}
-	ctx.UpdateTicketData(newAddedLowFeeTicketsMSA)
+	spd.UpdateTicketData(newAddedLowFeeTicketsMSA)
 	return nil
 }
 
@@ -277,14 +281,14 @@ func (ctx *AppContext) UpdateTicketDataFromMySQL() error {
 // performed because we are importing a brand new script, it shouldn't have any
 // associated history. Current block height is returned to indicate which height
 // the new user has registered.
-func (ctx *AppContext) ImportNewScript(script []byte) (int64, error) {
-	err := ctx.WalletConnection.RPCClient().ImportScriptRescanFrom(script, false, 0)
+func (spd *Stakepoold) ImportNewScript(script []byte) (int64, error) {
+	err := spd.WalletConnection.RPCClient().ImportScriptRescanFrom(script, false, 0)
 	if err != nil {
 		log.Errorf("ImportNewScript: ImportScriptRescanFrom rpc failed: %v", err)
 		return -1, err
 	}
 
-	_, bestBlockHeight, err := ctx.WalletConnection.RPCClient().GetBestBlock()
+	_, bestBlockHeight, err := spd.WalletConnection.RPCClient().GetBestBlock()
 	if err != nil {
 		log.Errorf("ImportNewScript: GetBestBlock rpc failed: %v", err)
 		return -1, err
@@ -296,11 +300,11 @@ func (ctx *AppContext) ImportNewScript(script []byte) (int64, error) {
 // will import all but one of the scripts without triggering a wallet rescan,
 // and finally trigger a rescan from the provided height after importing the
 // last one.
-func (ctx *AppContext) ImportMissingScripts(scripts [][]byte, rescanHeight int) error {
+func (spd *Stakepoold) ImportMissingScripts(scripts [][]byte, rescanHeight int) error {
 	// Import n-1 scripts without a rescan.
 	allButOne := scripts[:len(scripts)-1]
 	for _, script := range allButOne {
-		err := ctx.WalletConnection.RPCClient().ImportScriptRescanFrom(script, false, 0)
+		err := spd.WalletConnection.RPCClient().ImportScriptRescanFrom(script, false, 0)
 		if err != nil {
 			log.Errorf("ImportMissingScripts: ImportScript rpc failed: %v", err)
 			return err
@@ -309,7 +313,7 @@ func (ctx *AppContext) ImportMissingScripts(scripts [][]byte, rescanHeight int) 
 
 	// Import the last script and trigger a rescan
 	lastOne := scripts[len(scripts)-1]
-	err := ctx.WalletConnection.RPCClient().ImportScriptRescanFrom(lastOne, true, rescanHeight)
+	err := spd.WalletConnection.RPCClient().ImportScriptRescanFrom(lastOne, true, rescanHeight)
 	if err != nil {
 		log.Errorf("ImportMissingScripts: ImportScriptRescanFrom rpc failed: %v", err)
 		return err
@@ -320,7 +324,7 @@ func (ctx *AppContext) ImportMissingScripts(scripts [][]byte, rescanHeight int) 
 	return nil
 }
 
-func (ctx *AppContext) AddMissingTicket(ticketHash []byte) error {
+func (spd *Stakepoold) AddMissingTicket(ticketHash []byte) error {
 	log.Infof("AddMissingTicket: Adding ticket with hash %s", ticketHash)
 
 	hash, err := chainhash.NewHash(ticketHash)
@@ -329,13 +333,13 @@ func (ctx *AppContext) AddMissingTicket(ticketHash []byte) error {
 		return err
 	}
 
-	tx, err := ctx.WalletConnection.RPCClient().GetRawTransaction(hash)
+	tx, err := spd.WalletConnection.RPCClient().GetRawTransaction(hash)
 	if err != nil {
 		log.Errorf("AddMissingTicket: GetRawTransaction rpc failed: %v", err)
 		return err
 	}
 
-	err = ctx.WalletConnection.RPCClient().AddTicket(tx)
+	err = spd.WalletConnection.RPCClient().AddTicket(tx)
 	if err != nil {
 		log.Errorf("AddMissingTicket: AddTicket rpc failed: %v", err)
 		return err
@@ -344,8 +348,8 @@ func (ctx *AppContext) AddMissingTicket(ticketHash []byte) error {
 	return nil
 }
 
-func (ctx *AppContext) ListScripts() ([][]byte, error) {
-	scripts, err := ctx.WalletConnection.RPCClient().ListScripts()
+func (spd *Stakepoold) ListScripts() ([][]byte, error) {
+	scripts, err := spd.WalletConnection.RPCClient().ListScripts()
 	if err != nil {
 		log.Errorf("ListScripts: ListScripts rpc failed: %v", err)
 		return nil, err
@@ -356,7 +360,7 @@ func (ctx *AppContext) ListScripts() ([][]byte, error) {
 
 // CreateMultisig decodes the provided array of addresses, and then
 // passes them to dcrwallet to create a 1-of-N multisig address.
-func (ctx *AppContext) CreateMultisig(addresses []string) (*wallettypes.CreateMultiSigResult, error) {
+func (spd *Stakepoold) CreateMultisig(addresses []string) (*wallettypes.CreateMultiSigResult, error) {
 	decodedAddresses := make([]dcrutil.Address, len(addresses))
 
 	for i, addr := range addresses {
@@ -368,7 +372,7 @@ func (ctx *AppContext) CreateMultisig(addresses []string) (*wallettypes.CreateMu
 		decodedAddresses[i] = decodedAddress
 	}
 
-	result, err := ctx.WalletConnection.RPCClient().CreateMultisig(1, decodedAddresses)
+	result, err := spd.WalletConnection.RPCClient().CreateMultisig(1, decodedAddresses)
 	if err != nil {
 		log.Errorf("CreateMultisig: CreateMultisig rpc failed: %v", err)
 		return nil, err
@@ -377,8 +381,8 @@ func (ctx *AppContext) CreateMultisig(addresses []string) (*wallettypes.CreateMu
 	return result, nil
 }
 
-func (ctx *AppContext) AccountSyncAddressIndex(account string, branch uint32, index int) error {
-	err := ctx.WalletConnection.RPCClient().AccountSyncAddressIndex(account, branch, index)
+func (spd *Stakepoold) AccountSyncAddressIndex(account string, branch uint32, index int) error {
+	err := spd.WalletConnection.RPCClient().AccountSyncAddressIndex(account, branch, index)
 	if err != nil {
 		log.Errorf("AccountSyncAddressIndex: AccountSyncAddressIndex rpc failed: %v", err)
 		return err
@@ -387,8 +391,8 @@ func (ctx *AppContext) AccountSyncAddressIndex(account string, branch uint32, in
 	return nil
 }
 
-func (ctx *AppContext) GetTickets(includeImmature bool) ([]*chainhash.Hash, error) {
-	tickets, err := ctx.WalletConnection.RPCClient().GetTickets(includeImmature)
+func (spd *Stakepoold) GetTickets(includeImmature bool) ([]*chainhash.Hash, error) {
+	tickets, err := spd.WalletConnection.RPCClient().GetTickets(includeImmature)
 	if err != nil {
 		log.Errorf("GetTickets: GetTickets rpc failed: %v", err)
 		return nil, err
@@ -397,14 +401,14 @@ func (ctx *AppContext) GetTickets(includeImmature bool) ([]*chainhash.Hash, erro
 	return tickets, nil
 }
 
-func (ctx *AppContext) StakePoolUserInfo(multisigAddress string) (*wallettypes.StakePoolUserInfoResult, error) {
+func (spd *Stakepoold) StakePoolUserInfo(multisigAddress string) (*wallettypes.StakePoolUserInfoResult, error) {
 	decodedMultisig, err := dcrutil.DecodeAddress(multisigAddress)
 	if err != nil {
 		log.Errorf("StakePoolUserInfo: Address could not be decoded %v: %v", multisigAddress, err)
 		return nil, err
 	}
 
-	response, err := ctx.WalletConnection.RPCClient().StakePoolUserInfo(decodedMultisig)
+	response, err := spd.WalletConnection.RPCClient().StakePoolUserInfo(decodedMultisig)
 	if err != nil {
 		log.Errorf("StakePoolUserInfo: StakePoolUserInfo rpc failed: %v", err)
 		return nil, err
@@ -413,8 +417,8 @@ func (ctx *AppContext) StakePoolUserInfo(multisigAddress string) (*wallettypes.S
 	return response, nil
 }
 
-func (ctx *AppContext) WalletInfo() (*wallettypes.WalletInfoResult, error) {
-	response, err := ctx.WalletConnection.RPCClient().WalletInfo()
+func (spd *Stakepoold) WalletInfo() (*wallettypes.WalletInfoResult, error) {
+	response, err := spd.WalletConnection.RPCClient().WalletInfo()
 	if err != nil {
 		log.Errorf("WalletInfo: WalletInfo rpc failed: %v", err)
 		return nil, err
@@ -423,14 +427,14 @@ func (ctx *AppContext) WalletInfo() (*wallettypes.WalletInfoResult, error) {
 	return response, nil
 }
 
-func (ctx *AppContext) ValidateAddress(address string) (*wallettypes.ValidateAddressWalletResult, error) {
+func (spd *Stakepoold) ValidateAddress(address string) (*wallettypes.ValidateAddressWalletResult, error) {
 	addr, err := dcrutil.DecodeAddress(address)
 	if err != nil {
 		log.Errorf("ValidateAddress: ValidateAddress rpc failed: %v", err)
 		return nil, err
 	}
 
-	response, err := ctx.WalletConnection.RPCClient().ValidateAddress(addr)
+	response, err := spd.WalletConnection.RPCClient().ValidateAddress(addr)
 	if err != nil {
 		log.Errorf("ValidateAddress: ValidateAddress rpc failed: %v", err)
 		return nil, err
@@ -440,8 +444,8 @@ func (ctx *AppContext) ValidateAddress(address string) (*wallettypes.ValidateAdd
 }
 
 // GetStakeInfo performs the rpc command GetStakeInfo.
-func (ctx *AppContext) GetStakeInfo() (*wallettypes.GetStakeInfoResult, error) {
-	response, err := ctx.WalletConnection.RPCClient().GetStakeInfo()
+func (spd *Stakepoold) GetStakeInfo() (*wallettypes.GetStakeInfoResult, error) {
+	response, err := spd.WalletConnection.RPCClient().GetStakeInfo()
 	if err != nil {
 		log.Errorf("GetStakeInfo: GetStakeInfo rpc failed: %v", err)
 		return nil, err
@@ -450,26 +454,26 @@ func (ctx *AppContext) GetStakeInfo() (*wallettypes.GetStakeInfoResult, error) {
 	return response, nil
 }
 
-func (ctx *AppContext) UpdateUserData(newUserVotingConfig map[string]userdata.UserVotingConfig) {
-	ctx.Lock()
-	ctx.UserVotingConfig = newUserVotingConfig
-	ctx.Unlock()
+func (spd *Stakepoold) UpdateUserData(newUserVotingConfig map[string]userdata.UserVotingConfig) {
+	spd.Lock()
+	spd.UserVotingConfig = newUserVotingConfig
+	spd.Unlock()
 }
 
-func (ctx *AppContext) UpdateUserDataFromMySQL() error {
+func (spd *Stakepoold) UpdateUserDataFromMySQL() error {
 	start := time.Now()
-	newUserVotingConfig, err := ctx.UserData.MySQLFetchUserVotingConfig()
+	newUserVotingConfig, err := spd.UserData.MySQLFetchUserVotingConfig()
 	log.Infof("MySQLFetchUserVotingConfig took %v",
 		time.Since(start))
 	if err != nil {
 		return err
 	}
-	ctx.UpdateUserData(newUserVotingConfig)
+	spd.UpdateUserData(newUserVotingConfig)
 	return nil
 }
 
 // vote Generates a vote and send it off to the network.  This is a go routine!
-func (ctx *AppContext) vote(wg *sync.WaitGroup, blockHash *chainhash.Hash, blockHeight int64, w *ticketMetadata) {
+func (spd *Stakepoold) vote(wg *sync.WaitGroup, blockHash *chainhash.Hash, blockHeight int64, w *ticketMetadata) {
 	start := time.Now()
 
 	defer func() {
@@ -479,8 +483,8 @@ func (ctx *AppContext) vote(wg *sync.WaitGroup, blockHash *chainhash.Hash, block
 
 	// Ask wallet to generate vote result.
 	var res *wallettypes.GenerateVoteResult
-	res, w.err = ctx.WalletConnection.RPCClient().GenerateVote(blockHash, blockHeight,
-		w.ticket, w.config.VoteBits, ctx.VotingConfig.VoteBitsExtended)
+	res, w.err = spd.WalletConnection.RPCClient().GenerateVote(blockHash, blockHeight,
+		w.ticket, w.config.VoteBits, spd.VotingConfig.VoteBitsExtended)
 	if w.err != nil || res.Hex == "" {
 		return
 	}
@@ -500,7 +504,7 @@ func (ctx *AppContext) vote(wg *sync.WaitGroup, blockHash *chainhash.Hash, block
 
 	// Ask node to transmit raw transaction.
 	startSend := time.Now()
-	tx, err := ctx.NodeConnection.SendRawTransaction(newTx, false)
+	tx, err := spd.NodeConnection.SendRawTransaction(newTx, false)
 	if err != nil {
 		log.Infof("vote err %v", err)
 		w.err = err
@@ -512,7 +516,7 @@ func (ctx *AppContext) vote(wg *sync.WaitGroup, blockHash *chainhash.Hash, block
 
 // processNewTickets is invoked every time a new block is created. Any tickets
 // which matured in this block will be included in the parameter.
-func (ctx *AppContext) processNewTickets(nt NewTicketsForBlock) {
+func (spd *Stakepoold) processNewTickets(nt NewTicketsForBlock) {
 	start := time.Now()
 
 	log.Debugf("processNewTickets: Block %d contains %d newly matured tickets",
@@ -523,7 +527,7 @@ func (ctx *AppContext) processNewTickets(nt NewTicketsForBlock) {
 
 	var wg sync.WaitGroup // wait group for go routine exits
 
-	ctx.RLock()
+	spd.RLock()
 	for _, tickethash := range nt.NewTickets {
 		n := &ticketMetadata{
 			blockHash:   nt.BlockHash,
@@ -534,9 +538,9 @@ func (ctx *AppContext) processNewTickets(nt NewTicketsForBlock) {
 		newtickets = append(newtickets, n)
 
 		wg.Add(1)
-		go ctx.getticket(&wg, n)
+		go spd.getticket(&wg, n)
 	}
-	ctx.RUnlock()
+	spd.RUnlock()
 
 	wg.Wait()
 
@@ -556,7 +560,7 @@ func (ctx *AppContext) processNewTickets(nt NewTicketsForBlock) {
 			continue
 		}
 
-		ticketFeesValid, err := ctx.EvaluateStakePoolTicket(msgTx, int32(nt.BlockHeight))
+		ticketFeesValid, err := spd.EvaluateStakePoolTicket(msgTx, int32(nt.BlockHeight))
 
 		if err != nil {
 			log.Warnf("ignoring ticket %v for multisig %v due to error: %v", n.ticket, n.msa, err)
@@ -569,22 +573,22 @@ func (ctx *AppContext) processNewTickets(nt NewTicketsForBlock) {
 		}
 	}
 
-	ctx.Lock()
+	spd.Lock()
 	// update ignored low fee tickets
 	for ticket, msa := range newIgnoredLowFeeTickets {
-		ctx.IgnoredLowFeeTicketsMSA[ticket] = msa
+		spd.IgnoredLowFeeTicketsMSA[ticket] = msa
 	}
 
 	// update live tickets
 	for ticket, msa := range newLiveTickets {
-		ctx.LiveTicketsMSA[ticket] = msa
+		spd.LiveTicketsMSA[ticket] = msa
 	}
 
 	// update counts
-	addedLowFeeTicketsCount := len(ctx.AddedLowFeeTicketsMSA)
-	ignoredLowFeeTicketsCount := len(ctx.IgnoredLowFeeTicketsMSA)
-	liveTicketsCount := len(ctx.LiveTicketsMSA)
-	ctx.Unlock()
+	addedLowFeeTicketsCount := len(spd.AddedLowFeeTicketsMSA)
+	ignoredLowFeeTicketsCount := len(spd.IgnoredLowFeeTicketsMSA)
+	liveTicketsCount := len(spd.LiveTicketsMSA)
+	spd.Unlock()
 
 	// Log ticket information outside of the handler.
 	go func() {
@@ -611,7 +615,7 @@ func (ctx *AppContext) processNewTickets(nt NewTicketsForBlock) {
 // processSpentMissedTickets is invoked every time a new block is created. Any
 // tickets which are either spent or missed in this block will be included in
 // the parameter.
-func (ctx *AppContext) processSpentMissedTickets(smt SpentMissedTicketsForBlock) {
+func (spd *Stakepoold) processSpentMissedTickets(smt SpentMissedTicketsForBlock) {
 	start := time.Now()
 
 	// We use pointer because it is the fastest accessor.
@@ -619,7 +623,7 @@ func (ctx *AppContext) processSpentMissedTickets(smt SpentMissedTicketsForBlock)
 
 	var wg sync.WaitGroup // wait group for go routine exits
 
-	ctx.RLock()
+	spd.RLock()
 	for ticket, spent := range smt.SmTickets {
 		sm := &ticketMetadata{
 			blockHash:   smt.BlockHash,
@@ -631,9 +635,9 @@ func (ctx *AppContext) processSpentMissedTickets(smt SpentMissedTicketsForBlock)
 		smtickets = append(smtickets, sm)
 
 		wg.Add(1)
-		go ctx.getticket(&wg, sm)
+		go spd.getticket(&wg, sm)
 	}
-	ctx.RUnlock()
+	spd.RUnlock()
 
 	wg.Wait()
 
@@ -658,18 +662,18 @@ func (ctx *AppContext) processSpentMissedTickets(smt SpentMissedTicketsForBlock)
 	var ticketCountNew int
 	var ticketCountOld int
 
-	ctx.Lock()
-	ticketCountOld = len(ctx.LiveTicketsMSA)
+	spd.Lock()
+	ticketCountOld = len(spd.LiveTicketsMSA)
 	for _, ticket := range missedtickets {
-		delete(ctx.IgnoredLowFeeTicketsMSA, *ticket)
-		delete(ctx.LiveTicketsMSA, *ticket)
+		delete(spd.IgnoredLowFeeTicketsMSA, *ticket)
+		delete(spd.LiveTicketsMSA, *ticket)
 	}
 	for _, ticket := range spenttickets {
-		delete(ctx.IgnoredLowFeeTicketsMSA, *ticket)
-		delete(ctx.LiveTicketsMSA, *ticket)
+		delete(spd.IgnoredLowFeeTicketsMSA, *ticket)
+		delete(spd.LiveTicketsMSA, *ticket)
 	}
-	ticketCountNew = len(ctx.LiveTicketsMSA)
-	ctx.Unlock()
+	ticketCountNew = len(spd.LiveTicketsMSA)
+	spd.Unlock()
 
 	// Log ticket information outside of the handler.
 	go func() {
@@ -692,7 +696,7 @@ func (ctx *AppContext) processSpentMissedTickets(smt SpentMissedTicketsForBlock)
 // voting.  The function requires ASAP processing for each vote and therefore
 // it is not sequential and hard to read.  This is unfortunate but a reality of
 // speeding up code.
-func (ctx *AppContext) ProcessWinningTickets(wt WinningTicketsForBlock) {
+func (spd *Stakepoold) ProcessWinningTickets(wt WinningTicketsForBlock) {
 	start := time.Now()
 
 	log.Debugf("ProcessWinningTickets: Block %d contains %d winning tickets", wt.BlockHeight, len(wt.WinningTickets))
@@ -702,19 +706,19 @@ func (ctx *AppContext) ProcessWinningTickets(wt WinningTicketsForBlock) {
 
 	var wg sync.WaitGroup // wait group for go routine exits
 
-	ctx.RLock()
+	spd.RLock()
 	for _, ticket := range wt.WinningTickets {
 		// Look up multi sig address.
-		msa, ok := ctx.LiveTicketsMSA[*ticket]
+		msa, ok := spd.LiveTicketsMSA[*ticket]
 		if !ok {
 			log.Debugf("ProcessWinningTickets: unmanaged winning ticket: %v", ticket)
-			if ctx.Testing {
+			if spd.Testing {
 				panic("boom")
 			}
 			continue
 		}
 
-		voteCfg, ok := ctx.UserVotingConfig[msa]
+		voteCfg, ok := spd.UserVotingConfig[msa]
 		if !ok {
 			// Use defaults if not found.
 			log.Warnf("ProcessWinningTickets: vote config not found for %v using defaults",
@@ -722,21 +726,21 @@ func (ctx *AppContext) ProcessWinningTickets(wt WinningTicketsForBlock) {
 			voteCfg = userdata.UserVotingConfig{
 				Userid:          0,
 				MultiSigAddress: msa,
-				VoteBits:        ctx.VotingConfig.VoteBits,
-				VoteBitsVersion: ctx.VotingConfig.VoteVersion,
+				VoteBits:        spd.VotingConfig.VoteBits,
+				VoteBitsVersion: spd.VotingConfig.VoteVersion,
 			}
-		} else if voteCfg.VoteBitsVersion != ctx.VotingConfig.VoteVersion {
+		} else if voteCfg.VoteBitsVersion != spd.VotingConfig.VoteVersion {
 			// If the user's voting config has a vote version that
 			// is different from our global vote version that we
 			// plucked from dcrwallet walletinfo then just use the
 			// default votebits.
-			voteCfg.VoteBits = ctx.VotingConfig.VoteBits
+			voteCfg.VoteBits = spd.VotingConfig.VoteBits
 			log.Infof("ProcessWinningTickets: userid %v multisigaddress %v vote "+
 				"version mismatch user %v stakepoold "+
 				"%v using votebits %d",
 				voteCfg.Userid, voteCfg.MultiSigAddress,
 				voteCfg.VoteBitsVersion,
-				ctx.VotingConfig.VoteVersion,
+				spd.VotingConfig.VoteVersion,
 				voteCfg.VoteBits)
 		}
 
@@ -748,7 +752,7 @@ func (ctx *AppContext) ProcessWinningTickets(wt WinningTicketsForBlock) {
 		winners = append(winners, w)
 
 		// When testing we don't send the tickets.
-		if ctx.Testing {
+		if spd.Testing {
 			continue
 		}
 
@@ -756,10 +760,10 @@ func (ctx *AppContext) ProcessWinningTickets(wt WinningTicketsForBlock) {
 		log.Debugf("ProcessWinningTickets: calling GenerateVote with blockHash %v blockHeight %v "+
 			"ticket %v VoteBits %v VoteBitsExtended %v ",
 			wt.BlockHash, wt.BlockHeight, w.ticket, w.config.VoteBits,
-			ctx.VotingConfig.VoteBitsExtended)
-		go ctx.vote(&wg, wt.BlockHash, wt.BlockHeight, w)
+			spd.VotingConfig.VoteBitsExtended)
+		go spd.vote(&wg, wt.BlockHash, wt.BlockHeight, w)
 	}
-	ctx.RUnlock()
+	spd.RUnlock()
 
 	wg.Wait()
 
@@ -794,42 +798,42 @@ func (ctx *AppContext) ProcessWinningTickets(wt WinningTicketsForBlock) {
 	}()
 }
 
-func (ctx *AppContext) NewTicketHandler(shutdownContext context.Context, wg *sync.WaitGroup) {
+func (spd *Stakepoold) NewTicketHandler(shutdownContext context.Context, wg *sync.WaitGroup) {
 	wg.Add(1)
 	defer wg.Done()
 
 	for {
 		select {
-		case nt := <-ctx.NewTicketsChan:
-			go ctx.processNewTickets(nt)
+		case nt := <-spd.NewTicketsChan:
+			go spd.processNewTickets(nt)
 		case <-shutdownContext.Done():
 			return
 		}
 	}
 }
 
-func (ctx *AppContext) SpentmissedTicketHandler(shutdownContext context.Context, wg *sync.WaitGroup) {
+func (spd *Stakepoold) SpentmissedTicketHandler(shutdownContext context.Context, wg *sync.WaitGroup) {
 	wg.Add(1)
 	defer wg.Done()
 
 	for {
 		select {
-		case smt := <-ctx.SpentmissedTicketsChan:
-			go ctx.processSpentMissedTickets(smt)
+		case smt := <-spd.SpentmissedTicketsChan:
+			go spd.processSpentMissedTickets(smt)
 		case <-shutdownContext.Done():
 			return
 		}
 	}
 }
 
-func (ctx *AppContext) WinningTicketHandler(shutdownContext context.Context, wg *sync.WaitGroup) {
+func (spd *Stakepoold) WinningTicketHandler(shutdownContext context.Context, wg *sync.WaitGroup) {
 	wg.Add(1)
 	defer wg.Done()
 
 	for {
 		select {
-		case wt := <-ctx.WinningTicketsChan:
-			go ctx.ProcessWinningTickets(wt)
+		case wt := <-spd.WinningTicketsChan:
+			go spd.ProcessWinningTickets(wt)
 		case <-shutdownContext.Done():
 			return
 		}

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/gorilla/websocket v1.4.1 // indirect
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/jrick/logrotate v1.0.0
-	github.com/kr/pretty v0.1.0 // indirect
 	github.com/lib/pq v1.2.0 // indirect
 	github.com/mattn/go-sqlite3 v1.11.0 // indirect
 	github.com/onsi/ginkgo v1.10.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,7 @@ github.com/decred/dcrd/dcrec/secp256k1 v1.0.0/go.mod h1:JPMFscGlgXTV684jxQNDijae
 github.com/decred/dcrd/dcrec/secp256k1 v1.0.1/go.mod h1:lhu4eZFSfTJWUnR3CFRcpD+Vta0KUAqnhTsTksHXgy0=
 github.com/decred/dcrd/dcrec/secp256k1 v1.0.2 h1:awk7sYJ4pGWmtkiGHFfctztJjHMKGLV8jctGQhAbKe0=
 github.com/decred/dcrd/dcrec/secp256k1 v1.0.2/go.mod h1:CHTUIVfmDDd0KFVFpNX1pFVCBUegxW387nN0IGwNKR0=
+github.com/decred/dcrd/dcrjson v1.0.0 h1:50DnA0XeV2JrQXoHh43TCKmH+kz2gHjZ1Mj/Pdk7Oz0=
 github.com/decred/dcrd/dcrjson v1.0.0/go.mod h1:ozddIaeF+EAvZZvFuB3zpfxhyxBGfvbt22crQh+PYuI=
 github.com/decred/dcrd/dcrjson/v2 v2.0.0/go.mod h1:FYueNy8BREAFq04YNEwcTsmGFcNqY+ehUUO81w2igi4=
 github.com/decred/dcrd/dcrjson/v3 v3.0.0 h1:yDrNFvyn2l/557iZHB236jTqQjAmhZnVaFgMb2vm0UM=


### PR DESCRIPTION
I do not think that context.go belongs in the rpc package.  If it were just relaying rpc commands, sure, but it does and will do more.  The name "context" also conflicts with context.Context, which we want to start using to pass shutdowns and "request-scoped values across API boundaries and between processes"

This pr moves context to its own package named stakepool, renames the main struct Stakepool, and renames all references to it stakepool.

this work is on top of #528 