### PR TITLE
params: Remove unused WalletRPCServerPort

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/gorilla/websocket v1.4.1 // indirect
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/jrick/logrotate v1.0.0
-	github.com/kr/pretty v0.1.0 // indirect
 	github.com/lib/pq v1.2.0 // indirect
 	github.com/mattn/go-sqlite3 v1.11.0 // indirect
 	github.com/onsi/ginkgo v1.10.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,7 @@ github.com/decred/dcrd/dcrec/secp256k1 v1.0.0/go.mod h1:JPMFscGlgXTV684jxQNDijae
 github.com/decred/dcrd/dcrec/secp256k1 v1.0.1/go.mod h1:lhu4eZFSfTJWUnR3CFRcpD+Vta0KUAqnhTsTksHXgy0=
 github.com/decred/dcrd/dcrec/secp256k1 v1.0.2 h1:awk7sYJ4pGWmtkiGHFfctztJjHMKGLV8jctGQhAbKe0=
 github.com/decred/dcrd/dcrec/secp256k1 v1.0.2/go.mod h1:CHTUIVfmDDd0KFVFpNX1pFVCBUegxW387nN0IGwNKR0=
+github.com/decred/dcrd/dcrjson v1.0.0 h1:50DnA0XeV2JrQXoHh43TCKmH+kz2gHjZ1Mj/Pdk7Oz0=
 github.com/decred/dcrd/dcrjson v1.0.0/go.mod h1:ozddIaeF+EAvZZvFuB3zpfxhyxBGfvbt22crQh+PYuI=
 github.com/decred/dcrd/dcrjson/v2 v2.0.0/go.mod h1:FYueNy8BREAFq04YNEwcTsmGFcNqY+ehUUO81w2igi4=
 github.com/decred/dcrd/dcrjson/v3 v3.0.0 h1:yDrNFvyn2l/557iZHB236jTqQjAmhZnVaFgMb2vm0UM=

--- a/params.go
+++ b/params.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
+// Copyright (c) 2015-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -19,7 +19,6 @@ var activeNetParams = &mainNetParams
 type params struct {
 	*chaincfg.Params
 	StakepooldRPCServerPort string
-	WalletRPCServerPort     string
 }
 
 // mainNetParams contains parameters specific to the main network
@@ -31,7 +30,6 @@ type params struct {
 var mainNetParams = params{
 	Params:                  &chaincfg.MainNetParams,
 	StakepooldRPCServerPort: "9113",
-	WalletRPCServerPort:     "9110",
 }
 
 // testNet3Params contains parameters specific to the test network (version 0)
@@ -41,7 +39,6 @@ var mainNetParams = params{
 var testNet3Params = params{
 	Params:                  &chaincfg.TestNet3Params,
 	StakepooldRPCServerPort: "19113",
-	WalletRPCServerPort:     "19110",
 }
 
 // simNetParams contains parameters specific to the simulation test network
@@ -49,7 +46,6 @@ var testNet3Params = params{
 var simNetParams = params{
 	Params:                  &chaincfg.SimNetParams,
 	StakepooldRPCServerPort: "19560",
-	WalletRPCServerPort:     "19557",
 }
 
 // netName returns the name used when referring to a decred network.  At the


### PR DESCRIPTION
I don't think we are using or plan to use the wallet rpc port anymore for dcrstakepool as all wallet communication will pass through stakepoold.