### PR TITLE
Simplify construction of dcrdata urls

### DIFF
--- a/controllers/main.go
+++ b/controllers/main.go
@@ -179,6 +179,12 @@ func (controller *MainController) getNetworkName() string {
 	return controller.Cfg.NetParams.Name
 }
 
+// DCRDataURL returns a URL for accessing dcrdata. It will automatically detect
+// mainnet or testnet depending on current config.
+func (controller *MainController) DCRDataURL() string {
+	return fmt.Sprintf("https://%s.dcrdata.org", controller.getNetworkName())
+}
+
 // agendas returns agendas and their statuses. Fetches agenda status from
 // dcrdata.org if past agenda.Timer limit from previous fetch. Caches agenda
 // data for agendasCacheLife. This method is safe for concurrent use.
@@ -190,7 +196,7 @@ func (controller *MainController) agendas() []agenda {
 		return *agendasCache.agendas
 	}
 	agendasCache.timer = now.Add(agendasCacheLife)
-	url := fmt.Sprintf("https://%s.dcrdata.org/api/agendas", controller.getNetworkName())
+	url := fmt.Sprintf("%s/api/agendas", controller.DCRDataURL())
 	agendaInfos, err := dcrDataAgendas(url)
 	if err != nil {
 		// Ensure the next call tries to fetch statuses again.
@@ -896,7 +902,7 @@ func (controller *MainController) AdminTickets(c web.C, r *http.Request) (string
 
 	c.Env["Admin"] = isAdmin
 	c.Env["IsAdminTickets"] = true
-	c.Env["Network"] = controller.getNetworkName()
+	c.Env["DCRDataURL"] = controller.DCRDataURL()
 
 	c.Env["FlashError"] = session.Flashes("adminTicketsError")
 	c.Env["FlashSuccess"] = session.Flashes("adminTicketsSuccess")
@@ -1740,7 +1746,7 @@ func (controller *MainController) Stats(c web.C, r *http.Request) (string, int) 
 		return "/error", http.StatusSeeOther
 	}
 
-	c.Env["Network"] = controller.Cfg.NetParams.Name
+	c.Env["DCRDataURL"] = controller.DCRDataURL()
 
 	c.Env["PoolEmail"] = controller.Cfg.PoolEmail
 	c.Env["PoolFees"] = controller.Cfg.PoolFees
@@ -1822,7 +1828,7 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 	}
 
 	c.Env["IsTickets"] = true
-	c.Env["Network"] = controller.getNetworkName()
+	c.Env["DCRDataURL"] = controller.DCRDataURL()
 	c.Env["Title"] = "Decred VSP - Tickets"
 
 	dbMap := controller.GetDbMap(c)

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -82,6 +82,7 @@ type MainController struct {
 	Cfg            *Config
 	captchaHandler *CaptchaHandler
 	voteVersion    uint32
+	DCRDataURL     string
 }
 
 // agendasCache holds the current available agendas for agendasCacheLife. Should
@@ -165,6 +166,8 @@ func NewMainController(cfg *Config) (*MainController, error) {
 
 	mc.voteVersion = lastVersion
 
+	mc.DCRDataURL = fmt.Sprintf("https://%s.dcrdata.org", mc.getNetworkName())
+
 	return mc, nil
 }
 
@@ -179,12 +182,6 @@ func (controller *MainController) getNetworkName() string {
 	return controller.Cfg.NetParams.Name
 }
 
-// DCRDataURL returns a URL for accessing dcrdata. It will automatically detect
-// mainnet or testnet depending on current config.
-func (controller *MainController) DCRDataURL() string {
-	return fmt.Sprintf("https://%s.dcrdata.org", controller.getNetworkName())
-}
-
 // agendas returns agendas and their statuses. Fetches agenda status from
 // dcrdata.org if past agenda.Timer limit from previous fetch. Caches agenda
 // data for agendasCacheLife. This method is safe for concurrent use.
@@ -196,7 +193,7 @@ func (controller *MainController) agendas() []agenda {
 		return *agendasCache.agendas
 	}
 	agendasCache.timer = now.Add(agendasCacheLife)
-	url := fmt.Sprintf("%s/api/agendas", controller.DCRDataURL())
+	url := fmt.Sprintf("%s/api/agendas", controller.DCRDataURL)
 	agendaInfos, err := dcrDataAgendas(url)
 	if err != nil {
 		// Ensure the next call tries to fetch statuses again.
@@ -902,7 +899,7 @@ func (controller *MainController) AdminTickets(c web.C, r *http.Request) (string
 
 	c.Env["Admin"] = isAdmin
 	c.Env["IsAdminTickets"] = true
-	c.Env["DCRDataURL"] = controller.DCRDataURL()
+	c.Env["DCRDataURL"] = controller.DCRDataURL
 
 	c.Env["FlashError"] = session.Flashes("adminTicketsError")
 	c.Env["FlashSuccess"] = session.Flashes("adminTicketsSuccess")
@@ -1746,7 +1743,7 @@ func (controller *MainController) Stats(c web.C, r *http.Request) (string, int) 
 		return "/error", http.StatusSeeOther
 	}
 
-	c.Env["DCRDataURL"] = controller.DCRDataURL()
+	c.Env["DCRDataURL"] = controller.DCRDataURL
 
 	c.Env["PoolEmail"] = controller.Cfg.PoolEmail
 	c.Env["PoolFees"] = controller.Cfg.PoolFees
@@ -1828,7 +1825,7 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 	}
 
 	c.Env["IsTickets"] = true
-	c.Env["DCRDataURL"] = controller.DCRDataURL()
+	c.Env["DCRDataURL"] = controller.DCRDataURL
 	c.Env["Title"] = "Decred VSP - Tickets"
 
 	dbMap := controller.GetDbMap(c)

--- a/system/core.go
+++ b/system/core.go
@@ -67,13 +67,6 @@ var funcMap = template.FuncMap{
 	"times": func(a, b float64) float64 {
 		return a * b
 	},
-	"netname": func(network string) string {
-		net := strings.ToLower(network)
-		if strings.HasPrefix(net, "testnet") {
-			return "testnet"
-		}
-		return net
-	},
 }
 
 func (application *Application) LoadTemplates(templatePath string) error {

--- a/views/admin/tickets.html
+++ b/views/admin/tickets.html
@@ -47,7 +47,7 @@
 										<td class="pl-sm-5 pl-4 align-middle"><img src="/assets/images/group-1119.svg" alt=""></th>
 										<td class="align-middle"><pre class="m-0">{{printf "%.16s" $tickethash}}...</pre></td>
 										<td class="align-middle"><pre class="m-0">{{$msa}}</pre></td>
-										<td class="align-middle"><a href="https://{{$.Network}}.dcrdata.org/tx/{{$tickethash}}" rel="noopener noreferrer">Block Explorer</a></td>
+										<td class="align-middle"><a href="{{ $.DCRDataURL }}/tx/{{$tickethash}}" rel="noopener noreferrer">Block Explorer</a></td>
 										<td class="align-middle">
 											<label class="control control-checkbox">
 												<input type="checkbox" name="tickets[]" value="{{$tickethash}}">
@@ -94,7 +94,7 @@
 										<td class="pl-sm-5 pl-4 align-middle"><img src="/assets/images/group-1119.svg" alt=""></th>
 										<td class="align-middle"><pre class="m-0">{{printf "%.16s" $tickethash}}...</pre></td>
 										<td class="align-middle"><pre class="m-0">{{$msa}}</pre></td>
-										<td class="align-middle"><a href="https://{{$.Network}}.dcrdata.org/tx/{{$tickethash}}" rel="noopener noreferrer">Block Explorer</a></td>
+										<td class="align-middle"><a href="{{ $.DCRDataURL }}/tx/{{$tickethash}}" rel="noopener noreferrer">Block Explorer</a></td>
 										<td class="align-middle">
 											<label class="control control-checkbox">
 												<input type="checkbox" name="tickets[]" value="{{$tickethash}}">

--- a/views/stats.html
+++ b/views/stats.html
@@ -62,7 +62,7 @@
 					<div class="row">
 						<div class="col text-center bg-white py-2">
 							<p class="font-weight-bold text--size-13 mb-0">Ticket Price</p>
-							<p class="mb-0 text--size-13"><a href="https://{{netname $.Network}}.dcrdata.org/charts?chart=ticket-price&zoom=month" target="_blank" rel="noopener noreferrer">{{printf "%0.2f" .StakeInfo.Difficulty}}&nbsp;DCR</a></p>
+							<p class="mb-0 text--size-13"><a href="{{ $.DCRDataURL }}/charts?chart=ticket-price&zoom=month" target="_blank" rel="noopener noreferrer">{{printf "%0.2f" .StakeInfo.Difficulty}}&nbsp;DCR</a></p>
 						</div>
 						<div class="col text-center bg-white py-2">
 							<p class="font-weight-bold text--size-13 mb-0">Pool Size</p>
@@ -70,7 +70,7 @@
 						</div>
 						<div class="col text-center bg-white mb-3 py-2">
 							<p class="font-weight-bold text--size-13 mb-0">Tickets in Mempool</p>
-							<p class="mb-0 text--size-13"><a href="https://{{netname $.Network}}.dcrdata.org/mempool" target="_blank" rel="noopener noreferrer">{{ .StakeInfo.AllMempoolTix }}</a></p>
+							<p class="mb-0 text--size-13"><a href="{{ $.DCRDataURL }}/mempool" target="_blank" rel="noopener noreferrer">{{ .StakeInfo.AllMempoolTix }}</a></p>
 						</div>
 						<div class="col text-center bg-white mb-3 py-2">
 							<p class="font-weight-bold text--size-13 mb-0">Block Height</p>

--- a/views/tickets.html
+++ b/views/tickets.html
@@ -43,7 +43,7 @@
 							<div>
 								<img src="/assets/images/group-1120.svg" alt="">
 								<span><pre class="m-0 d-inline">{{printf "%.16s" $data.Ticket}}...</pre></span>
-								<a style="margin-left:50px; margin-right:50px" href="https://{{$.Network}}.dcrdata.org/tx/{{$data.Ticket}}" rel="noopener noreferrer">Block Explorer</a>
+								<a style="margin-left:50px; margin-right:50px" href="{{ $.DCRDataURL }}/tx/{{$data.Ticket}}" rel="noopener noreferrer">Block Explorer</a>
 								<span>Purchase height:&nbsp;{{$data.TicketHeight}}</span>
 							</div>
 							{{else}}
@@ -68,7 +68,7 @@
 							<div>
 								<img src="/assets/images/group-1119.svg" alt="">
 								<span><pre class="m-0 d-inline">{{printf "%.16s" $data.Ticket}}...</pre></span>
-								<a style="margin-left:50px; margin-right:50px" href="https://{{$.Network}}.dcrdata.org/tx/{{$data.Ticket}}" rel="noopener noreferrer">Block Explorer</a>
+								<a style="margin-left:50px; margin-right:50px" href="{{ $.DCRDataURL }}/tx/{{$data.Ticket}}" rel="noopener noreferrer">Block Explorer</a>
 								<span>Purchase height:&nbsp;{{$data.TicketHeight}}</span>
 							</div>
 							{{else}}
@@ -100,7 +100,7 @@
 								<div>
 									<img src="/assets/images/symbol-8-1.svg" alt="">
 									<span><pre class="m-0 d-inline">{{printf "%.16s" $data.Ticket}}...</pre></span>
-									<a style="margin-left:50px; margin-right:50px" href="https://{{$.Network}}.dcrdata.org/tx/{{$data.Ticket}}" rel="noopener noreferrer">Block Explorer</a>
+									<a style="margin-left:50px; margin-right:50px" href="{{ $.DCRDataURL }}/tx/{{$data.Ticket}}" rel="noopener noreferrer">Block Explorer</a>
 									<span>Voted height:&nbsp;{{$data.SpentByHeight}}</span>
 								</div>
 								{{else}}
@@ -125,7 +125,7 @@
 									<div>
 										<img src="/assets/images/symbol-9-1.svg" alt="">
 										<span><pre class="m-0 d-inline">{{printf "%.16s" $data.Ticket}}...</pre></span>
-										<a style="margin-left:50px; margin-right:50px" href="https://{{$.Network}}.dcrdata.org/tx/{{$data.Ticket}}" rel="noopener noreferrer">Block Explorer</a>
+										<a style="margin-left:50px; margin-right:50px" href="{{ $.DCRDataURL }}/tx/{{$data.Ticket}}" rel="noopener noreferrer">Block Explorer</a>
 										<span>Revoked height:&nbsp;{{$data.SpentByHeight}}</span>
 									</div>
 								{{else}}
@@ -150,7 +150,7 @@
 								<div>
 									<img src="/assets/images/symbol-5-1.svg" alt="">
 									<span><pre class="m-0 d-inline">{{printf "%.16s" $data.Ticket}}...</pre></span>
-									<a style="margin-left:50px; margin-right:50px" href="https://{{$.Network}}.dcrdata.org/tx/{{$data.Ticket}}" rel="noopener noreferrer">Block Explorer</a>
+									<a style="margin-left:50px; margin-right:50px" href="{{ $.DCRDataURL }}/tx/{{$data.Ticket}}" rel="noopener noreferrer">Block Explorer</a>
 									<span>Revoked height:&nbsp;{{$data.SpentByHeight}}</span>
 								</div>
 								{{else}}
@@ -176,7 +176,7 @@
 								<div>
 									<img src="/assets/images/symbol-5-1-1.svg" alt="">
 									<span><pre class="m-0 d-inline">{{printf "%.16s" $data.Ticket}}...</pre></span>
-									<a style="margin-left:50px; margin-right:50px" href="https://{{$.Network}}.dcrdata.org/tx/{{$data.Ticket}}" rel="noopener noreferrer">Block Explorer</a>
+									<a style="margin-left:50px; margin-right:50px" href="{{ $.DCRDataURL }}/tx/{{$data.Ticket}}" rel="noopener noreferrer">Block Explorer</a>
 								</div>
 								{{else}}
 									<div class="accordion__empty">


### PR DESCRIPTION
The dcrdata URL is now only built in one location rather than scattered
throughout the templates.