### PR TITLE
Add closing notice to homepage UI

### DIFF
--- a/config.go
+++ b/config.go
@@ -89,6 +89,7 @@ type config struct {
 	PoolEmail          string  `long:"poolemail" description:"Email address to for support inquiries"`
 	PoolFees           float64 `long:"poolfees" description:"The per-ticket fees the user must send to the pool with their tickets"`
 	PoolLink           string  `long:"poollink" description:"URL for support inquiries such as forum, IRC, etc"`
+	NewVspLink         string  `long:"newvsplink" description:"URL to new vspd"`
 	RealIPHeader       string  `long:"realipheader" description:"The name of an HTTP request header containing the actual remote client IP address, typically set by a reverse proxy. An empty string (default) indicates to use net/Request.RemodeAddr."`
 	SMTPFrom           string  `long:"smtpfrom" description:"From address to use on outbound mail"`
 	SMTPHost           string  `long:"smtphost" description:"SMTP hostname/ip and port, e.g. mail.example.com:25"`

--- a/controllers/main.go
+++ b/controllers/main.go
@@ -61,6 +61,7 @@ type Config struct {
 	PoolEmail            string
 	PoolFees             float64
 	PoolLink             string
+	NewVspLink           string
 	RealIPHeader         string
 	MaxVotedTickets      int
 	Description          string
@@ -1195,6 +1196,8 @@ func (controller *MainController) Index(c web.C, r *http.Request) (string, int) 
 	if controller.Cfg.ClosePool {
 		c.Env["IsClosed"] = true
 		c.Env["ClosePoolMsg"] = controller.Cfg.ClosePoolMsg
+		c.Env["NewVspLink"] = controller.Cfg.NewVspLink
+		c.Env["Designation"] = controller.Cfg.Designation
 	}
 	c.Env["Network"] = controller.Cfg.NetParams.Name
 	c.Env["PoolEmail"] = controller.Cfg.PoolEmail

--- a/server.go
+++ b/server.go
@@ -59,6 +59,10 @@ func runMain(ctx context.Context) error {
 	cfg = loadedCfg
 	log.Infof("Network: %s", activeNetParams.Params.Name)
 
+	if cfg.ClosePool && cfg.NewVspLink == "" {
+		log.Warn("Config Warning: New vsp link is not set")
+	}
+
 	defer func() {
 		if logRotator != nil {
 			logRotator.Close()
@@ -107,6 +111,7 @@ func runMain(ctx context.Context) error {
 		PoolEmail:       cfg.PoolEmail,
 		PoolFees:        cfg.PoolFees,
 		PoolLink:        cfg.PoolLink,
+		NewVspLink:      cfg.NewVspLink,
 		RealIPHeader:    cfg.RealIPHeader,
 		MaxVotedTickets: cfg.MaxVotedTickets,
 		Description:     cfg.Description,
@@ -161,8 +166,7 @@ func runMain(ctx context.Context) error {
 
 	err = controller.RPCSync(ctx, application.DbMap)
 	if err != nil {
-		return fmt.Errorf("failed to sync the wallets: %v",
-			err)
+		return fmt.Errorf("failed to sync the wallets: %v", err)
 	}
 
 	// Set up web server routes

--- a/views/home.html
+++ b/views/home.html
@@ -4,6 +4,25 @@
   <div class="row mx-3">
     <div class="col-md-6 col-12">
       <div class="row">
+         {{ if .IsClosed}}
+            <div class="alert alert-danger">
+                <h4 class="alert-heading mb-3">
+                    This Voting Service Provider is closed
+                </h4>
+                <p>
+                    {{ .ClosePoolMsg }}
+                </p>
+                <p>
+                    {{if not .NewVspLink}}
+                    Visit <a href="https://decred.org/vsp/" class="alert-link" target="_blank" rel="noopener noreferrer">decred.org</a> to find a new VSP.
+                    {{else}}
+                    Visit the new <a href={{.NewVspLink}} class="alert-link" target="_blank" rel="noopener noreferrer">{{.Designation}}</a> to vote.
+                    {{end}}
+                    <br>
+                    Visit <a href="https://blog.decred.org/2020/06/02/A-More-Private-Way-to-Stake/" class="alert-link" target="_blank" rel="noopener noreferrer">Decred’s Blog</a> to find out more about the migration to a new VSP implementation.
+                </p>
+            </div>
+        {{ end }}
         <section class="block">
           <div class="col-12 block__title">
             <h1><span>Voting Service Provider Overview</span></h1>


### PR DESCRIPTION
This PR incentivize and facilitate the migration from dcrstakepool to vspd by informing dcrstakepool users about it on the front page.
This includes three items:
- a visible banner about the migration with text template covering all important information
- a visible link to the replacement vspd server. If not provided, link to decred.org/vsp is shown to users.
- a link to Decred Blog about the new vsp implementation.

dcrstakepool operator can set the link to their vspd and tweak banner text (specify a closing message). However, the closing notice is only shown if the dcrstakepool operator is closed.
Pictures below:
Before:
![before](https://user-images.githubusercontent.com/57448127/147806392-69cf447c-b766-4127-ad70-10d13aaf30bc.png)
After(If link to new vsp server is set):
![newvspspecified](https://user-images.githubusercontent.com/57448127/147806421-e11023c9-67ba-4033-ad4e-6c181ec1995f.PNG)
After(If link to new vsp is not set):
![newvspnotspecified](https://user-images.githubusercontent.com/57448127/147806441-0842bc84-256b-4f66-bfa0-e76cb91d2eba.PNG)
After(If custom message is not specified and new vsp not set):
![newvspnotspecified](https://user-images.githubusercontent.com/57448127/147806482-700d3454-6abd-407c-ae2e-5e362a1afd08.PNG)
Closes #635 
