### PR TITLE
Prevent header links from moving

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -7412,6 +7412,9 @@ h2 {
     color: #8997a5; }
   .site-header p {
     color: #424F67; }
+  .site-header a {
+    border-bottom: 5px solid transparent;
+  }
   .site-header a:hover, .site-header a:focus, .site-header a.active {
     text-decoration: none;
     color: #091440;


### PR DESCRIPTION
Closes #555

Previously a border was appearing upon hover and pushing other content around the page.
Now the border is always there, but it is transparent until it is hovered over.