### PR TITLE
dcrstakepool: exit early on configuration error.

### DIFF
--- a/config.go
+++ b/config.go
@@ -333,6 +333,7 @@ func loadConfig() (*config, []string, error) {
 			fmt.Fprintln(os.Stderr, err)
 			return nil, nil, err
 		}
+		return nil, nil, err
 	}
 
 	// Show the version and exit if the version flag was specified.
@@ -357,7 +358,6 @@ func loadConfig() (*config, []string, error) {
 	}
 
 	// Load additional config from file.
-	var configFileError error
 	parser := newConfigParser(&cfg, &serviceOpts, flags.Default)
 	if !(preCfg.SimNet) || preCfg.ConfigFile != defaultConfigFile {
 		err := flags.NewIniParser(parser).ParseFile(preCfg.ConfigFile)
@@ -368,7 +368,7 @@ func loadConfig() (*config, []string, error) {
 				fmt.Fprintln(os.Stderr, usageMessage)
 				return nil, nil, err
 			}
-			configFileError = err
+			return nil, nil, err
 		}
 	}
 
@@ -586,13 +586,6 @@ func loadConfig() (*config, []string, error) {
 		if cfg.SMTPSkipVerify {
 			log.Warnf("SMTPCert has been set so SMTPSkipVerify is being disregarded.")
 		}
-	}
-
-	// Warn about missing config file only after all other configuration is
-	// done.  This prevents the warning on help messages and invalid
-	// options.  Note this should go directly before the return.
-	if configFileError != nil {
-		log.Warnf("%v", configFileError)
 	}
 
 	return &cfg, remainingArgs, nil

--- a/log.go
+++ b/log.go
@@ -24,7 +24,10 @@ type logWriter struct{}
 
 func (logWriter) Write(p []byte) (n int, err error) {
 	os.Stdout.Write(p)
-	return logRotator.Write(p)
+	if logRotator != nil {
+		return logRotator.Write(p)
+	}
+	return 0, nil
 }
 
 // Loggers per subsystem.  A single backend logger is created and all subsytem


### PR DESCRIPTION
avoid nil deref panic if logrotator is not initialized.