### PR TITLE
Print startup error to os.Stderr

### DIFF
--- a/server.go
+++ b/server.go
@@ -316,7 +316,7 @@ func main() {
 	ctx := signal.WithShutdownCancel(context.Background())
 	go signal.ShutdownListener()
 	if err := runMain(ctx); err != nil {
-		log.Error(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 	log.Info("server off")


### PR DESCRIPTION
There is a chance that logging has not been initiated yet, causing a
panic.

I changed this in #588 but it was a mistake. You can see the panic on master by passing the -h or -l flag.