### PR TITLE
stakepoold: Move rpc/rpcserver to rpc/server

### DIFF
--- a/backend/stakepoold/log.go
+++ b/backend/stakepoold/log.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/decred/dcrstakepool/backend/stakepoold/rpc/rpcserver"
+	"github.com/decred/dcrstakepool/backend/stakepoold/rpc/server"
 	"github.com/decred/dcrstakepool/backend/stakepoold/stakepool"
 	"github.com/decred/dcrstakepool/backend/stakepoold/userdata"
 	"github.com/decred/slog"
@@ -62,7 +62,7 @@ var subsystemLoggers = map[string]slog.Logger{
 // Initialize package-global logger variables.
 func init() {
 	userdata.UseLogger(dbLog)
-	rpcserver.UseLogger(grpcLog)
+	server.UseLogger(grpcLog)
 	stakepool.UseLogger(stakepoolLog)
 }
 

--- a/backend/stakepoold/rpc/server/log.go
+++ b/backend/stakepoold/rpc/server/log.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package rpcserver
+package server
 
 import "github.com/decred/slog"
 

--- a/backend/stakepoold/rpc/server/server.go
+++ b/backend/stakepoold/rpc/server/server.go
@@ -3,14 +3,14 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-// Package rpcserver implements the RPC API and is used by the main package to
+// Package server implements the RPC API and is used by the main package to
 // start gRPC services.
 //
 // Full documentation of the API implemented by this package is maintained in a
 // language-agnostic document:
 //
 // TODO Document gRPC API like dcrwallet once the API is stable
-package rpcserver
+package server
 
 import (
 	"time"


### PR DESCRIPTION
depends on #529 

Suggested by @jholdstock to use the nameing convention:
rpc/server
rpc/client

This moves rpc/rpcserver -> rpc/server as the second rpc is redundant

The current stakepool/client.go file is a wrapper and will be removed asap. I don't think it's worth the trouble to move it now tbh. I will if someone thinks otherwise though.