### PR TITLE
clean up LoadTemplates and link to explorer on stats page

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/decred/dcrstakepool
 
+go 1.12
+
 require (
 	github.com/DATA-DOG/go-sqlmock v1.3.3
 	github.com/apoydence/onpar v0.0.0-20190519213022-ee068f8ea4d1 // indirect

--- a/harness.sh
+++ b/harness.sh
@@ -154,6 +154,7 @@ walletpassword=${RPC_PASS}
 testnet=true
 appdata=${NODES_ROOT}/stakepoold-${i}
 rpclisten=${STAKEPOOLD_RPC_LISTEN}
+debuglevel=debug
 EOF
 
     echo "Starting stakepoold-${i}"
@@ -185,6 +186,7 @@ adminips=${DCRSTAKEPOOL_ADMIN_IPS}
 adminuserids=${DCRSTAKEPOOL_ADMIN_IDS}
 stakepooldhosts=${ALL_STAKEPOOLDS}
 stakepooldcerts=${ALL_STAKEPOOLD_RPC_CERTS}
+debuglevel=debug
 EOF
 
 tmux new-window -t $SESSION -n "dcrstakepool"

--- a/system/core.go
+++ b/system/core.go
@@ -62,6 +62,19 @@ func (application *Application) Init(APISecret, baseURL, cookieSecret string,
 	application.APISecret = APISecret
 }
 
+var funcMap = template.FuncMap{
+	"times": func(a, b float64) float64 {
+		return a * b
+	},
+	"netname": func(network string) string {
+		net := strings.ToLower(network)
+		if strings.HasPrefix(net, "testnet") {
+			return "testnet"
+		}
+		return net
+	},
+}
+
 func (application *Application) LoadTemplates(templatePath string) error {
 	var templates []string
 
@@ -82,17 +95,9 @@ func (application *Application) LoadTemplates(templatePath string) error {
 		return err
 	}
 
-	// Since template.Must panics with non-nil error, it is much more
-	// informative to pass the error to the caller (runMain) to log it and exit
-	// gracefully.
-	httpTemplates, err := template.ParseFiles(templates...)
-	if err != nil {
-		return err
-	}
-
-	application.Template = template.Must(httpTemplates, nil)
 	application.TemplatesPath = templatePath
-	return nil
+	application.Template, err = template.New("vsp").Funcs(funcMap).ParseFiles(templates...)
+	return err
 }
 
 func (application *Application) Close() {

--- a/views/stats.html
+++ b/views/stats.html
@@ -62,7 +62,7 @@
 					<div class="row">
 						<div class="col text-center bg-white py-2">
 							<p class="font-weight-bold text--size-13 mb-0">Ticket Price</p>
-							<p class="mb-0 text--size-13"><a href="https://dcrdata.decred.org/charts?chart=ticket-price&zoom=month" target="_blank" rel="noopener noreferrer">{{printf "%0.2f" .StakeInfo.Difficulty}}&nbsp;DCR</a></p>
+							<p class="mb-0 text--size-13"><a href="https://{{netname $.Network}}.dcrdata.org/charts?chart=ticket-price&zoom=month" target="_blank" rel="noopener noreferrer">{{printf "%0.2f" .StakeInfo.Difficulty}}&nbsp;DCR</a></p>
 						</div>
 						<div class="col text-center bg-white py-2">
 							<p class="font-weight-bold text--size-13 mb-0">Pool Size</p>

--- a/views/stats.html
+++ b/views/stats.html
@@ -33,11 +33,11 @@
 							<p class="mb-0 text--size-13">{{ .StakeInfo.ProportionMissed }}</p>
 						</div>
 						<div class="col text-center bg-white py-2">
-							<p class="font-weight-bold text--size-13 mb-0">Revoked Ticket</p>
+							<p class="font-weight-bold text--size-13 mb-0">Revoked Tickets</p>
 							<p class="mb-0 text--size-13">{{ .StakeInfo.Revoked }}</p>
 						</div>
 						<div class="col text-center bg-white py-2">
-							<p class="font-weight-bold text--size-13 mb-0">Pool Fees</p>
+							<p class="font-weight-bold text--size-13 mb-0">VSP Fees</p>
 							<p class="mb-0 text--size-13">{{ .PoolFees }}%</p>
 						</div>
 						<div class="col text-center bg-white py-2">
@@ -62,15 +62,15 @@
 					<div class="row">
 						<div class="col text-center bg-white py-2">
 							<p class="font-weight-bold text--size-13 mb-0">Ticket Price</p>
-							<p class="mb-0 text--size-13">{{printf "%0.2f" .StakeInfo.Difficulty}}&nbsp;DCR</p>
+							<p class="mb-0 text--size-13"><a href="https://dcrdata.decred.org/charts?chart=ticket-price&zoom=month" target="_blank" rel="noopener noreferrer">{{printf "%0.2f" .StakeInfo.Difficulty}}&nbsp;DCR</a></p>
 						</div>
 						<div class="col text-center bg-white py-2">
 							<p class="font-weight-bold text--size-13 mb-0">Pool Size</p>
 							<p class="mb-0 text--size-13">{{ .StakeInfo.PoolSize }}</p>
 						</div>
 						<div class="col text-center bg-white mb-3 py-2">
-							<p class="font-weight-bold text--size-13 mb-0">AllMempoolTix</p>
-							<p class="mb-0 text--size-13">{{ .StakeInfo.AllMempoolTix }}</p>
+							<p class="font-weight-bold text--size-13 mb-0">Tickets in Mempool</p>
+							<p class="mb-0 text--size-13"><a href="https://{{netname $.Network}}.dcrdata.org/mempool" target="_blank" rel="noopener noreferrer">{{ .StakeInfo.AllMempoolTix }}</a></p>
 						</div>
 						<div class="col text-center bg-white mb-3 py-2">
 							<p class="font-weight-bold text--size-13 mb-0">Block Height</p>


### PR DESCRIPTION
Previously, `template.Must(httpTemplates, nil)` was pointless (`err=nil`).
This assigns the parsed templates directly to the `Templates` field.

Also define a template function map for more involved template tasks.
e.g. On the stats page, use the `netname` function for links. This could
also be done prior to executing the template, but it may be desirable
to have the actual network name with any number suffix (e.g. testnet3)
still available in the `Network` data field.

Add `debuglevel=debug` to the stakepoold and dcrstakepool config used
in harness.sh.