### PR TITLE
Parameter to configure database connection encryption

### DIFF
--- a/backend/stakepoold/config.go
+++ b/backend/stakepoold/config.go
@@ -39,6 +39,7 @@ var (
 	defaultDBName = "stakepool"
 	defaultDBPort = "3306"
 	defaultDBUser = "stakepool"
+	defaultDBTLS  = "false"
 )
 
 // runServiceCommand is only set to a real function on Windows.  It is used
@@ -67,6 +68,7 @@ type config struct {
 	DBPassword       string   `long:"dbpassword" description:"Password for database connection"`
 	DBPort           string   `long:"dbport" description:"Port for database connection"`
 	DBName           string   `long:"dbname" description:"Name of database"`
+	DBTLS            string   `long:"dbtls" description:"Use encryption when connecting to database"`
 	DcrdHost         string   `long:"dcrdhost" description:"Hostname/IP for dcrd server"`
 	DcrdUser         string   `long:"dcrduser" description:"Username for dcrd server"`
 	DcrdPassword     string   `long:"dcrdpassword" description:"Password for dcrd server"`
@@ -260,6 +262,7 @@ func loadConfig() (*config, []string, error) {
 		DBName:     defaultDBName,
 		DBPort:     defaultDBPort,
 		DBUser:     defaultDBUser,
+		DBTLS:      defaultDBTLS,
 		LogDir:     defaultLogDir,
 		PoolFees:   defaultPoolFees,
 		RPCKey:     defaultRPCKeyFile,

--- a/backend/stakepoold/server.go
+++ b/backend/stakepoold/server.go
@@ -187,7 +187,7 @@ func runMain(ctx context.Context) error {
 		votingConfig.VoteBits)
 
 	var userData = &userdata.UserData{}
-	userData.DBSetConfig(cfg.DBUser, cfg.DBPassword, cfg.DBHost, cfg.DBPort, cfg.DBName)
+	userData.DBSetConfig(cfg.DBUser, cfg.DBPassword, cfg.DBHost, cfg.DBPort, cfg.DBName, cfg.DBTLS)
 
 	addedLowFeeTicketsMSA, errMySQLFetchAddedLowFeeTickets := userData.MySQLFetchAddedLowFeeTickets()
 	if errMySQLFetchAddedLowFeeTickets != nil {

--- a/backend/stakepoold/userdata/userdata.go
+++ b/backend/stakepoold/userdata/userdata.go
@@ -14,6 +14,7 @@ type DBConfig struct {
 	DBPassword string
 	DBPort     string
 	DBUser     string
+	DBTLS      string
 }
 
 // UserData stores the current snapshot of the user voting config.
@@ -41,7 +42,7 @@ func (u *UserData) MySQLFetchAddedLowFeeTickets() (map[chainhash.Hash]string, er
 
 	tickets := make(map[chainhash.Hash]string)
 
-	db, err := sql.Open("mysql", fmt.Sprint(u.DBConfig.DBUser, ":", u.DBConfig.DBPassword, "@(", u.DBConfig.DBHost, ":", u.DBConfig.DBPort, ")/", u.DBConfig.DBName, "?charset=utf8mb4"))
+	db, err := sql.Open("mysql", fmt.Sprint(u.DBConfig.DBUser, ":", u.DBConfig.DBPassword, "@(", u.DBConfig.DBHost, ":", u.DBConfig.DBPort, ")/", u.DBConfig.DBName, "?charset=utf8mb4&tls=", u.DBConfig.DBTLS))
 	if err != nil {
 		log.Errorf("Unable to open db: %v", err)
 		return tickets, err
@@ -92,7 +93,7 @@ func (u *UserData) MySQLFetchUserVotingConfig() (map[string]UserVotingConfig, er
 
 	userInfo := map[string]UserVotingConfig{}
 
-	db, err := sql.Open("mysql", fmt.Sprint(u.DBConfig.DBUser, ":", u.DBConfig.DBPassword, "@(", u.DBConfig.DBHost, ":", u.DBConfig.DBPort, ")/", u.DBConfig.DBName, "?charset=utf8mb4"))
+	db, err := sql.Open("mysql", fmt.Sprint(u.DBConfig.DBUser, ":", u.DBConfig.DBPassword, "@(", u.DBConfig.DBHost, ":", u.DBConfig.DBPort, ")/", u.DBConfig.DBName, "?charset=utf8mb4&tls=", u.DBConfig.DBTLS))
 	if err != nil {
 		log.Errorf("Unable to open db: %v", err)
 		return userInfo, err
@@ -131,13 +132,14 @@ func (u *UserData) MySQLFetchUserVotingConfig() (map[string]UserVotingConfig, er
 }
 
 // DBSetConfig sets the database configuration.
-func (u *UserData) DBSetConfig(DBUser string, DBPassword string, DBHost string, DBPort string, DBName string) {
+func (u *UserData) DBSetConfig(DBUser string, DBPassword string, DBHost string, DBPort string, DBName string, DBTLS string) {
 	dbconfig := &DBConfig{
 		DBHost:     DBHost,
 		DBName:     DBName,
 		DBPassword: DBPassword,
 		DBPort:     DBPort,
 		DBUser:     DBUser,
+		DBTLS:      DBTLS,
 	}
 	u.Lock()
 	u.DBConfig = dbconfig

--- a/sample-stakepoold.conf
+++ b/sample-stakepoold.conf
@@ -18,6 +18,8 @@ testnet=1
 ;dbport=3306
 ;dbname=stakepool
 ;dbuser=stakepool
+; Valid dbtls values are {true, false, skip-verify, preferred}
+;dbtls=false
 
 ; No default password so you need to specify one.
 ;dbpassword=


### PR DESCRIPTION
`--dbtls` is a configurable parameter to set the go-sql-driver/mysql option for tls. [1]

1: https://github.com/go-sql-driver/mysql#tls