### PR TITLE
multi: Comment all exported functions.

### DIFF
--- a/backend/stakepoold/stakepool/stakepool.go
+++ b/backend/stakepoold/stakepool/stakepool.go
@@ -34,7 +34,7 @@ var (
 	ticketTypeSpentMissed = "SpentMissed"
 )
 
-// Stakepoold is stores everything related to stakepoold.
+// Stakepoold stores everything related to stakepoold.
 type Stakepoold struct {
 	sync.RWMutex
 

--- a/backend/stakepoold/stakepool/stakepool.go
+++ b/backend/stakepoold/stakepool/stakepool.go
@@ -34,6 +34,7 @@ var (
 	ticketTypeSpentMissed = "SpentMissed"
 )
 
+// Stakepoold is stores everything related to stakepoold.
 type Stakepoold struct {
 	sync.RWMutex
 
@@ -59,12 +60,14 @@ type Stakepoold struct {
 	Testing                bool // enabled only for testing
 }
 
+// NewTicketsForBlock stores tickets from a NewTickets notification.
 type NewTicketsForBlock struct {
 	BlockHash   *chainhash.Hash
 	BlockHeight int64
 	NewTickets  []*chainhash.Hash
 }
 
+// SpentMissedTicketsForBlock stores tickets from a SpentMissedTickets notification.
 type SpentMissedTicketsForBlock struct {
 	BlockHash   *chainhash.Hash
 	BlockHeight int64
@@ -78,6 +81,7 @@ type VotingConfig struct {
 	VoteBitsExtended string
 }
 
+// WinningTicketsForBlock stores tickets from a WinningTickets notification.
 type WinningTicketsForBlock struct {
 	BlockHash      *chainhash.Hash
 	BlockHeight    int64
@@ -232,6 +236,7 @@ func (spd *Stakepoold) getticket(wg *sync.WaitGroup, nt *ticketMetadata) {
 		strings.ToLower(nt.ticketType), nt.ticket)
 }
 
+// UpdateTicketData moves ignored low fee tickets to live tickets for voting.
 func (spd *Stakepoold) UpdateTicketData(newAddedLowFeeTicketsMSA map[chainhash.Hash]string) {
 	spd.Lock()
 
@@ -266,6 +271,8 @@ func (spd *Stakepoold) UpdateTicketData(newAddedLowFeeTicketsMSA map[chainhash.H
 	}()
 }
 
+// UpdateTicketDataFromMySQL moves ignored low fee tickets to live tickets for
+// voting based on information pulled from the DB.
 func (spd *Stakepoold) UpdateTicketDataFromMySQL() error {
 	start := time.Now()
 	newAddedLowFeeTicketsMSA, err := spd.UserData.MySQLFetchAddedLowFeeTickets()
@@ -324,6 +331,7 @@ func (spd *Stakepoold) ImportMissingScripts(scripts [][]byte, rescanHeight int) 
 	return nil
 }
 
+// AddMissingTicket forcefully adds a ticket to be watched by dcrwallet.
 func (spd *Stakepoold) AddMissingTicket(ticketHash []byte) error {
 	log.Infof("AddMissingTicket: Adding ticket with hash %s", ticketHash)
 
@@ -348,6 +356,7 @@ func (spd *Stakepoold) AddMissingTicket(ticketHash []byte) error {
 	return nil
 }
 
+// ListScripts performs the rpc command listscripts on dcrwallet.
 func (spd *Stakepoold) ListScripts() ([][]byte, error) {
 	scripts, err := spd.WalletConnection.RPCClient().ListScripts()
 	if err != nil {
@@ -381,6 +390,8 @@ func (spd *Stakepoold) CreateMultisig(addresses []string) (*wallettypes.CreateMu
 	return result, nil
 }
 
+// AccountSyncAddressIndex performs the accountsyncaddressindex command on
+// dcrwallet and returns the result.
 func (spd *Stakepoold) AccountSyncAddressIndex(account string, branch uint32, index int) error {
 	err := spd.WalletConnection.RPCClient().AccountSyncAddressIndex(account, branch, index)
 	if err != nil {
@@ -391,6 +402,7 @@ func (spd *Stakepoold) AccountSyncAddressIndex(account string, branch uint32, in
 	return nil
 }
 
+// GetTickets performs the gettickets command on dcrwallet and returns the result.
 func (spd *Stakepoold) GetTickets(includeImmature bool) ([]*chainhash.Hash, error) {
 	tickets, err := spd.WalletConnection.RPCClient().GetTickets(includeImmature)
 	if err != nil {
@@ -401,6 +413,8 @@ func (spd *Stakepoold) GetTickets(includeImmature bool) ([]*chainhash.Hash, erro
 	return tickets, nil
 }
 
+// StakePoolUserInfo performs the rpc command stakepooluserinfo on dcrwallet and
+// returns the result.
 func (spd *Stakepoold) StakePoolUserInfo(multisigAddress string) (*wallettypes.StakePoolUserInfoResult, error) {
 	decodedMultisig, err := dcrutil.DecodeAddress(multisigAddress, spd.Params)
 	if err != nil {
@@ -417,6 +431,8 @@ func (spd *Stakepoold) StakePoolUserInfo(multisigAddress string) (*wallettypes.S
 	return response, nil
 }
 
+// WalletInfo performs the rpc command walletinfo on dcrwallet and returns the
+// result.
 func (spd *Stakepoold) WalletInfo() (*wallettypes.WalletInfoResult, error) {
 	response, err := spd.WalletConnection.RPCClient().WalletInfo()
 	if err != nil {
@@ -427,6 +443,8 @@ func (spd *Stakepoold) WalletInfo() (*wallettypes.WalletInfoResult, error) {
 	return response, nil
 }
 
+// ValidateAddress performs the validateaddress command on dcrwallet and returns
+// the result.
 func (spd *Stakepoold) ValidateAddress(address string) (*wallettypes.ValidateAddressWalletResult, error) {
 	addr, err := dcrutil.DecodeAddress(address, spd.Params)
 	if err != nil {
@@ -454,12 +472,15 @@ func (spd *Stakepoold) GetStakeInfo() (*wallettypes.GetStakeInfoResult, error) {
 	return response, nil
 }
 
+// UpdateUserData replaces the user voting config in memory with newUserVotingConfig.
 func (spd *Stakepoold) UpdateUserData(newUserVotingConfig map[string]userdata.UserVotingConfig) {
 	spd.Lock()
 	spd.UserVotingConfig = newUserVotingConfig
 	spd.Unlock()
 }
 
+// UpdateUserDataFromMySQL performs UpdateUserData using the voting config
+// pulled from the DB.
 func (spd *Stakepoold) UpdateUserDataFromMySQL() error {
 	start := time.Now()
 	newUserVotingConfig, err := spd.UserData.MySQLFetchUserVotingConfig()
@@ -798,6 +819,8 @@ func (spd *Stakepoold) ProcessWinningTickets(wt WinningTicketsForBlock) {
 	}()
 }
 
+// NewTicketHandler is a go routine that waits for NewTicket notifications from
+// dcrd.
 func (spd *Stakepoold) NewTicketHandler(ctx context.Context, wg *sync.WaitGroup) {
 	wg.Add(1)
 	defer wg.Done()
@@ -812,6 +835,8 @@ func (spd *Stakepoold) NewTicketHandler(ctx context.Context, wg *sync.WaitGroup)
 	}
 }
 
+// SpentmissedTicketHandler is a go routine that waits for SpentMissedTicket
+// notification from dcrd.
 func (spd *Stakepoold) SpentmissedTicketHandler(ctx context.Context, wg *sync.WaitGroup) {
 	wg.Add(1)
 	defer wg.Done()
@@ -826,6 +851,8 @@ func (spd *Stakepoold) SpentmissedTicketHandler(ctx context.Context, wg *sync.Wa
 	}
 }
 
+// WinningTicketHandler is a go routine that waits for WinningTicket notifications
+// from dcrd.
 func (spd *Stakepoold) WinningTicketHandler(ctx context.Context, wg *sync.WaitGroup) {
 	wg.Add(1)
 	defer wg.Done()

--- a/backend/stakepoold/userdata/userdata.go
+++ b/backend/stakepoold/userdata/userdata.go
@@ -8,6 +8,7 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainhash"
 )
 
+// DBConfig stores DB login information.
 type DBConfig struct {
 	DBHost     string
 	DBName     string

--- a/controllers/api.go
+++ b/controllers/api.go
@@ -4,6 +4,7 @@ import (
 	"github.com/decred/dcrstakepool/system"
 )
 
-type ApiController struct {
+// APIController holds a dcrstakepool/system controller
+type APIController struct {
 	system.Controller
 }

--- a/controllers/captcha.go
+++ b/controllers/captcha.go
@@ -11,11 +11,12 @@ import (
 	"github.com/zenazn/goji/web"
 )
 
-type CaptchaHandler struct {
+type captchaHandler struct {
 	ImgWidth  int
 	ImgHeight int
 }
 
+// CaptchaServe writes and serves captchas.
 func (controller *MainController) CaptchaServe(c web.C, w http.ResponseWriter, r *http.Request) {
 	// Get the captcha id by stripping the file extension.
 	_, file := path.Split(r.URL.Path)
@@ -46,6 +47,8 @@ func (controller *MainController) CaptchaServe(c web.C, w http.ResponseWriter, r
 	http.ServeContent(w, r, id+ext, time.Time{}, bytes.NewReader(content.Bytes()))
 }
 
+// CaptchaVerify verifies that the provided captcha matches the on screen text
+// and sets the CaptchaDone session value.
 func (controller *MainController) CaptchaVerify(c web.C, w http.ResponseWriter, r *http.Request) {
 	id, solution := r.FormValue("captchaId"), r.FormValue("captchaSolution")
 	if id == "" {

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -49,6 +49,7 @@ const (
 	agendasCacheLife = time.Hour
 )
 
+// Config holds all the data used to create an new MainController.
 type Config struct {
 	AdminIPs             []string
 	AdminUserIDs         []string
@@ -79,7 +80,7 @@ type MainController struct {
 	system.Controller
 
 	Cfg            *Config
-	captchaHandler *CaptchaHandler
+	captchaHandler *captchaHandler
 	voteVersion    uint32
 	DCRDataURL     string
 }
@@ -126,7 +127,7 @@ func getClientIP(r *http.Request, realIPHeader string) string {
 
 // NewMainController is the constructor for the entire controller routing.
 func NewMainController(cfg *Config) (*MainController, error) {
-	ch := &CaptchaHandler{
+	ch := &captchaHandler{
 		ImgHeight: 127,
 		ImgWidth:  257,
 	}
@@ -289,7 +290,7 @@ func (controller *MainController) APIAddress(c web.C, r *http.Request) ([]string
 		return nil, codes.Unauthenticated, "address error", errors.New("invalid api token")
 	}
 
-	user, _ := models.GetUserById(dbMap, c.Env["APIUserID"].(int64))
+	user, _ := models.GetUserByID(dbMap, c.Env["APIUserID"].(int64))
 
 	if len(user.UserPubKeyAddr) > 0 {
 		return nil, codes.AlreadyExists, "address error", errors.New("address already submitted")
@@ -343,13 +344,13 @@ func (controller *MainController) APIAddress(c web.C, r *http.Request) ([]string
 		return nil, codes.Unavailable, "system error", errors.New("unable to process wallet commands")
 	}
 
-	userFeeAddr, err := controller.FeeAddressForUserID(int(user.Id))
+	userFeeAddr, err := controller.FeeAddressForUserID(int(user.ID))
 	if err != nil {
 		log.Warnf("unexpected error deriving pool addr: %s", err.Error())
 		return nil, codes.Unavailable, "system error", errors.New("unable to process wallet commands")
 	}
 
-	models.UpdateUserByID(dbMap, user.Id, createMultiSig.Address,
+	models.UpdateUserByID(dbMap, user.ID, createMultiSig.Address,
 		createMultiSig.RedeemScript, poolPubKeyAddr, userPubKeyAddr,
 		userFeeAddr.Address(), importedHeight)
 
@@ -372,7 +373,7 @@ func (controller *MainController) APIPurchaseInfo(c web.C,
 		return nil, codes.Unauthenticated, "purchaseinfo error", errors.New("invalid api token")
 	}
 
-	user, _ := models.GetUserById(dbMap, c.Env["APIUserID"].(int64))
+	user, _ := models.GetUserByID(dbMap, c.Env["APIUserID"].(int64))
 
 	if len(user.UserPubKeyAddr) == 0 {
 		return nil, codes.FailedPrecondition, "purchaseinfo error", errors.New("no address submitted")
@@ -445,7 +446,7 @@ func (controller *MainController) APIVoting(c web.C, r *http.Request) ([]string,
 		return nil, codes.Unauthenticated, "voting error", errors.New("invalid api token")
 	}
 
-	user, _ := models.GetUserById(dbMap, c.Env["APIUserID"].(int64))
+	user, _ := models.GetUserByID(dbMap, c.Env["APIUserID"].(int64))
 	oldVoteBits := user.VoteBits
 
 	vb := r.FormValue("VoteBits")
@@ -459,7 +460,7 @@ func (controller *MainController) APIVoting(c web.C, r *http.Request) ([]string,
 		return nil, codes.InvalidArgument, "voting error", errors.New("votebits invalid for current agendas")
 	}
 
-	user, err = helpers.UpdateVoteBitsByID(dbMap, user.Id, userVoteBits)
+	user, err = helpers.UpdateVoteBitsByID(dbMap, user.ID, userVoteBits)
 	if err != nil {
 		return nil, codes.Internal, "voting error", errors.New("failed to update voting prefs in database")
 	}
@@ -471,7 +472,7 @@ func (controller *MainController) APIVoting(c web.C, r *http.Request) ([]string,
 	}
 
 	log.Infof("updated voteBits for user %d from %d to %d",
-		user.Id, oldVoteBits, userVoteBits)
+		user.ID, oldVoteBits, userVoteBits)
 
 	return nil, codes.OK, "successfully updated voting preferences", nil
 }
@@ -615,7 +616,7 @@ func (controller *MainController) CheckAndResetUserVoteBits(dbMap *gorp.DbMap) (
 	userMax := models.GetUserMax(dbMap)
 	for userid := int64(1); userid <= userMax; userid++ {
 		// may have gaps due to users deleted from the database
-		user, err := models.GetUserById(dbMap, userid)
+		user, err := models.GetUserByID(dbMap, userid)
 		if err != nil {
 			continue
 		}
@@ -662,12 +663,12 @@ func (controller *MainController) CheckAndResetUserVoteBits(dbMap *gorp.DbMap) (
 	allUsers := make(map[int64]*models.User)
 	for userid := int64(1); userid <= userMax; userid++ {
 		// may have gaps due to users deleted from the database
-		user, err := models.GetUserById(dbMap, userid)
+		user, err := models.GetUserByID(dbMap, userid)
 		if err != nil || user.MultiSigAddress == "" {
 			continue
 		}
 
-		allUsers[user.Id] = user
+		allUsers[user.ID] = user
 	}
 
 	return allUsers, nil
@@ -690,16 +691,16 @@ func (controller *MainController) Address(c web.C, r *http.Request) (string, int
 	c.Env["Network"] = controller.getNetworkName()
 
 	c.Env["Flash"] = session.Flashes("address")
-	user, _ := models.GetUserById(dbMap, session.Values["UserId"].(int64))
+	user, _ := models.GetUserByID(dbMap, session.Values["UserId"].(int64))
 
 	// Generate an API Token for the user on demand if one does not exist and
 	// refresh the user's data before displaying it.
 	if user.APIToken == "" {
 		token, err := models.SetUserAPIToken(dbMap, controller.Cfg.APISecret,
-			controller.Cfg.BaseURL, user.Id)
+			controller.Cfg.BaseURL, user.ID)
 		if err != nil {
 			session.AddFlash("Unable to set API Token", "settingsError")
-			log.Errorf("could not set API Token for UserId %v", user.Id)
+			log.Errorf("could not set API Token for UserId %v", user.ID)
 		}
 
 		c.Env["APIToken"] = token
@@ -759,7 +760,7 @@ func (controller *MainController) AddressPost(c web.C, r *http.Request) (string,
 
 	// Only accept address if user does not already have a PubKeyAddr set.
 	dbMap := controller.GetDbMap(c)
-	user, _ := models.GetUserById(dbMap, session.Values["UserId"].(int64))
+	user, _ := models.GetUserByID(dbMap, session.Values["UserId"].(int64))
 	if len(user.UserPubKeyAddr) > 0 {
 		session.AddFlash("The voting service is currently limited to one address per account", "address")
 		return controller.Address(c, r)
@@ -991,7 +992,7 @@ func (controller *MainController) AdminTicketsPost(c web.C, r *http.Request) (st
 			expires := controller.CalcEstimatedTicketExpiry()
 
 			lowFeeTicket := &models.LowFeeTicket{
-				AddedByUid:    userID,
+				AddedByUID:    userID,
 				TicketAddress: msa,
 				TicketHash:    t,
 				TicketExpiry:  0,
@@ -1288,7 +1289,7 @@ func (controller *MainController) PasswordResetPost(c web.C, r *http.Request) (s
 
 		token := models.NewUserToken()
 		passReset := &models.PasswordReset{
-			UserId:  user.Id,
+			UserID:  user.ID,
 			Token:   token.String(),
 			Created: t.Unix(),
 			Expires: expires.Unix(),
@@ -1381,7 +1382,7 @@ func (controller *MainController) PasswordUpdatePost(c web.C, r *http.Request) (
 		return controller.PasswordUpdate(c, r)
 	}
 
-	user, err := helpers.UserIDExists(dbMap, resetData.UserId)
+	user, err := helpers.UserIDExists(dbMap, resetData.UserID)
 	if err != nil {
 		log.Infof("UserIDExists failure %v, %v", err, remoteIP)
 		session.AddFlash("Unable to find User ID.", "passwordupdateError")
@@ -1392,7 +1393,7 @@ func (controller *MainController) PasswordUpdatePost(c web.C, r *http.Request) (
 		user.Email)
 
 	user.HashPassword(password)
-	_, err = helpers.UpdateUserPasswordById(dbMap, resetData.UserId,
+	_, err = helpers.UpdateUserPasswordByID(dbMap, resetData.UserID,
 		user.Password)
 	if err != nil {
 		log.Errorf("error updating password %v", err)
@@ -1406,9 +1407,9 @@ func (controller *MainController) PasswordUpdatePost(c web.C, r *http.Request) (
 	}
 
 	// destroy session data
-	if err := system.DestroySessionsForUserID(dbMap, user.Id); err != nil {
+	if err := system.DestroySessionsForUserID(dbMap, user.ID); err != nil {
 		log.Warnf("PasswordUpdatePost: DestroySessionsForUserID '%v' failed: %v",
-			user.Id, err)
+			user.ID, err)
 	}
 	session.AddFlash("Password successfully updated", "passwordupdateSuccess")
 	return controller.PasswordUpdate(c, r)
@@ -1465,7 +1466,7 @@ func (controller *MainController) SettingsPost(c web.C, r *http.Request) (string
 	}
 
 	// Changes to email or password require the current password.
-	user, err := helpers.PasswordValidById(dbMap, session.Values["UserId"].(int64), password)
+	user, err := helpers.PasswordValidByID(dbMap, session.Values["UserId"].(int64), password)
 	if err != nil {
 		session.AddFlash("Password not valid", "settingsError")
 		return controller.Settings(c, r)
@@ -1488,7 +1489,7 @@ func (controller *MainController) SettingsPost(c web.C, r *http.Request) (string
 
 		token := models.NewUserToken()
 		emailChange := &models.EmailChange{
-			UserId:   user.Id,
+			UserID:   user.ID,
 			NewEmail: newEmail,
 			Token:    token.String(),
 			Created:  t.Unix(),
@@ -1529,7 +1530,7 @@ func (controller *MainController) SettingsPost(c web.C, r *http.Request) (string
 		}
 
 		user.HashPassword(newPassword)
-		_, err = helpers.UpdateUserPasswordById(dbMap, user.Id,
+		_, err = helpers.UpdateUserPasswordByID(dbMap, user.ID,
 			user.Password)
 		if err != nil {
 			log.Errorf("error updating password %v", err)
@@ -1538,9 +1539,9 @@ func (controller *MainController) SettingsPost(c web.C, r *http.Request) (string
 		}
 
 		// destroy session data
-		err := system.DestroySessionsForUserID(dbMap, user.Id)
+		err := system.DestroySessionsForUserID(dbMap, user.ID)
 		if err != nil {
-			log.Warnf("SettingsPost: DestroySessionsForUserId '%v' failed: %v", user.Id, err)
+			log.Warnf("SettingsPost: DestroySessionsForUserID '%v' failed: %v", user.ID, err)
 		}
 
 		// send a confirmation email.
@@ -1604,7 +1605,7 @@ func (controller *MainController) LoginPost(c web.C, r *http.Request) (string, i
 		return controller.Login(c, r)
 	}
 
-	session.Values["UserId"] = user.Id
+	session.Values["UserId"] = user.ID
 
 	// Go to Address page if multisig script not yet set up.
 	// GUI users can copy their API Token from here.
@@ -1828,7 +1829,7 @@ func (controller *MainController) Tickets(c web.C, r *http.Request) (string, int
 	c.Env["Title"] = "Decred VSP - Tickets"
 
 	dbMap := controller.GetDbMap(c)
-	user, _ := models.GetUserById(dbMap, session.Values["UserId"].(int64))
+	user, _ := models.GetUserByID(dbMap, session.Values["UserId"].(int64))
 
 	if user.MultiSigAddress == "" {
 		log.Info("Multisigaddress empty")
@@ -1945,7 +1946,7 @@ func (controller *MainController) Voting(c web.C, r *http.Request) (string, int)
 		return "/", http.StatusSeeOther
 	}
 
-	user, _ := models.GetUserById(dbMap, session.Values["UserId"].(int64))
+	user, _ := models.GetUserByID(dbMap, session.Values["UserId"].(int64))
 
 	if user.MultiSigAddress == "" {
 		log.Info("Multisigaddress empty")
@@ -1988,7 +1989,7 @@ func (controller *MainController) VotingPost(c web.C, r *http.Request) (string, 
 
 	var generatedVoteBits uint16
 
-	user, _ := models.GetUserById(dbMap, session.Values["UserId"].(int64))
+	user, _ := models.GetUserByID(dbMap, session.Values["UserId"].(int64))
 
 	// last block valid
 	generatedVoteBits |= 1
@@ -2012,14 +2013,14 @@ func (controller *MainController) VotingPost(c web.C, r *http.Request) (string, 
 	}
 
 	oldVoteBits := user.VoteBits
-	user, err := helpers.UpdateVoteBitsByID(dbMap, user.Id, generatedVoteBits)
+	user, err := helpers.UpdateVoteBitsByID(dbMap, user.ID, generatedVoteBits)
 	if err != nil {
 		session.AddFlash("unable to save new voting preferences", "votingError")
 		return "/voting", http.StatusSeeOther
 	}
 
 	log.Infof("updated voteBits for user %d from %d to %d",
-		user.Id, oldVoteBits, generatedVoteBits)
+		user.ID, oldVoteBits, generatedVoteBits)
 	if uint16(oldVoteBits) != generatedVoteBits {
 		if err := controller.StakepooldUpdateUsers(dbMap); err != nil {
 			log.Errorf("unable to update all: %v", err)

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -49,7 +49,7 @@ const (
 	agendasCacheLife = time.Hour
 )
 
-// Config holds all the data used to create an new MainController.
+// Config holds all the data used to create a new MainController.
 type Config struct {
 	AdminIPs             []string
 	AdminUserIDs         []string

--- a/email/email.go
+++ b/email/email.go
@@ -13,11 +13,13 @@ import (
 	"github.com/dajohi/goemail"
 )
 
+// Sender holds information related to outgoing smtp mail.
 type Sender struct {
 	smtpFrom   string
 	smtpServer *goemail.SMTP
 }
 
+// NewSender returns an initiated Sender to send emails with.
 func NewSender(smtpHost string, smtpUsername string, smtpPassword string,
 	smtpFrom string, useSMTPS bool, systemCerts *x509.CertPool,
 	skipVerify bool) (Sender, error) {
@@ -75,6 +77,7 @@ func (s *Sender) sendMail(emailaddress, subject, body string) error {
 	return s.smtpServer.Send(mailMsg)
 }
 
+// PasswordChangeRequest creates and sends a password reset email.
 func (s *Sender) PasswordChangeRequest(email, clientIP, baseURL, token string) error {
 	body := "A request to reset your password was made from IP address: " +
 		clientIP + "\r\n\n" +
@@ -88,6 +91,7 @@ func (s *Sender) PasswordChangeRequest(email, clientIP, baseURL, token string) e
 	return s.sendMail(email, "Voting service password reset", body)
 }
 
+// EmailChangeVerification creates and sends an email change verification email.
 func (s *Sender) EmailChangeVerification(baseURL, currentEmail, newEmail, clientIP, token string) error {
 	body := "A request was made to change the email address " +
 		"for a voting service account at " + baseURL +
@@ -102,6 +106,7 @@ func (s *Sender) EmailChangeVerification(baseURL, currentEmail, newEmail, client
 	return s.sendMail(newEmail, "Voting service email change", body)
 }
 
+// EmailChangeNotification creates and sends an email change notification email.
 func (s *Sender) EmailChangeNotification(baseURL, currentEmail, newEmail, clientIP string) error {
 	body := "A request was made to change the email address " +
 		"for your voting service account at " + baseURL +
@@ -113,6 +118,7 @@ func (s *Sender) EmailChangeNotification(baseURL, currentEmail, newEmail, client
 	return s.sendMail(currentEmail, "Voting service email change", body)
 }
 
+// PasswordChangeConfirm creates and sends a password change confirmation email.
 func (s *Sender) PasswordChangeConfirm(email, baseURL, clientIP string) error {
 	body := "Your voting service password for " + baseURL +
 		" was just changed by IP Address " + clientIP + "\r\n\n" +
@@ -122,6 +128,7 @@ func (s *Sender) PasswordChangeConfirm(email, baseURL, clientIP string) error {
 	return s.sendMail(email, "Voting service password change", body)
 }
 
+// Registration creates and sends a registration email.
 func (s *Sender) Registration(email, baseURL, clientIP, token string) error {
 	body := "A request for an account for " + baseURL + " was made from " +
 		clientIP + " for this email address.\r\n\n" +

--- a/helpers/auth.go
+++ b/helpers/auth.go
@@ -32,7 +32,7 @@ func EmailChangeComplete(dbMap *gorp.DbMap, token models.UserToken) error {
 	return err
 }
 
-// EmailChangeTokenExists checks whether the token exits and returns the
+// EmailChangeTokenExists checks whether the token exists and returns the
 // EmailChange information if found in the DB.
 func EmailChangeTokenExists(dbMap *gorp.DbMap, token models.UserToken) (*models.EmailChange, error) {
 	var emailChange models.EmailChange
@@ -56,7 +56,7 @@ func EmailExists(dbMap *gorp.DbMap, email string) (*models.User, error) {
 	return &user, err
 }
 
-// EmailVerificationTokenExists checks whether the token exits and returns User
+// EmailVerificationTokenExists checks whether the token exists and returns User
 // information if found in the DB.
 func EmailVerificationTokenExists(dbMap *gorp.DbMap, token models.UserToken) (*models.User, error) {
 	var user models.User
@@ -69,7 +69,7 @@ func EmailVerificationTokenExists(dbMap *gorp.DbMap, token models.UserToken) (*m
 	return &user, err
 }
 
-// EmailVerificationComplete Changes a users EmailVerified value to 1.
+// EmailVerificationComplete changes a users EmailVerified value to 1.
 func EmailVerificationComplete(dbMap *gorp.DbMap, token models.UserToken) error {
 	_, err := dbMap.Exec(`UPDATE Users
 		SET EmailToken = '', EmailVerified = 1
@@ -77,14 +77,14 @@ func EmailVerificationComplete(dbMap *gorp.DbMap, token models.UserToken) error 
 	return err
 }
 
-// PasswordResetTokenDelete delets the PasswordReset row identified by token
+// PasswordResetTokenDelete deletes the PasswordReset row identified by token
 // from the DB.
 func PasswordResetTokenDelete(dbMap *gorp.DbMap, token models.UserToken) error {
 	_, err := dbMap.Exec("DELETE FROM PasswordReset WHERE Token = ?", token.String())
 	return err
 }
 
-// PasswordResetTokenExists checks whether the token exits and returns
+// PasswordResetTokenExists checks whether the token exists and returns
 // PasswordReset information if found in the DB.
 func PasswordResetTokenExists(dbMap *gorp.DbMap, token models.UserToken) (*models.PasswordReset, error) {
 	var passwordReset models.PasswordReset

--- a/helpers/auth.go
+++ b/helpers/auth.go
@@ -6,6 +6,8 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
+// EmailChangeComplete checks that token is correct, updates a users email
+// based on their choice, and deletes the EmailChange row from the DB.
 func EmailChangeComplete(dbMap *gorp.DbMap, token models.UserToken) error {
 	var emailChange models.EmailChange
 
@@ -16,12 +18,12 @@ func EmailChangeComplete(dbMap *gorp.DbMap, token models.UserToken) error {
 	}
 
 	_, err = dbMap.Exec("UPDATE Users SET Email = ? WHERE UserId = ?",
-		emailChange.NewEmail, emailChange.UserId)
+		emailChange.NewEmail, emailChange.UserID)
 	if err != nil {
 		return err
 	}
 
-	_, err = dbMap.Exec("DELETE FROM PasswordReset WHERE UserId = ?", emailChange.UserId)
+	_, err = dbMap.Exec("DELETE FROM PasswordReset WHERE UserId = ?", emailChange.UserID)
 	if err != nil {
 		return err
 	}
@@ -30,6 +32,8 @@ func EmailChangeComplete(dbMap *gorp.DbMap, token models.UserToken) error {
 	return err
 }
 
+// EmailChangeTokenExists checks whether the token exits and returns the
+// EmailChange information if found in the DB.
 func EmailChangeTokenExists(dbMap *gorp.DbMap, token models.UserToken) (*models.EmailChange, error) {
 	var emailChange models.EmailChange
 	err := dbMap.SelectOne(&emailChange,
@@ -41,6 +45,7 @@ func EmailChangeTokenExists(dbMap *gorp.DbMap, token models.UserToken) (*models.
 	return &emailChange, err
 }
 
+// EmailExists returns User information if email exists for a user in the DB.
 func EmailExists(dbMap *gorp.DbMap, email string) (*models.User, error) {
 	var user models.User
 	err := dbMap.SelectOne(&user, "SELECT * FROM Users WHERE Email = ?", email)
@@ -51,6 +56,8 @@ func EmailExists(dbMap *gorp.DbMap, email string) (*models.User, error) {
 	return &user, err
 }
 
+// EmailVerificationTokenExists checks whether the token exits and returns User
+// information if found in the DB.
 func EmailVerificationTokenExists(dbMap *gorp.DbMap, token models.UserToken) (*models.User, error) {
 	var user models.User
 	err := dbMap.SelectOne(&user,
@@ -62,6 +69,7 @@ func EmailVerificationTokenExists(dbMap *gorp.DbMap, token models.UserToken) (*m
 	return &user, err
 }
 
+// EmailVerificationComplete Changes a users EmailVerified value to 1.
 func EmailVerificationComplete(dbMap *gorp.DbMap, token models.UserToken) error {
 	_, err := dbMap.Exec(`UPDATE Users
 		SET EmailToken = '', EmailVerified = 1
@@ -69,11 +77,15 @@ func EmailVerificationComplete(dbMap *gorp.DbMap, token models.UserToken) error 
 	return err
 }
 
+// PasswordResetTokenDelete delets the PasswordReset row identified by token
+// from the DB.
 func PasswordResetTokenDelete(dbMap *gorp.DbMap, token models.UserToken) error {
 	_, err := dbMap.Exec("DELETE FROM PasswordReset WHERE Token = ?", token.String())
 	return err
 }
 
+// PasswordResetTokenExists checks whether the token exits and returns
+// PasswordReset information if found in the DB.
 func PasswordResetTokenExists(dbMap *gorp.DbMap, token models.UserToken) (*models.PasswordReset, error) {
 	var passwordReset models.PasswordReset
 	err := dbMap.SelectOne(&passwordReset,
@@ -85,7 +97,9 @@ func PasswordResetTokenExists(dbMap *gorp.DbMap, token models.UserToken) (*model
 	return &passwordReset, err
 }
 
-func PasswordValidById(dbMap *gorp.DbMap, id int64, password string) (*models.User, error) {
+// PasswordValidByID checks whether the passed password belongs to the user
+// specified by id. Return the User information if found in the DB.
+func PasswordValidByID(dbMap *gorp.DbMap, id int64, password string) (*models.User, error) {
 	var user models.User
 	err := dbMap.SelectOne(&user, "SELECT * FROM Users WHERE UserId = ?", id)
 	if err != nil {
@@ -99,7 +113,9 @@ func PasswordValidById(dbMap *gorp.DbMap, id int64, password string) (*models.Us
 	return &user, err
 }
 
-func UpdateUserPasswordById(dbMap *gorp.DbMap, id int64, password []byte) (*models.User, error) {
+// UpdateUserPasswordByID sets the user's password specified by id to the
+// password hash. Returns the User information if found in the DB.
+func UpdateUserPasswordByID(dbMap *gorp.DbMap, id int64, password []byte) (*models.User, error) {
 	var user models.User
 	err := dbMap.SelectOne(&user, "SELECT * FROM Users WHERE UserId = ?", id)
 	if err != nil {
@@ -116,6 +132,8 @@ func UpdateUserPasswordById(dbMap *gorp.DbMap, id int64, password []byte) (*mode
 	return &user, err
 }
 
+// UpdateVoteBitsByID sets the user's vote bits specified by id to voteBits.
+// Returns the User information if found in the DB.
 func UpdateVoteBitsByID(dbMap *gorp.DbMap, id int64, voteBits uint16) (*models.User, error) {
 	var user models.User
 	err := dbMap.SelectOne(&user, "SELECT * FROM Users WHERE UserId = ?", id)
@@ -133,6 +151,8 @@ func UpdateVoteBitsByID(dbMap *gorp.DbMap, id int64, voteBits uint16) (*models.U
 	return &user, err
 }
 
+// UpdateVoteBitsVersionByID sets the user's vote bits version specified by id
+// to voteVersion. Returns the User information if found in the DB.
 func UpdateVoteBitsVersionByID(dbMap *gorp.DbMap, id int64, voteVersion uint32) (*models.User, error) {
 	var user models.User
 	err := dbMap.SelectOne(&user, "SELECT * FROM Users WHERE UserId = ?", id)
@@ -150,6 +170,7 @@ func UpdateVoteBitsVersionByID(dbMap *gorp.DbMap, id int64, voteVersion uint32) 
 	return &user, err
 }
 
+// UserIDExists returns User information if found in the DB.
 func UserIDExists(dbMap *gorp.DbMap, userid int64) (*models.User, error) {
 	var user models.User
 	err := dbMap.SelectOne(&user, "SELECT * FROM Users WHERE UserId = ?", userid)

--- a/helpers/template.go
+++ b/helpers/template.go
@@ -5,6 +5,7 @@ import (
 	"html/template"
 )
 
+// Parse parses html templates and returns the template as a string.
 func Parse(t *template.Template, name string, data interface{}) (string, error) {
 	var doc bytes.Buffer
 	err := t.ExecuteTemplate(&doc, name, data)

--- a/models/user.go
+++ b/models/user.go
@@ -86,18 +86,21 @@ func UserTokenFromStr(token string) (UserToken, error) {
 	return ut, nil
 }
 
+// EmailChange is used for DB responses and holds information related to an
+// email change.
 type EmailChange struct {
-	Id       int64 `db:"EmailChangeID"`
-	UserId   int64
+	ID       int64 `db:"EmailChangeID"`
+	UserID   int64 `db:"UserId"`
 	NewEmail string
 	Token    string
 	Created  int64
 	Expires  int64
 }
 
+// LowFeeTicket is used for DB responses and holds low fee ticket information.
 type LowFeeTicket struct {
-	Id            int64 `db:"LowFeeTicketID"`
-	AddedByUid    int64
+	ID            int64 `db:"LowFeeTicketID"`
+	AddedByUID    int64 `db:"AddedByUid"`
 	TicketAddress string
 	TicketHash    string
 	TicketExpiry  int64
@@ -106,25 +109,30 @@ type LowFeeTicket struct {
 	Expires       int64
 }
 
+// PasswordReset is used for DB responses and holds information related to a
+// password reset.
 type PasswordReset struct {
-	Id      int64 `db:"PasswordResetID"`
-	UserId  int64
+	ID      int64 `db:"PasswordResetID"`
+	UserID  int64 `db:"UserId"`
 	Token   string
 	Created int64
 	Expires int64
 }
 
+// Session is used for DB responses and holds information about a user's login
+// session.
 type Session struct {
-	Id      int64 `db:"SessionID"`
+	ID      int64 `db:"SessionID"`
 	Token   string
 	Data    []byte
-	UserId  int64
+	UserID  int64 `db:"UserId"`
 	Created int64
 	Expires int64
 }
 
+// User is used for DB responses and holds information about a user.
 type User struct {
-	Id               int64 `db:"UserId"`
+	ID               int64 `db:"UserId"`
 	Email            string
 	Username         string
 	Password         []byte
@@ -141,6 +149,7 @@ type User struct {
 	VoteBitsVersion  int64
 }
 
+// HashPassword hashes the passed password string.
 func (user *User) HashPassword(password string) {
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
@@ -150,6 +159,7 @@ func (user *User) HashPassword(password string) {
 	user.Password = hash
 }
 
+// GetUserByEmail is a helper function that returns a user with email.
 func GetUserByEmail(dbMap *gorp.DbMap, email string) (user *User) {
 	err := dbMap.SelectOne(&user, "SELECT * FROM Users where Email = ?", email)
 
@@ -159,7 +169,8 @@ func GetUserByEmail(dbMap *gorp.DbMap, email string) (user *User) {
 	return
 }
 
-func GetUserById(dbMap *gorp.DbMap, id int64) (user *User, err error) {
+// GetUserByID is a helper function that returns a user with id.
+func GetUserByID(dbMap *gorp.DbMap, id int64) (user *User, err error) {
 	err = dbMap.SelectOne(&user, "SELECT * FROM Users WHERE UserId = ?", id)
 
 	if err != nil {
@@ -169,7 +180,7 @@ func GetUserById(dbMap *gorp.DbMap, id int64) (user *User, err error) {
 	return user, nil
 }
 
-// GetUserCount gives a count of all users
+// GetUserCount gives a count of all users.
 func GetUserCount(dbMap *gorp.DbMap) int64 {
 	userCount, err := dbMap.SelectInt("SELECT COUNT(*) FROM Users")
 	if err != nil {
@@ -179,7 +190,7 @@ func GetUserCount(dbMap *gorp.DbMap) int64 {
 	return userCount
 }
 
-// GetUserMax gives the last userid
+// GetUserMax gives the last userid.
 func GetUserMax(dbMap *gorp.DbMap) int64 {
 	maxUserID, err := dbMap.SelectInt("SELECT MAX(Userid) FROM Users")
 	if err != nil {
@@ -189,7 +200,7 @@ func GetUserMax(dbMap *gorp.DbMap) int64 {
 	return maxUserID
 }
 
-// GetUserCountActive gives a count of all users who have submitted an address
+// GetUserCountActive gives a count of all users who have submitted an address.
 func GetUserCountActive(dbMap *gorp.DbMap) int64 {
 	userCountActive, err := dbMap.SelectInt("SELECT COUNT(*) FROM Users " +
 		"WHERE MultiSigAddress <> ''")
@@ -200,20 +211,22 @@ func GetUserCountActive(dbMap *gorp.DbMap) int64 {
 	return userCountActive
 }
 
+// InsertEmailChange inserts a new EmailChange row into the DB.
 func InsertEmailChange(dbMap *gorp.DbMap, emailChange *EmailChange) error {
 	return dbMap.Insert(emailChange)
 }
 
-// InsertLowFeeTicket inserts a user into the DB
+// InsertLowFeeTicket inserts a user into the DB.
 func InsertLowFeeTicket(dbMap *gorp.DbMap, lowFeeTicket *LowFeeTicket) error {
 	return dbMap.Insert(lowFeeTicket)
 }
 
-// InsertUser inserts a user into the DB
+// InsertUser inserts a user into the DB.
 func InsertUser(dbMap *gorp.DbMap, user *User) error {
 	return dbMap.Insert(user)
 }
 
+// InsertPasswordReset inserts a new PasswordReset row into the DB.
 func InsertPasswordReset(dbMap *gorp.DbMap, passwordReset *PasswordReset) error {
 	return dbMap.Insert(passwordReset)
 }
@@ -276,6 +289,7 @@ func UpdateUserByID(dbMap *gorp.DbMap, id int64, multiSigAddr string,
 	return
 }
 
+// GetAllCurrentMultiSigScripts returns all tracked multisig scripts.
 func GetAllCurrentMultiSigScripts(dbMap *gorp.DbMap) ([]User, error) {
 	var multiSigs []User
 	_, err := dbMap.Select(&multiSigs, "SELECT MultiSigScript, HeightRegistered FROM Users WHERE MultiSigAddress <> ''")
@@ -285,6 +299,7 @@ func GetAllCurrentMultiSigScripts(dbMap *gorp.DbMap) ([]User, error) {
 	return multiSigs, nil
 }
 
+// GetVotableLowFeeTickets returns all unexpired LowFeeTickets.
 func GetVotableLowFeeTickets(dbMap *gorp.DbMap) ([]LowFeeTicket, error) {
 	var votableLowFeeTickets []LowFeeTicket
 	_, err := dbMap.Select(&votableLowFeeTickets, "SELECT * FROM LowFeeTicket WHERE Voted = 0 AND Expires > UNIX_TIMESTAMP()")
@@ -294,6 +309,8 @@ func GetVotableLowFeeTickets(dbMap *gorp.DbMap) ([]LowFeeTicket, error) {
 	return votableLowFeeTickets, nil
 }
 
+// GetDbMap returns the entire gorp DbMap. It creates tables where none are
+// found and updates values when needed.
 func GetDbMap(APISecret, baseURL, user, password, hostname, port, database string) *gorp.DbMap {
 	// Connect to db using standard Go database/sql API.
 	dataSource := fmt.Sprintf("%s:%s@(%s:%s)/%s?charset=utf8mb4",
@@ -320,12 +337,12 @@ func GetDbMap(APISecret, baseURL, user, password, hostname, port, database strin
 
 	// Add a table, setting the table name and specifying that the Id property
 	// is an auto incrementing primary key
-	dbMap.AddTableWithName(EmailChange{}, "EmailChange").SetKeys(true, "Id")
-	dbMap.AddTableWithName(LowFeeTicket{}, "LowFeeTicket").SetKeys(true, "Id")
-	dbMap.AddTableWithName(PasswordReset{}, "PasswordReset").SetKeys(true, "Id")
-	dbMap.AddTableWithName(Session{}, "Session").SetKeys(true, "Id")
+	dbMap.AddTableWithName(EmailChange{}, "EmailChange").SetKeys(true, "ID")
+	dbMap.AddTableWithName(LowFeeTicket{}, "LowFeeTicket").SetKeys(true, "ID")
+	dbMap.AddTableWithName(PasswordReset{}, "PasswordReset").SetKeys(true, "ID")
+	dbMap.AddTableWithName(Session{}, "Session").SetKeys(true, "ID")
 	usersTableName := "Users"
-	dbMap.AddTableWithName(User{}, usersTableName).SetKeys(true, "Id")
+	dbMap.AddTableWithName(User{}, usersTableName).SetKeys(true, "ID")
 
 	// Create the table.
 	err = dbMap.CreateTablesIfNotExists()
@@ -389,9 +406,9 @@ func GetDbMap(APISecret, baseURL, user, password, hostname, port, database strin
 	}
 
 	for _, u := range users {
-		_, err := SetUserAPIToken(dbMap, APISecret, baseURL, u.Id)
+		_, err := SetUserAPIToken(dbMap, APISecret, baseURL, u.ID)
 		if err != nil {
-			log.Errorf("Unable to set API Token for UserId %v: %v", u.Id, err)
+			log.Errorf("Unable to set API Token for UserId %v: %v", u.ID, err)
 		}
 	}
 

--- a/models/user.go
+++ b/models/user.go
@@ -216,7 +216,7 @@ func InsertEmailChange(dbMap *gorp.DbMap, emailChange *EmailChange) error {
 	return dbMap.Insert(emailChange)
 }
 
-// InsertLowFeeTicket inserts a user into the DB.
+// InsertLowFeeTicket inserts a low fee ticket into the DB.
 func InsertLowFeeTicket(dbMap *gorp.DbMap, lowFeeTicket *LowFeeTicket) error {
 	return dbMap.Insert(lowFeeTicket)
 }

--- a/poolapi/apijson.go
+++ b/poolapi/apijson.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 )
 
+// Response is the JSON API response to all requests and holds data related to
+// the request if successful.
 type Response struct {
 	Status  string           `json:"status"`
 	Message string           `json:"message"`
@@ -12,6 +14,7 @@ type Response struct {
 
 // TODO: make JSON tags lower-case and add "_" between words
 
+// PurchaseInfo is a JSON data struct related to a user's ticket purchases.
 type PurchaseInfo struct {
 	PoolAddress     string  `json:"PoolAddress"`
 	PoolFees        float64 `json:"PoolFees"`
@@ -21,6 +24,7 @@ type PurchaseInfo struct {
 	VoteBitsVersion uint32  `json:"VoteBitsVersion"`
 }
 
+// Stats is a JSON data struct with information about the pool.
 type Stats struct {
 	AllMempoolTix        uint32  `json:"AllMempoolTix"`
 	APIVersionsSupported []int   `json:"APIVersionsSupported"`

--- a/server.go
+++ b/server.go
@@ -71,10 +71,10 @@ func runMain(ctx context.Context) error {
 		cfg.CookieSecure, cfg.DBHost, cfg.DBName, cfg.DBPassword, cfg.DBPort,
 		cfg.DBUser)
 	if application.DbMap == nil {
-		return fmt.Errorf("Failed to open database.")
+		return fmt.Errorf("failed to open database")
 	}
 	if err = application.LoadTemplates(cfg.TemplatePath); err != nil {
-		return fmt.Errorf("Failed to load templates: %v", err)
+		return fmt.Errorf("failed to load templates: %v", err)
 	}
 
 	// Set up signal handler
@@ -90,7 +90,7 @@ func runMain(ctx context.Context) error {
 
 	stakepooldConnMan, err = stakepooldclient.ConnectStakepooldGRPC(cfg.StakepooldHosts, cfg.StakepooldCerts)
 	if err != nil {
-		return fmt.Errorf("Failed to connect to stakepoold host: %v", err)
+		return fmt.Errorf("failed to connect to stakepoold host: %v", err)
 	}
 
 	var sender email.Sender
@@ -98,7 +98,7 @@ func runMain(ctx context.Context) error {
 		sender, err = email.NewSender(cfg.SMTPHost, cfg.SMTPUsername, cfg.SMTPPassword,
 			cfg.SMTPFrom, cfg.UseSMTPS, cfg.SystemCerts, cfg.SMTPSkipVerify)
 		if err != nil {
-			return fmt.Errorf("Failed to initialize the smtp server: %v", err)
+			return fmt.Errorf("failed to initialize the smtp server: %v", err)
 		}
 	}
 
@@ -128,7 +128,7 @@ func runMain(ctx context.Context) error {
 	controller, err := controllers.NewMainController(&controllerCfg)
 
 	if err != nil {
-		return fmt.Errorf("Failed to initialize the main controller: %v", err)
+		return fmt.Errorf("failed to initialize the main controller: %v", err)
 	}
 
 	// Check that dcrstakepool config and all stakepoold configs
@@ -167,7 +167,7 @@ func runMain(ctx context.Context) error {
 
 	err = controller.RPCSync(application.DbMap)
 	if err != nil {
-		return fmt.Errorf("Failed to sync the wallets: %v",
+		return fmt.Errorf("failed to sync the wallets: %v",
 			err)
 	}
 

--- a/stakepooldclient/stakepooldclient.go
+++ b/stakepooldclient/stakepooldclient.go
@@ -623,6 +623,7 @@ type BackendStatus struct {
 	*WalletStatus
 }
 
+// WalletStatus holds information about a dcrwallet.
 type WalletStatus struct {
 	DaemonConnected bool
 	VoteVersion     uint32

--- a/system/controller.go
+++ b/system/controller.go
@@ -12,26 +12,32 @@ import (
 	"github.com/zenazn/goji/web"
 )
 
+// Controller is the type of the main web controller.
 type Controller struct {
 }
 
+// GetSession returns the session stored in the header.
 func (controller *Controller) GetSession(c web.C) *sessions.Session {
 	return c.Env["Session"].(*sessions.Session)
 }
 
+// GetTemplate returns the template stored in the header.
 func (controller *Controller) GetTemplate(c web.C) *template.Template {
 	return c.Env["Template"].(*template.Template)
 }
 
+// GetDbMap returns the DbMap stored in the header.
 func (controller *Controller) GetDbMap(c web.C) *gorp.DbMap {
 	return c.Env["DbMap"].(*gorp.DbMap)
 }
 
+// IsCaptchaDone returns the CaptchaDone value stored in the header.
 func (controller *Controller) IsCaptchaDone(c web.C) bool {
 	done, ok := c.Env["CaptchaDone"].(bool)
 	return done && ok
 }
 
+// Parse parses html templates and returns the template as a string.
 func (controller *Controller) Parse(t *template.Template, name string, data interface{}) string {
 	var doc bytes.Buffer
 	err := t.ExecuteTemplate(&doc, name, data)

--- a/system/core.go
+++ b/system/core.go
@@ -22,6 +22,8 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
+// Application represents dcrstakepool's infrastructure, including html
+// templates and the mysql database.
 type Application struct {
 	APISecret     string
 	Template      *template.Template
@@ -38,6 +40,7 @@ func GojiWebHandlerFunc(h http.HandlerFunc) web.HandlerFunc {
 	}
 }
 
+// Init initiates an Application with the passed variables.
 func (application *Application) Init(ctx context.Context, wg *sync.WaitGroup,
 	APISecret, baseURL, cookieSecret string, cookieSecure bool, DBHost,
 	DBName, DBPassword, DBPort, DBUser string) {
@@ -71,6 +74,7 @@ var funcMap = template.FuncMap{
 	},
 }
 
+// LoadTemplates parses and loads all html templates found in templatePath.
 func (application *Application) LoadTemplates(templatePath string) error {
 	var templates []string
 
@@ -99,6 +103,8 @@ func (application *Application) LoadTemplates(templatePath string) error {
 // route is a type for http endpoints.
 type route func(web.C, *http.Request) (string, int)
 
+// Route calls methods from controllers/main, directs users based on the
+// returned status, and writes the response.
 func (application *Application) Route(fn route) web.HandlerFunc {
 	return func(c web.C, w http.ResponseWriter, r *http.Request) {
 		c.Env["Content-Type"] = "text/html"

--- a/system/sigs_unix.go
+++ b/system/sigs_unix.go
@@ -4,6 +4,8 @@ package system
 
 import "syscall"
 
+// ReloadTemplatesSig forces the html templates to be reloaded by signalling
+// SIGUSR1.
 func ReloadTemplatesSig(app *Application) {
 	reloadTemplatesSig(syscall.SIGUSR1, app)
 }

--- a/system/sqlstore.go
+++ b/system/sqlstore.go
@@ -71,7 +71,7 @@ func (s *SQLStore) New(r *http.Request, name string) (*sessions.Session, error) 
 	err = securecookie.DecodeMulti(name, c.Value, &session.ID, s.codecs...)
 	if err != nil {
 		// these are not the sessions you are looking for
-		log.Infof("sqlstore: New: unable to decode cookie: %v", err)
+		log.Debugf("sqlstore: New: unable to decode cookie: %v", err)
 		return session, nil
 	}
 	err = s.load(session)
@@ -111,7 +111,7 @@ func (s *SQLStore) load(session *sessions.Session) error {
 		if err == sql.ErrNoRows {
 			return nil
 		}
-		return fmt.Errorf("Could not select session to destroy: %v", err)
+		return fmt.Errorf("could not select session to destroy: %v", err)
 	}
 	if dbSession.Expires < time.Now().Unix() {
 		return s.destroy(session)
@@ -128,16 +128,16 @@ func (s *SQLStore) save(session *sessions.Session) error {
 	var isNew bool
 	if err := s.dbMap.SelectOne(&dbSession, "SELECT * FROM Session WHERE Token = ?", session.ID); err != nil {
 		if err != sql.ErrNoRows {
-			return fmt.Errorf("Could not select session: %v", err)
+			return fmt.Errorf("could not select session: %v", err)
 		}
 		// no rows found so new
 		isNew = true
 	}
 	if userID, ok := session.Values["UserId"].(int64); ok {
-		dbSession.UserId = userID
+		dbSession.UserID = userID
 	} else {
-		// all sessions with no user specified are UserId -1
-		dbSession.UserId = -1
+		// all sessions with no user specified are UserID -1
+		dbSession.UserID = -1
 	}
 	if err := gob.NewEncoder(&buf).Encode(session.Values); err != nil {
 		return err
@@ -149,10 +149,10 @@ func (s *SQLStore) save(session *sessions.Session) error {
 		dbSession.Created = now
 		dbSession.Expires = now + int64(session.Options.MaxAge)
 		if err := s.dbMap.Insert(&dbSession); err != nil {
-			return fmt.Errorf("Could not insert session: %v", err)
+			return fmt.Errorf("could not insert session: %v", err)
 		}
 	} else if _, err := s.dbMap.Update(&dbSession); err != nil {
-		return fmt.Errorf("Could not update session: %v", err)
+		return fmt.Errorf("could not update session: %v", err)
 	}
 	return nil
 }
@@ -165,10 +165,10 @@ func (s *SQLStore) destroy(session *sessions.Session) error {
 		if err == sql.ErrNoRows {
 			return nil
 		}
-		return fmt.Errorf("Could not select session to destroy: %v", err)
+		return fmt.Errorf("could not select session to destroy: %v", err)
 	}
 	if _, err := s.dbMap.Delete(&dbSession); err != nil {
-		return fmt.Errorf("Could not destroy session: %v", err)
+		return fmt.Errorf("could not destroy session: %v", err)
 	}
 	return nil
 }
@@ -178,11 +178,11 @@ func (s *SQLStore) destroyExpiredSessions() error {
 	var dbSession models.Session
 	dbSessions, err := s.dbMap.Select(&dbSession, "SELECT * FROM Session WHERE Expires < ?", time.Now().Unix())
 	if err != nil {
-		return fmt.Errorf("Could not select expired sessions: %v", err)
+		return fmt.Errorf("could not select expired sessions: %v", err)
 	}
 	_, err = s.dbMap.Delete(dbSessions...)
 	if err != nil {
-		return fmt.Errorf("Could not destroy expired sessions: %v", err)
+		return fmt.Errorf("could not destroy expired sessions: %v", err)
 	}
 	return nil
 }
@@ -196,11 +196,11 @@ func DestroySessionsForUserID(dbMap *gorp.DbMap, userID int64) error {
 	var dbSession models.Session
 	dbSessions, err := dbMap.Select(&dbSession, "SELECT * FROM Session WHERE UserId = ?", userID)
 	if err != nil {
-		return fmt.Errorf("Could not select user sessions to destroy: %v", err)
+		return fmt.Errorf("could not select user sessions to destroy: %v", err)
 	}
 	_, err = dbMap.Delete(dbSessions...)
 	if err != nil {
-		return fmt.Errorf("Could not destroy user sessions: %v", err)
+		return fmt.Errorf("could not destroy user sessions: %v", err)
 	}
 	return nil
 }

--- a/system/sqlstore_test.go
+++ b/system/sqlstore_test.go
@@ -85,7 +85,7 @@ func makeDbAndStore() (sqlmock.Sqlmock, *sql.DB, *SQLStore) {
 		Dialect:         gorp.MySQLDialect{Engine: "InnoDB", Encoding: "UTF8MB4"},
 		ExpandSliceArgs: true,
 	}
-	dbMap.AddTableWithName(models.Session{}, "Session").SetKeys(true, "Id")
+	dbMap.AddTableWithName(models.Session{}, "Session").SetKeys(true, "ID")
 	hash := sha256.New()
 	io.WriteString(hash, "abrakadabra")
 	s := NewSQLStore(ctx, &wg, dbMap, hash.Sum(nil))


### PR DESCRIPTION
Closes #564 

Unexport one method. Change all occurrences of Id as a field with ID.
 
Changing the Id fields to ID isn't actually necessary to get the score down. So let me know if anyone disagrees with that.  I think it is more uniformed this way. However, the fields in the db are already mostly "somethingId" so...

https://goreportcard.com/report/github.com/JoeGruffins/dcrstakepool

I haven't touched the gocyclo. If that's something that should be worried about we can make a new issue.