### PR TITLE
dcrd.conf: Add dcrd sample config file

### DIFF
--- a/backend/stakepoold/stakepool/stakepool.go
+++ b/backend/stakepoold/stakepool/stakepool.go
@@ -333,7 +333,7 @@ func (spd *Stakepoold) AddMissingTicket(ticketHash []byte) error {
 		return err
 	}
 
-	tx, err := spd.WalletConnection.RPCClient().GetRawTransaction(hash)
+	tx, err := spd.NodeConnection.GetRawTransaction(hash)
 	if err != nil {
 		log.Errorf("AddMissingTicket: GetRawTransaction rpc failed: %v", err)
 		return err

--- a/sample-dcrd.conf
+++ b/sample-dcrd.conf
@@ -1,0 +1,12 @@
+; Debug is very useful to see more activity.
+debuglevel=debug
+
+; Stay on testnet until everything is well tested.
+testnet=1
+
+; Address indexing must be turned on.
+txindex=1
+
+; RPC auth stuff.
+;rpcuser=user
+;rpcpass=pass


### PR DESCRIPTION
The purpose for turning on txindex is outlined in this pr #557 
I think it will be best to actively check that this is turned on on startup as well, if others agree.  I will make a seperate issue for that.

Otherwise this sample config follows the patterns set down by the the other sample configuration files.